### PR TITLE
fix: Support for analyzer `^6.6.0`

### DIFF
--- a/examples/todo_list/pubspec.yaml
+++ b/examples/todo_list/pubspec.yaml
@@ -14,12 +14,12 @@ dependencies:
     sdk: flutter
   mix: 
     path: ../../packages/mix
-  custom_lint: ^0.6.4
   google_fonts: ^6.0.0 
 
   cupertino_icons: ^1.0.6
 
 dev_dependencies:
+  custom_lint: ^0.6.5
   flutter_test:
     sdk: flutter
   mix_lint: 

--- a/packages/mix_lint/lib/src/assists/extract_attributes.dart
+++ b/packages/mix_lint/lib/src/assists/extract_attributes.dart
@@ -16,8 +16,6 @@ class ExtractAttributes extends DartAssist {
     AstNode? ancestorNode;
 
     ancestorNode = node.thisOrAncestorMatching<Block>((node) {
-      print('node ${node.runtimeType}');
-
       return node is Block;
     });
 

--- a/packages/mix_lint/pubspec.yaml
+++ b/packages/mix_lint/pubspec.yaml
@@ -7,9 +7,9 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  analyzer: ^6.0.0
+  analyzer: ^6.6.0
   analyzer_plugin: ^0.11.2
-  custom_lint_builder: ^0.6.0
+  custom_lint_builder: ^0.6.5
 
 dev_dependencies:
   test: ^1.24.0

--- a/packages/mix_lint_test/pubspec.yaml
+++ b/packages/mix_lint_test/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  custom_lint: ^0.6.4
-  analyzer: ^6.0.0
+  custom_lint: ^0.6.5
+  analyzer: ^6.6.0
   analyzer_plugin: ^0.11.2
   test: ^1.24.9
 


### PR DESCRIPTION
### Description

The `mix_lint` was crashing when it ran on the new version of Flutter.

### Changes

- Update the `custom_lint` version to 0.6.5

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?
