### PR TITLE
feat: implement toast layer from root

### DIFF
--- a/packages/remix/lib/src/components/toast/toast_layer.dart
+++ b/packages/remix/lib/src/components/toast/toast_layer.dart
@@ -107,8 +107,14 @@ class ToastLayerState extends State<ToastLayer> implements ToastActions {
   }
 }
 
-void showToast({required BuildContext context, required ToastEntry entry}) {
-  final toastState = context.findAncestorStateOfType<ToastLayerState>();
+void showToast({
+  required BuildContext context,
+  bool useRootNavigator = true,
+  required ToastEntry entry,
+}) {
+  final toastState = useRootNavigator
+      ? context.findRootAncestorStateOfType<ToastLayerState>()
+      : context.findAncestorStateOfType<ToastLayerState>();
 
   if (toastState == null) {
     throw FlutterError.fromParts([

--- a/packages/remix/lib/src/core/remix_app.dart
+++ b/packages/remix/lib/src/core/remix_app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' as m;
 import 'package:flutter/widgets.dart';
 
+import '../components/toast/toast.dart';
 import 'theme/remix_theme.dart';
 
 //ignore: avoid-unnecessary-stateful-widgets
@@ -123,13 +124,15 @@ class _RemixAppState extends State<RemixApp> {
     return RemixTheme(
       theme: widget.theme,
       darkTheme: widget.darkTheme ?? widget.theme,
-      child: widget.builder != null
-          ? Builder(
-              builder: (BuildContext context) {
-                return widget.builder!(context, child);
-              },
-            )
-          : (child ?? const SizedBox.shrink()),
+      child: ToastLayer(
+        child: widget.builder != null
+            ? Builder(
+                builder: (BuildContext context) {
+                  return widget.builder!(context, child);
+                },
+              )
+            : (child ?? const SizedBox.shrink()),
+      ),
     );
   }
 


### PR DESCRIPTION
#### Related issue

This PR refactors the `showToast` method and improves the `ToastLayer` integration within the RemixApp

### Description

- `showToast`: Added a new parameter useRootNavigator to specify whether the root navigator should be used when finding the ToastLayerState

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
