### PR TITLE
refactor: accordion

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -12,6 +12,10 @@
         {
           "title": "NakedCheckbox",
           "href": "/checkbox"
+        },
+        {
+          "title": "NakedAccordion",
+          "href": "/accordion"
         }
       ]
     }

--- a/docs/accordion.mdx
+++ b/docs/accordion.mdx
@@ -4,42 +4,135 @@ title: NakedAccordion
 
 NakedAccordion provides expandable/collapsible sections without imposing any visual styling, giving consumers complete design freedom. It manages the state of expanded sections through an `AccordionController` and allows for fully customizable transitions.
 
-You can find this example in our GitHub repository.
+You can find this example in our [GitHub repository](https://github.com/btwld/mix/blob/main/packages/naked/example/lib/api/naked_accordion.0.dart).
 
+<CodeGroup title="Real Use Case" defaultLanguage="dart">
 ```dart
-final controller = AccordionController<String>();
+class MyAccordion extends StatefulWidget {
+  const MyAccordion({super.key});
 
-NakedAccordion<String>(
-  controller: controller,
-  initialExpandedValues: ['section1'],
-  children: [
-    NakedAccordionItem<String>(
-      value: 'section1',
+  @override
+  State<MyAccordion> createState() => _MyAccordionState();
+}
+
+class _MyAccordionState extends State<MyAccordion>
+    with TickerProviderStateMixin {
+  final _controller = AccordionController<String>(max: 1, min: 1);
+  late final _animationController = AnimationController(
+    duration: const Duration(milliseconds: 300),
+    vsync: this,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 300,
+      child: NakedAccordion<String>(
+        controller: _controller,
+        initialExpandedValues: const ['1'],
+        children: const [
+          AccordionItem(
+            value: '1',
+            title: 'Section 1',
+            content:
+                'This is the content for section 1. You can put anything here!',
+          ),
+          SizedBox(height: 8),
+          AccordionItem(
+            value: '2',
+            title: 'Section 2',
+            content:
+                'This is the content for section 2. You can put anything here!',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class AccordionItem extends StatelessWidget {
+  const AccordionItem({
+    super.key,
+    required this.value,
+    required this.title,
+    required this.content,
+  });
+
+  final String value;
+  final String title;
+  final String content;
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedAccordionItem<String>(
+      value: value,
       trigger: (context, isExpanded, toggle) {
-        return TextButton(
-          onPressed: toggle,
-          child: Text(isExpanded ? 'Close' : 'Open'),
+        return InkWell(
+          onTap: toggle,
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: const Color(0xFF3D3D3D)),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF3D3D3D),
+                  ),
+                ),
+                const Spacer(),
+                AnimatedRotation(
+                  turns: isExpanded ? 0.5 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: const Icon(
+                    Icons.expand_more,
+                    color: Color(0xFF3D3D3D),
+                  ),
+                ),
+              ],
+            ),
+          ),
         );
       },
-      child: Text('Content for section 1'),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          content,
+          style: const TextStyle(color: Color(0xFF3D3D3D)),
+        ),
+      ),
       transitionBuilder: (child) => AnimatedSwitcher(
-        duration: Duration(milliseconds: 300),
+        duration: const Duration(milliseconds: 200),
+        transitionBuilder: (child, animation) {
+          return SizeTransition(
+            axis: Axis.vertical,
+            sizeFactor: animation,
+            axisAlignment: 1,
+            child: child,
+          );
+        },
         child: child,
       ),
-    ),
-    NakedAccordionItem<String>(
-      value: 'section2',
-      trigger: (context, isExpanded, toggle) {
-        return TextButton(
-          onPressed: toggle,
-          child: Text(isExpanded ? 'Hide Details' : 'Show Details'),
-        );
-      },
-      child: Text('Content for section 2'),
-    ),
-  ],
-)
+    );
+  }
+}
 ```
+</CodeGroup>
 
 ## AccordionController
 

--- a/docs/accordion.mdx
+++ b/docs/accordion.mdx
@@ -4,10 +4,8 @@ title: NakedAccordion
 
 NakedAccordion provides expandable/collapsible sections without imposing any visual styling, giving consumers complete design freedom. It manages the state of expanded sections through an `AccordionController` and allows for fully customizable transitions.
 
-<Info>
-  You can find this example in our GitHub repository.
-</Info>
-<CodeGroup title="An implementation of NakedAccordion" defaultLanguage="dart">
+You can find this example in our GitHub repository.
+
 ```dart
 final controller = AccordionController<String>();
 
@@ -43,14 +41,9 @@ NakedAccordion<String>(
 )
 ```
 
-</CodeGroup>
-
-
 ## AccordionController
 
 The `AccordionController` manages the state of the accordion, keeping track of which items are expanded or collapsed.
-
-### Constructor
 
 ```dart
 AccordionController({
@@ -84,8 +77,9 @@ Checks if an item with the given value is currently expanded.
 #### clear() → `void`
 Removes all expanded values.
 
-#### openAll(List<T> newValues) → `void`
+#### openAll(List&lt;T&gt; newValues) → `void`
 Opens all accordion items with the given values.
+
 
 ## NakedAccordion
 

--- a/docs/accordion.mdx
+++ b/docs/accordion.mdx
@@ -1,0 +1,156 @@
+---
+title: NakedAccordion
+---
+
+NakedAccordion provides expandable/collapsible sections without imposing any visual styling, giving consumers complete design freedom. It manages the state of expanded sections through an `AccordionController` and allows for fully customizable transitions.
+
+<Info>
+  You can find this example in our GitHub repository.
+</Info>
+<CodeGroup title="An implementation of NakedAccordion" defaultLanguage="dart">
+```dart
+final controller = AccordionController<String>();
+
+NakedAccordion<String>(
+  controller: controller,
+  initialExpandedValues: ['section1'],
+  children: [
+    NakedAccordionItem<String>(
+      value: 'section1',
+      trigger: (context, isExpanded, toggle) {
+        return TextButton(
+          onPressed: toggle,
+          child: Text(isExpanded ? 'Close' : 'Open'),
+        );
+      },
+      child: Text('Content for section 1'),
+      transitionBuilder: (child) => AnimatedSwitcher(
+        duration: Duration(milliseconds: 300),
+        child: child,
+      ),
+    ),
+    NakedAccordionItem<String>(
+      value: 'section2',
+      trigger: (context, isExpanded, toggle) {
+        return TextButton(
+          onPressed: toggle,
+          child: Text(isExpanded ? 'Hide Details' : 'Show Details'),
+        );
+      },
+      child: Text('Content for section 2'),
+    ),
+  ],
+)
+```
+
+</CodeGroup>
+
+
+## AccordionController
+
+The `AccordionController` manages the state of the accordion, keeping track of which items are expanded or collapsed.
+
+### Constructor
+
+```dart
+AccordionController({
+  this.min = 0,
+  this.max,
+})
+```
+
+### Properties
+
+#### min → `int`
+The minimum number of expanded items allowed. Defaults to 0.
+
+#### max → `int?`
+The maximum number of expanded items allowed. If null, there is no maximum limit.
+
+### Methods
+
+#### open(T value) → `void`
+Opens the accordion item with the given value.
+
+#### close(T value) → `void`
+Closes the accordion item with the given value.
+
+#### toggle(T value) → `void`
+Toggles the accordion item with the given value.
+
+#### contains(T value) → `bool`
+Checks if an item with the given value is currently expanded.
+
+#### clear() → `void`
+Removes all expanded values.
+
+#### openAll(List<T> newValues) → `void`
+Opens all accordion items with the given values.
+
+## NakedAccordion
+
+### Constructor
+
+```dart
+const NakedAccordion({
+  Key? key,
+  required this.children,
+  required this.controller,
+  this.initialExpandedValues = const [],
+})
+```
+
+### Properties
+
+#### children → `List<Widget>`
+The accordion items to display. These should be `NakedAccordionItem` widgets.
+
+#### controller → `AccordionController<T>`
+The controller that manages which items are expanded or collapsed.
+
+#### initialExpandedValues → `List<T>`
+Values that should be expanded when the accordion is first built. Defaults to an empty list.
+
+## NakedAccordionItem
+
+### Constructor
+
+```dart
+const NakedAccordionItem({
+  Key? key,
+  required this.trigger,
+  required this.value,
+  required this.child,
+  this.transitionBuilder,
+  this.semanticLabel,
+  this.onFocusState,
+  this.autoFocus = false,
+  this.focusNode,
+})
+```
+
+### Properties
+
+#### trigger → `NakedAccordionTriggerBuilder`
+Builder function that creates the trigger widget. The builder provides the current BuildContext, a boolean indicating if the item is expanded, and a callback to toggle the expansion state.
+
+#### value → `T`
+The unique identifier for this accordion item. This value is used by the AccordionController to track expansion state.
+
+#### child → `Widget`
+The content displayed when this item is expanded.
+
+#### transitionBuilder → `Widget Function(Widget child)?`
+Optional builder to customize the transition when expanding/collapsing. If not provided, content will appear/disappear instantly.
+
+#### semanticLabel → `String?`
+Optional semantic label describing the section for screen readers.
+
+#### onFocusState → `ValueChanged<bool>?`
+Optional callback to handle focus state changes.
+
+#### autoFocus → `bool`
+Whether the item should be focused when the accordion is opened. Defaults to false.
+
+#### focusNode → `FocusNode?`
+The focus node for the item.

--- a/docs/button.mdx
+++ b/docs/button.mdx
@@ -8,7 +8,7 @@ NakedButton provides interaction behavior and accessibility features without imp
 <Info>
   You can find this example in our [GitHub repository](https://github.com/btwld/mix/blob/main/packages/naked/example/lib/api/naked_button.0.dart).
 </Info>
-<CodeGroup title="An implementation of NakedButton" defaultLanguage="dart">
+<CodeGroup title="Real Use Case" defaultLanguage="dart">
 ```dart
 class MyButton extends StatefulWidget {
   @override

--- a/docs/button.mdx
+++ b/docs/button.mdx
@@ -8,7 +8,7 @@ NakedButton provides interaction behavior and accessibility features without imp
 <Info>
   You can find this example in our [GitHub repository](https://github.com/btwld/mix/blob/main/packages/naked/example/lib/api/naked_button.0.dart).
 </Info>
-<CodeGroup title="Real Use Case" defaultLanguage="dart">
+<CodeGroup title="NakedButton Usage Example" defaultLanguage="dart">
 ```dart
 class MyButton extends StatefulWidget {
   @override

--- a/docs/checkbox.mdx
+++ b/docs/checkbox.mdx
@@ -8,7 +8,7 @@ This component uses direct callbacks for state changes instead of managing its o
 <Info>
   You can find this example in our [GitHub repository](https://github.com/btwld/mix/blob/main/packages/naked/example/lib/api/naked_checkbox.0.dart).
 </Info>
-<CodeGroup title="Real Use Case" defaultLanguage="dart">
+<CodeGroup title="NakedCheckbox Usage Example" defaultLanguage="dart">
 ```dart
 class MyCheckbox extends StatefulWidget {
   const MyCheckbox({super.key});

--- a/docs/checkbox.mdx
+++ b/docs/checkbox.mdx
@@ -8,7 +8,7 @@ This component uses direct callbacks for state changes instead of managing its o
 <Info>
   You can find this example in our [GitHub repository](https://github.com/btwld/mix/blob/main/packages/naked/example/lib/api/naked_checkbox.0.dart).
 </Info>
-<CodeGroup title="An implementation of NakedCheckbox" defaultLanguage="dart">
+<CodeGroup title="Real Use Case" defaultLanguage="dart">
 ```dart
 class MyCheckbox extends StatefulWidget {
   const MyCheckbox({super.key});

--- a/packages/naked/example/lib/api/naked_accordion.0..dart
+++ b/packages/naked/example/lib/api/naked_accordion.0..dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:naked/naked.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: ExampleAccordion(),
+        ),
+      ),
+    );
+  }
+}
+
+class ExampleAccordion extends StatefulWidget {
+  const ExampleAccordion({super.key});
+
+  @override
+  State<ExampleAccordion> createState() => _ExampleAccordionState();
+}
+
+class _ExampleAccordionState extends State<ExampleAccordion>
+    with TickerProviderStateMixin {
+  final _controller = AccordionController<String>(max: 1, min: 1);
+  late final _animationController = AnimationController(
+    duration: const Duration(milliseconds: 300),
+    vsync: this,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 300,
+      child: NakedAccordion<String>(
+        controller: _controller,
+        initialExpandedValues: const ['1'],
+        children: const [
+          AccordionItem(
+            value: '1',
+            title: 'Section 1',
+            content:
+                'This is the content for section 1. You can put anything here!',
+          ),
+          SizedBox(height: 8),
+          AccordionItem(
+            value: '2',
+            title: 'Section 2',
+            content:
+                'This is the content for section 2. You can put anything here!',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class AccordionItem extends StatelessWidget {
+  const AccordionItem({
+    super.key,
+    required this.value,
+    required this.title,
+    required this.content,
+  });
+
+  final String value;
+  final String title;
+  final String content;
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedAccordionItem<String>(
+      value: value,
+      trigger: (context, isExpanded, toggle) {
+        return InkWell(
+          onTap: toggle,
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: const Color(0xFF3D3D3D)),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF3D3D3D),
+                  ),
+                ),
+                const Spacer(),
+                AnimatedRotation(
+                  turns: isExpanded ? 0.5 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: const Icon(
+                    Icons.expand_more,
+                    color: Color(0xFF3D3D3D),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          content,
+          style: const TextStyle(color: Color(0xFF3D3D3D)),
+        ),
+      ),
+      transitionBuilder: (child) => AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        transitionBuilder: (child, animation) {
+          return SizeTransition(
+            axis: Axis.vertical,
+            sizeFactor: animation,
+            axisAlignment: 1,
+            child: child,
+          );
+        },
+        child: child,
+      ),
+    );
+  }
+}

--- a/packages/naked/example/lib/examples/naked_accordion_example.dart
+++ b/packages/naked/example/lib/examples/naked_accordion_example.dart
@@ -155,7 +155,7 @@ class _BasicAccordionState extends State<_BasicAccordion> {
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: NakedAccordionTrigger<String>(
+            trigger: (_) => NakedAccordionTrigger<String>(
               onHoverState: (hovered) =>
                   setState(() => _hoveredItems[id] = hovered),
               onFocusState: (focused) =>
@@ -193,7 +193,7 @@ class _BasicAccordionState extends State<_BasicAccordion> {
                 ),
               ),
             ),
-            content: Container(
+            child: Container(
               padding: const EdgeInsets.all(16),
               color: Colors.blue.shade50,
               child: Text(
@@ -265,7 +265,7 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
 
         return NakedAccordionItem<String>(
           value: id,
-          trigger: NakedAccordionTrigger<String>(
+          trigger: (_) => NakedAccordionTrigger<String>(
             onHoverState: (isHovered) =>
                 setState(() => _hoverStates[id] = isHovered),
             onFocusState: (isFocused) =>
@@ -273,10 +273,10 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
             child: Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: color.withValues(alpha: 0.1),
+                color: color.withOpacity(0.1),
                 border: Border.all(
-                  color: color.withValues(
-                    alpha: isHovered
+                  color: color.withOpacity(
+                    isHovered
                         ? 0.8
                         : isFocused
                             ? 0.6
@@ -291,30 +291,30 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
                     child: Text(
                       item['title'] as String,
                       style: TextStyle(
-                        color: color.withValues(alpha: 0.8),
+                        color: color.withOpacity(0.8),
                         fontWeight: FontWeight.w500,
                       ),
                     ),
                   ),
                   Icon(
                     isExpanded ? Icons.expand_less : Icons.expand_more,
-                    color: color.withValues(alpha: 0.6),
+                    color: color.withOpacity(0.6),
                   ),
                 ],
               ),
             ),
           ),
-          content: Container(
+          child: Container(
             padding: const EdgeInsets.all(16),
             margin: const EdgeInsets.only(top: 8),
             decoration: BoxDecoration(
-              color: color.withValues(alpha: 0.05),
+              color: color.withOpacity(0.05),
               borderRadius: const BorderRadius.all(Radius.circular(8)),
             ),
             child: Text(
               item['content'] as String,
               style: TextStyle(
-                color: color.withValues(alpha: 0.7),
+                color: color.withOpacity(0.7),
               ),
             ),
           ),
@@ -378,7 +378,7 @@ class _BorderedAccordionState extends State<_BorderedAccordion> {
 
         return NakedAccordionItem<String>(
           value: id,
-          trigger: NakedAccordionTrigger<String>(
+          trigger: (_) => NakedAccordionTrigger<String>(
             onHoverState: (isHovered) =>
                 setState(() => _hoverStates[id] = isHovered),
             onFocusState: (isFocused) =>
@@ -422,7 +422,7 @@ class _BorderedAccordionState extends State<_BorderedAccordion> {
               ),
             ),
           ),
-          content: Container(
+          child: Container(
             padding: const EdgeInsets.all(16),
             margin: const EdgeInsets.only(bottom: 8),
             decoration: BoxDecoration(
@@ -519,7 +519,7 @@ class _AccordionGroupState extends State<_AccordionGroup> {
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: NakedAccordionTrigger<String>(
+            trigger: (_) => NakedAccordionTrigger<String>(
               child: Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
@@ -557,7 +557,7 @@ class _AccordionGroupState extends State<_AccordionGroup> {
                 ),
               ),
             ),
-            content: Container(
+            child: Container(
               padding: const EdgeInsets.all(16),
               color: const Color(0xFFF9FAFB),
               child: Text(
@@ -670,7 +670,7 @@ class _NestedAccordionState extends State<_NestedAccordion> {
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: NakedAccordionTrigger<String>(
+            trigger: (_) => NakedAccordionTrigger<String>(
               child: Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
@@ -705,7 +705,7 @@ class _NestedAccordionState extends State<_NestedAccordion> {
                 ),
               ),
             ),
-            content: Container(
+            child: Container(
               padding: const EdgeInsets.all(16),
               color: const Color(0xFFEEF2FF), // indigo-50
               child: Column(
@@ -746,7 +746,7 @@ class _NestedAccordionState extends State<_NestedAccordion> {
 
                         return NakedAccordionItem<String>(
                           value: childId,
-                          trigger: NakedAccordionTrigger<String>(
+                          trigger: (_) => NakedAccordionTrigger<String>(
                             child: Container(
                               margin: const EdgeInsets.only(top: 8),
                               padding: const EdgeInsets.all(12),
@@ -757,7 +757,7 @@ class _NestedAccordionState extends State<_NestedAccordion> {
                                 borderRadius: BorderRadius.circular(8),
                                 boxShadow: [
                                   BoxShadow(
-                                    color: Colors.black.withValues(alpha: 0.05),
+                                    color: Colors.black.withOpacity(0.05),
                                     blurRadius: 2,
                                     offset: const Offset(0, 1),
                                   ),
@@ -788,7 +788,7 @@ class _NestedAccordionState extends State<_NestedAccordion> {
                               ),
                             ),
                           ),
-                          content: Container(
+                          child: Container(
                             padding: const EdgeInsets.all(12),
                             margin: const EdgeInsets.only(top: 4),
                             decoration: BoxDecoration(
@@ -900,7 +900,7 @@ class _IconAccordionState extends State<_IconAccordion> {
             children: [
               NakedAccordionItem<String>(
                 value: id,
-                trigger: NakedAccordionTrigger<String>(
+                trigger: (_) => NakedAccordionTrigger<String>(
                   child: Padding(
                     padding: const EdgeInsets.all(16),
                     child: Row(
@@ -909,7 +909,7 @@ class _IconAccordionState extends State<_IconAccordion> {
                           width: 40,
                           height: 40,
                           decoration: BoxDecoration(
-                            color: iconColor.withValues(alpha: 0.1),
+                            color: iconColor.withOpacity(0.1),
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Center(
@@ -940,7 +940,7 @@ class _IconAccordionState extends State<_IconAccordion> {
                     ),
                   ),
                 ),
-                content: Container(
+                child: Container(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                   decoration: BoxDecoration(
                     border: Border(
@@ -1036,8 +1036,8 @@ class _CardAccordionState extends State<_CardAccordion> {
               boxShadow: [
                 BoxShadow(
                   color: isExpanded
-                      ? gradient[0].withValues(alpha: 0.3)
-                      : Colors.grey.withValues(alpha: 0.1),
+                      ? gradient[0].withOpacity(0.3)
+                      : Colors.grey.withOpacity(0.1),
                   blurRadius: isExpanded ? 15 : 5,
                   offset: const Offset(0, 5),
                 ),
@@ -1059,7 +1059,7 @@ class _CardAccordionState extends State<_CardAccordion> {
               children: [
                 NakedAccordionItem<String>(
                   value: id,
-                  trigger: NakedAccordionTrigger<String>(
+                  trigger: (_) => NakedAccordionTrigger<String>(
                     child: Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
@@ -1104,7 +1104,7 @@ class _CardAccordionState extends State<_CardAccordion> {
                                 '/${item['period']}',
                                 style: TextStyle(
                                   fontSize: 14,
-                                  color: Colors.white.withValues(alpha: 0.8),
+                                  color: Colors.white.withOpacity(0.8),
                                 ),
                               ),
                             ],
@@ -1117,7 +1117,7 @@ class _CardAccordionState extends State<_CardAccordion> {
                                 isExpanded
                                     ? Icons.expand_less
                                     : Icons.expand_more,
-                                color: Colors.white.withValues(alpha: 0.8),
+                                color: Colors.white.withOpacity(0.8),
                               ),
                             ],
                           ),
@@ -1125,7 +1125,7 @@ class _CardAccordionState extends State<_CardAccordion> {
                       ),
                     ),
                   ),
-                  content: AnimatedContainer(
+                  child: AnimatedContainer(
                     duration: const Duration(milliseconds: 300),
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
@@ -1135,7 +1135,7 @@ class _CardAccordionState extends State<_CardAccordion> {
                       ),
                       boxShadow: [
                         BoxShadow(
-                          color: Colors.grey.withValues(alpha: 0.05),
+                          color: Colors.grey.withOpacity(0.05),
                           blurRadius: 5,
                           offset: const Offset(0, 3),
                         ),

--- a/packages/naked/example/lib/examples/naked_accordion_example.dart
+++ b/packages/naked/example/lib/examples/naked_accordion_example.dart
@@ -116,7 +116,6 @@ class BasicAccordion extends StatefulWidget {
 class _BasicAccordionState extends State<BasicAccordion> {
   final AccordionController<String> _controller = AccordionController<String>();
   final Map<String, bool> _hoveredItems = {};
-  final Map<String, bool> _focusedItems = {};
 
   final List<Map<String, dynamic>> items = [
     {
@@ -151,7 +150,7 @@ class _BasicAccordionState extends State<BasicAccordion> {
         controller: _controller,
         children: items.map((item) {
           final String id = item['id'] as String;
-          final bool isExpanded = _controller.values.contains(id);
+
           final bool isHovered = _hoveredItems[id] ?? false;
 
           return NakedAccordionItem<String>(
@@ -255,7 +254,6 @@ class _ColoredAccordionState extends State<ColoredAccordion> {
       children: items.map((item) {
         final String id = item['id'] as String;
         final Color color = item['color'] as Color;
-        final bool isExpanded = _controller.values.contains(id);
         final bool isHovered = _hoverStates[id] ?? false;
         final bool isFocused = _focusStates[id] ?? false;
 
@@ -360,7 +358,6 @@ class _BorderedAccordionState extends State<BorderedAccordion> {
       controller: _controller,
       children: items.map((item) {
         final String id = item['id'] as String;
-        final bool isExpanded = _controller.values.contains(id);
 
         return NakedAccordionItem<String>(
           value: id,
@@ -636,7 +633,6 @@ class _NestedAccordionState extends State<NestedAccordion> {
           final String id = item['id'] as String;
           final List<Map<String, dynamic>> children =
               (item['children'] as List<dynamic>).cast<Map<String, dynamic>>();
-          final bool isExpanded = _parentController.values.contains(id);
           final childController = _childControllers[id]!;
 
           return NakedAccordionItem<String>(
@@ -850,7 +846,6 @@ class _IconAccordionState extends State<IconAccordion> {
         final IconData icon = item['icon'] as IconData;
         final Color iconColor = item['iconColor'] as Color;
         final controller = _controllers[id]!;
-        final bool isExpanded = controller.values.contains(id);
 
         return Container(
           margin: const EdgeInsets.only(bottom: 8),

--- a/packages/naked/example/lib/examples/naked_accordion_example.dart
+++ b/packages/naked/example/lib/examples/naked_accordion_example.dart
@@ -6,13 +6,13 @@ class NakedAccordionExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
+    return const SingleChildScrollView(
       child: Padding(
-        padding: const EdgeInsets.all(24.0),
+        padding: EdgeInsets.all(24.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
+            Text(
               'Beautiful Accordion Examples',
               style: TextStyle(
                 fontSize: 32,
@@ -20,62 +20,74 @@ class NakedAccordionExample extends StatelessWidget {
                 color: Color(0xFF1F2937), // text-gray-800
               ),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Basic Accordion
-            _buildSection(
-              'Simple Accordion',
-              const _BasicAccordion(),
+            SectionWidget(
+              title: 'Simple Accordion',
+              child: BasicAccordion(),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Styled Variations
-            _buildSection(
-              'Styled Variations',
-              const Row(
+            SectionWidget(
+              title: 'Styled Variations',
+              child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Expanded(child: _ColoredAccordion()),
+                  Expanded(child: ColoredAccordion()),
                   SizedBox(width: 24),
-                  Expanded(child: _BorderedAccordion()),
+                  Expanded(child: BorderedAccordion()),
                 ],
               ),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Accordion Group
-            _buildSection(
-              'Accordion Group (Only one open at a time)',
-              const _AccordionGroup(),
+            SectionWidget(
+              title: 'Accordion Group (Only one open at a time)',
+              child: AccordionGroup(),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Nested Accordions
-            _buildSection(
-              'Nested Accordions',
-              const _NestedAccordion(),
+            SectionWidget(
+              title: 'Nested Accordions',
+              child: NestedAccordion(),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Icon Accordions
-            _buildSection(
-              'Accordion with Icons',
-              const _IconAccordion(),
+            SectionWidget(
+              title: 'Accordion with Icons',
+              child: IconAccordion(),
             ),
-            const SizedBox(height: 48),
+            SizedBox(height: 48),
 
             // Card Style Accordions
-            _buildSection(
-              'Card Style Accordion',
-              const _CardAccordion(),
+            SectionWidget(
+              title: 'Card Style Accordion',
+              child: CardAccordion(),
             ),
           ],
         ),
       ),
     );
   }
+}
 
-  Widget _buildSection(String title, Widget content) {
+class SectionWidget extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const SectionWidget({
+    super.key,
+    required this.title,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -88,20 +100,20 @@ class NakedAccordionExample extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 16),
-        content,
+        child,
       ],
     );
   }
 }
 
-class _BasicAccordion extends StatefulWidget {
-  const _BasicAccordion();
+class BasicAccordion extends StatefulWidget {
+  const BasicAccordion({super.key});
 
   @override
-  State<_BasicAccordion> createState() => _BasicAccordionState();
+  State<BasicAccordion> createState() => _BasicAccordionState();
 }
 
-class _BasicAccordionState extends State<_BasicAccordion> {
+class _BasicAccordionState extends State<BasicAccordion> {
   final AccordionController<String> _controller = AccordionController<String>();
   final Map<String, bool> _hoveredItems = {};
   final Map<String, bool> _focusedItems = {};
@@ -137,17 +149,6 @@ class _BasicAccordionState extends State<_BasicAccordion> {
       clipBehavior: Clip.antiAlias,
       child: NakedAccordion<String>(
         controller: _controller,
-        onTriggerPressed: (value) {
-          setState(() {
-            if (_controller.values.contains(value)) {
-              _controller.close(value);
-            } else {
-              // Close all other items when opening a new one (single mode)
-              _controller.clear();
-              _controller.open(value);
-            }
-          });
-        },
         children: items.map((item) {
           final String id = item['id'] as String;
           final bool isExpanded = _controller.values.contains(id);
@@ -155,41 +156,42 @@ class _BasicAccordionState extends State<_BasicAccordion> {
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: (_) => NakedAccordionTrigger<String>(
-              onHoverState: (hovered) =>
-                  setState(() => _hoveredItems[id] = hovered),
-              onFocusState: (focused) =>
-                  setState(() => _focusedItems[id] = focused),
-              child: Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: isExpanded
-                      ? Colors.blue.shade100
-                      : isHovered
-                          ? Colors.grey.shade300
-                          : Colors.grey.shade200,
-                  border: Border(
-                    bottom: BorderSide(color: Colors.grey.shade300),
+            trigger: (context, isExpanded, toggle) => MouseRegion(
+              onEnter: (_) => setState(() => _hoveredItems[id] = true),
+              onExit: (_) => setState(() => _hoveredItems[id] = false),
+              child: GestureDetector(
+                onTap: toggle,
+                child: Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: isExpanded
+                        ? Colors.blue.shade100
+                        : isHovered
+                            ? Colors.grey.shade300
+                            : Colors.grey.shade200,
+                    border: Border(
+                      bottom: BorderSide(color: Colors.grey.shade300),
+                    ),
                   ),
-                ),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        item['title'] as String,
-                        style: TextStyle(
-                          fontWeight: FontWeight.w500,
-                          color: isExpanded
-                              ? Colors.blue.shade800
-                              : Colors.grey.shade800,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          item['title'] as String,
+                          style: TextStyle(
+                            fontWeight: FontWeight.w500,
+                            color: isExpanded
+                                ? Colors.blue.shade800
+                                : Colors.grey.shade800,
+                          ),
                         ),
                       ),
-                    ),
-                    Icon(
-                      isExpanded ? Icons.expand_less : Icons.expand_more,
-                      color: isExpanded ? Colors.blue : Colors.grey.shade600,
-                    ),
-                  ],
+                      Icon(
+                        isExpanded ? Icons.expand_less : Icons.expand_more,
+                        color: isExpanded ? Colors.blue : Colors.grey.shade600,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -211,14 +213,14 @@ class _BasicAccordionState extends State<_BasicAccordion> {
   }
 }
 
-class _ColoredAccordion extends StatefulWidget {
-  const _ColoredAccordion();
+class ColoredAccordion extends StatefulWidget {
+  const ColoredAccordion({super.key});
 
   @override
-  State<_ColoredAccordion> createState() => _ColoredAccordionState();
+  State<ColoredAccordion> createState() => _ColoredAccordionState();
 }
 
-class _ColoredAccordionState extends State<_ColoredAccordion> {
+class _ColoredAccordionState extends State<ColoredAccordion> {
   final AccordionController<String> _controller = AccordionController<String>();
   final Map<String, bool> _hoverStates = {};
   final Map<String, bool> _focusStates = {};
@@ -250,12 +252,6 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
   Widget build(BuildContext context) {
     return NakedAccordion<String>(
       controller: _controller,
-      onTriggerPressed: (value) {
-        setState(() {
-          // Allow multiple items to be expanded
-          _controller.toggle(value);
-        });
-      },
       children: items.map((item) {
         final String id = item['id'] as String;
         final Color color = item['color'] as Color;
@@ -265,42 +261,43 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
 
         return NakedAccordionItem<String>(
           value: id,
-          trigger: (_) => NakedAccordionTrigger<String>(
-            onHoverState: (isHovered) =>
-                setState(() => _hoverStates[id] = isHovered),
-            onFocusState: (isFocused) =>
-                setState(() => _focusStates[id] = isFocused),
-            child: Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: color.withOpacity(0.1),
-                border: Border.all(
-                  color: color.withOpacity(
-                    isHovered
-                        ? 0.8
-                        : isFocused
-                            ? 0.6
-                            : 0.3,
-                  ),
-                ),
-                borderRadius: const BorderRadius.all(Radius.circular(8)),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      item['title'] as String,
-                      style: TextStyle(
-                        color: color.withOpacity(0.8),
-                        fontWeight: FontWeight.w500,
-                      ),
+          trigger: (context, isExpanded, toggle) => MouseRegion(
+            onEnter: (_) => setState(() => _hoverStates[id] = true),
+            onExit: (_) => setState(() => _hoverStates[id] = false),
+            child: GestureDetector(
+              onTap: toggle,
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: color.withOpacity(0.1),
+                  border: Border.all(
+                    color: color.withOpacity(
+                      isHovered
+                          ? 0.8
+                          : isFocused
+                              ? 0.6
+                              : 0.3,
                     ),
                   ),
-                  Icon(
-                    isExpanded ? Icons.expand_less : Icons.expand_more,
-                    color: color.withOpacity(0.6),
-                  ),
-                ],
+                  borderRadius: const BorderRadius.all(Radius.circular(8)),
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        item['title'] as String,
+                        style: TextStyle(
+                          color: color.withOpacity(0.8),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    Icon(
+                      isExpanded ? Icons.expand_less : Icons.expand_more,
+                      color: color.withOpacity(0.6),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -324,14 +321,14 @@ class _ColoredAccordionState extends State<_ColoredAccordion> {
   }
 }
 
-class _BorderedAccordion extends StatefulWidget {
-  const _BorderedAccordion();
+class BorderedAccordion extends StatefulWidget {
+  const BorderedAccordion({super.key});
 
   @override
-  State<_BorderedAccordion> createState() => _BorderedAccordionState();
+  State<BorderedAccordion> createState() => _BorderedAccordionState();
 }
 
-class _BorderedAccordionState extends State<_BorderedAccordion> {
+class _BorderedAccordionState extends State<BorderedAccordion> {
   final AccordionController<String> _controller = AccordionController<String>();
   final Map<String, bool> _hoverStates = {};
   final Map<String, bool> _focusStates = {};
@@ -361,64 +358,54 @@ class _BorderedAccordionState extends State<_BorderedAccordion> {
   Widget build(BuildContext context) {
     return NakedAccordion<String>(
       controller: _controller,
-      onTriggerPressed: (value) {
-        setState(() {
-          if (_controller.values.contains(value)) {
-            _controller.close(value);
-          } else {
-            // Single mode - close other items
-            _controller.clear();
-            _controller.open(value);
-          }
-        });
-      },
       children: items.map((item) {
         final String id = item['id'] as String;
         final bool isExpanded = _controller.values.contains(id);
 
         return NakedAccordionItem<String>(
           value: id,
-          trigger: (_) => NakedAccordionTrigger<String>(
-            onHoverState: (isHovered) =>
-                setState(() => _hoverStates[id] = isHovered),
-            onFocusState: (isFocused) =>
-                setState(() => _focusStates[id] = isFocused),
-            child: Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: isExpanded
-                      ? const Color(0xFF8B5CF6) // purple-500
-                      : _hoverStates[id] == true
-                          ? const Color(0xFFA78BFA) // purple-400
-                          : _focusStates[id] == true
-                              ? const Color(0xFFC4B5FD) // purple-300
-                              : Colors.grey.shade300,
-                  width: isExpanded ? 2 : 1,
-                ),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      item['title'] as String,
-                      style: TextStyle(
-                        fontWeight: FontWeight.w500,
-                        color: isExpanded
-                            ? const Color(0xFF6D28D9) // purple-700
-                            : Colors.grey.shade800,
-                      ),
-                    ),
-                  ),
-                  Icon(
-                    isExpanded ? Icons.expand_less : Icons.expand_more,
+          trigger: (context, isExpanded, toggle) => MouseRegion(
+            onEnter: (_) => setState(() => _hoverStates[id] = true),
+            onExit: (_) => setState(() => _hoverStates[id] = false),
+            child: GestureDetector(
+              onTap: toggle,
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
                     color: isExpanded
                         ? const Color(0xFF8B5CF6) // purple-500
-                        : Colors.grey.shade500,
+                        : _hoverStates[id] == true
+                            ? const Color(0xFFA78BFA) // purple-400
+                            : _focusStates[id] == true
+                                ? const Color(0xFFC4B5FD) // purple-300
+                                : Colors.grey.shade300,
+                    width: isExpanded ? 2 : 1,
                   ),
-                ],
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        item['title'] as String,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w500,
+                          color: isExpanded
+                              ? const Color(0xFF6D28D9) // purple-700
+                              : Colors.grey.shade800,
+                        ),
+                      ),
+                    ),
+                    Icon(
+                      isExpanded ? Icons.expand_less : Icons.expand_more,
+                      color: isExpanded
+                          ? const Color(0xFF8B5CF6) // purple-500
+                          : Colors.grey.shade500,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
@@ -446,14 +433,14 @@ class _BorderedAccordionState extends State<_BorderedAccordion> {
   }
 }
 
-class _AccordionGroup extends StatefulWidget {
-  const _AccordionGroup();
+class AccordionGroup extends StatefulWidget {
+  const AccordionGroup({super.key});
 
   @override
-  State<_AccordionGroup> createState() => _AccordionGroupState();
+  State<AccordionGroup> createState() => _AccordionGroupState();
 }
 
-class _AccordionGroupState extends State<_AccordionGroup> {
+class _AccordionGroupState extends State<AccordionGroup> {
   final AccordionController<String> _controller = AccordionController<String>();
 
   final List<Map<String, dynamic>> items = [
@@ -501,25 +488,14 @@ class _AccordionGroupState extends State<_AccordionGroup> {
       clipBehavior: Clip.antiAlias,
       child: NakedAccordion<String>(
         controller: _controller,
-        onTriggerPressed: (value) {
-          setState(() {
-            if (_controller.values.contains(value)) {
-              // Don't allow closing the active item
-              return;
-            } else {
-              // Single mode - close other items
-              _controller.clear();
-              _controller.open(value);
-            }
-          });
-        },
         children: items.map((item) {
           final String id = item['id'] as String;
           final bool isActive = _controller.values.contains(id);
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: (_) => NakedAccordionTrigger<String>(
+            trigger: (context, isExpanded, toggle) => GestureDetector(
+              onTap: toggle,
               child: Container(
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
@@ -575,14 +551,14 @@ class _AccordionGroupState extends State<_AccordionGroup> {
   }
 }
 
-class _NestedAccordion extends StatefulWidget {
-  const _NestedAccordion();
+class NestedAccordion extends StatefulWidget {
+  const NestedAccordion({super.key});
 
   @override
-  State<_NestedAccordion> createState() => _NestedAccordionState();
+  State<NestedAccordion> createState() => _NestedAccordionState();
 }
 
-class _NestedAccordionState extends State<_NestedAccordion> {
+class _NestedAccordionState extends State<NestedAccordion> {
   final AccordionController<String> _parentController =
       AccordionController<String>();
   final Map<String, AccordionController<String>> _childControllers = {};
@@ -656,11 +632,6 @@ class _NestedAccordionState extends State<_NestedAccordion> {
       ),
       child: NakedAccordion<String>(
         controller: _parentController,
-        onTriggerPressed: (value) {
-          setState(() {
-            _parentController.toggle(value);
-          });
-        },
         children: items.map((item) {
           final String id = item['id'] as String;
           final List<Map<String, dynamic>> children =
@@ -670,7 +641,8 @@ class _NestedAccordionState extends State<_NestedAccordion> {
 
           return NakedAccordionItem<String>(
             value: id,
-            trigger: (_) => NakedAccordionTrigger<String>(
+            trigger: (context, isExpanded, toggle) => GestureDetector(
+              onTap: toggle,
               child: Container(
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
@@ -734,11 +706,6 @@ class _NestedAccordionState extends State<_NestedAccordion> {
                     ),
                     child: NakedAccordion<String>(
                       controller: childController,
-                      onTriggerPressed: (childId) {
-                        setState(() {
-                          childController.toggle(childId);
-                        });
-                      },
                       children: children.map((child) {
                         final String childId = child['id'] as String;
                         final bool isChildExpanded =
@@ -746,7 +713,9 @@ class _NestedAccordionState extends State<_NestedAccordion> {
 
                         return NakedAccordionItem<String>(
                           value: childId,
-                          trigger: (_) => NakedAccordionTrigger<String>(
+                          trigger: (context, isExpanded, toggle) =>
+                              GestureDetector(
+                            onTap: toggle,
                             child: Container(
                               margin: const EdgeInsets.only(top: 8),
                               padding: const EdgeInsets.all(12),
@@ -818,14 +787,14 @@ class _NestedAccordionState extends State<_NestedAccordion> {
   }
 }
 
-class _IconAccordion extends StatefulWidget {
-  const _IconAccordion();
+class IconAccordion extends StatefulWidget {
+  const IconAccordion({super.key});
 
   @override
-  State<_IconAccordion> createState() => _IconAccordionState();
+  State<IconAccordion> createState() => _IconAccordionState();
 }
 
-class _IconAccordionState extends State<_IconAccordion> {
+class _IconAccordionState extends State<IconAccordion> {
   final Map<String, AccordionController<String>> _controllers = {};
 
   final List<Map<String, dynamic>> items = [
@@ -892,15 +861,11 @@ class _IconAccordionState extends State<_IconAccordion> {
           ),
           child: NakedAccordion<String>(
             controller: controller,
-            onTriggerPressed: (value) {
-              setState(() {
-                controller.toggle(value);
-              });
-            },
             children: [
               NakedAccordionItem<String>(
                 value: id,
-                trigger: (_) => NakedAccordionTrigger<String>(
+                trigger: (context, isExpanded, toggle) => GestureDetector(
+                  onTap: toggle,
                   child: Padding(
                     padding: const EdgeInsets.all(16),
                     child: Row(
@@ -967,14 +932,14 @@ class _IconAccordionState extends State<_IconAccordion> {
   }
 }
 
-class _CardAccordion extends StatefulWidget {
-  const _CardAccordion();
+class CardAccordion extends StatefulWidget {
+  const CardAccordion({super.key});
 
   @override
-  State<_CardAccordion> createState() => _CardAccordionState();
+  State<CardAccordion> createState() => _CardAccordionState();
 }
 
-class _CardAccordionState extends State<_CardAccordion> {
+class _CardAccordionState extends State<CardAccordion> {
   final AccordionController<String> _controller = AccordionController<String>();
 
   final List<Map<String, dynamic>> items = [
@@ -1045,21 +1010,11 @@ class _CardAccordionState extends State<_CardAccordion> {
             ),
             child: NakedAccordion<String>(
               controller: _controller,
-              onTriggerPressed: (value) {
-                setState(() {
-                  if (_controller.values.contains(value)) {
-                    _controller.close(value);
-                  } else {
-                    // Single mode - close others when opening this one
-                    _controller.clear();
-                    _controller.open(value);
-                  }
-                });
-              },
               children: [
                 NakedAccordionItem<String>(
                   value: id,
-                  trigger: (_) => NakedAccordionTrigger<String>(
+                  trigger: (context, isExpanded, toggle) => GestureDetector(
+                    onTap: toggle,
                     child: Container(
                       padding: const EdgeInsets.all(20),
                       decoration: BoxDecoration(
@@ -1078,46 +1033,46 @@ class _CardAccordionState extends State<_CardAccordion> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          Text(
-                            item['title'] as String,
-                            style: const TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: 8),
                           Row(
-                            crossAxisAlignment: CrossAxisAlignment.baseline,
-                            textBaseline: TextBaseline.alphabetic,
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                item['title'] as String,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 18,
+                                ),
+                              ),
+                              Icon(
+                                isExpanded
+                                    ? Icons.keyboard_arrow_up
+                                    : Icons.keyboard_arrow_down,
+                                color: Colors.white.withOpacity(0.8),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 16),
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.end,
                             children: [
                               Text(
                                 item['price'] as String,
                                 style: const TextStyle(
-                                  fontSize: 24,
-                                  fontWeight: FontWeight.bold,
                                   color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 28,
                                 ),
                               ),
                               const SizedBox(width: 4),
-                              Text(
-                                '/${item['period']}',
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  color: Colors.white.withOpacity(0.8),
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 4),
+                                child: Text(
+                                  '/ ${item['period']}',
+                                  style: TextStyle(
+                                    color: Colors.white.withOpacity(0.8),
+                                  ),
                                 ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 8),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.end,
-                            children: [
-                              Icon(
-                                isExpanded
-                                    ? Icons.expand_less
-                                    : Icons.expand_more,
-                                color: Colors.white.withOpacity(0.8),
                               ),
                             ],
                           ),
@@ -1125,8 +1080,7 @@ class _CardAccordionState extends State<_CardAccordion> {
                       ),
                     ),
                   ),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 300),
+                  child: Container(
                     padding: const EdgeInsets.all(20),
                     decoration: BoxDecoration(
                       color: Colors.white,

--- a/packages/naked/example/lib/main.dart
+++ b/packages/naked/example/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:example/examples/naked_tooltip_example.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-// Import examples
 import 'examples/naked_accordion_example.dart';
 import 'examples/naked_avatar_example.dart';
 import 'examples/naked_button_example.dart';

--- a/packages/naked/lib/src/naked_accordion.dart
+++ b/packages/naked/lib/src/naked_accordion.dart
@@ -1,5 +1,89 @@
 import 'package:flutter/widgets.dart';
 
+/// Controller that manages the state of an accordion.
+///
+/// This controller keeps track of which accordion items are expanded or collapsed
+/// and provides methods to open, close, or toggle items. It can also enforce
+/// minimum and maximum limits on the number of expanded items.
+///
+/// Generic type [T] represents the unique identifier for each accordion item.
+/// This could be a String, int, or any other type that can uniquely identify sections.
+class AccordionController<T> with ChangeNotifier {
+  /// Creates an accordion controller.
+  ///
+  /// [min] specifies the minimum number of expanded items (default: 0).
+  /// [max] specifies the maximum number of expanded items (optional).
+  /// When [max] is specified and reached, opening a new item will close the oldest one.
+  AccordionController({this.min = 0, this.max});
+
+  /// The minimum number of expanded items allowed.
+  final int min;
+
+  /// The maximum number of expanded items allowed.
+  /// If null, there is no maximum limit.
+  final int? max;
+
+  /// Set of currently expanded values.
+  final Set<T> values = {};
+
+  /// Opens the accordion item with the given [value].
+  ///
+  /// If [max] is specified and the maximum number of expanded items is reached,
+  /// this will close the oldest expanded item to maintain the limit.
+  void open(T value) {
+    if (max != null && values.length >= max!) {
+      close(values.first);
+      values.add(value);
+    } else {
+      values.add(value);
+    }
+    notifyListeners();
+  }
+
+  /// Closes the accordion item with the given [value].
+  ///
+  /// Will not close if doing so would violate the [min] constraint.
+  void close(T value) {
+    if (min > 0 && values.length <= min) {
+      return;
+    }
+    values.remove(value);
+    notifyListeners();
+  }
+
+  /// Toggles the accordion item with the given [value].
+  ///
+  /// If the item is expanded, it will be closed (subject to [min] constraint).
+  /// If the item is collapsed, it will be opened (subject to [max] constraint).
+  void toggle(T value) {
+    if (values.contains(value)) {
+      close(value);
+    } else {
+      open(value);
+    }
+    notifyListeners();
+  }
+
+  /// Removes all expanded values.
+  ///
+  /// Note that if [min] is greater than 0, this operation may not be allowed.
+  void clear() {
+    values.clear();
+    notifyListeners();
+  }
+
+  /// Opens all accordion items with the given [newValues].
+  ///
+  /// Note that if [max] is specified, only the first [max] items will be opened.
+  void openAll(List<T> newValues) {
+    values.addAll(newValues);
+    notifyListeners();
+  }
+
+  /// Checks if an item with the given [value] is currently expanded.
+  bool contains(T value) => values.contains(value);
+}
+
 /// A fully customizable accordion with no default styling.
 ///
 /// NakedAccordion provides expandable/collapsible sections without imposing any visual styling,
@@ -36,83 +120,6 @@ import 'package:flutter/widgets.dart';
 ///   ],
 /// )
 /// ```
-
-/// Controller that manages the state of an accordion.
-///
-/// This controller keeps track of which accordion items are expanded or collapsed
-/// and provides methods to open, close, or toggle items. It can also enforce
-/// minimum and maximum limits on the number of expanded items.
-///
-/// Generic type [T] represents the unique identifier for each accordion item.
-class AccordionController<T> with ChangeNotifier {
-  /// Creates an accordion controller.
-  ///
-  /// [min] specifies the minimum number of expanded items (default: 0).
-  /// [max] specifies the maximum number of expanded items (optional).
-  /// When [max] is specified and reached, opening a new item will close the oldest one.
-  AccordionController({this.min = 0, this.max});
-
-  /// The minimum number of expanded items allowed.
-  final int min;
-
-  /// The maximum number of expanded items allowed.
-  /// If null, there is no maximum limit.
-  final int? max;
-
-  /// Set of currently expanded values.
-  final Set<T> values = {};
-
-  /// Opens the accordion item with the given [value].
-  ///
-  /// If [max] is specified and the maximum number of expanded items is reached,
-  /// this will close the oldest expanded item to maintain the limit.
-  void open(T value) {
-    if (max != null && values.length >= max!) {
-      close(values.first);
-      values.add(value);
-    } else {
-      values.add(value);
-    }
-    notifyListeners();
-  }
-
-  void close(T value) {
-    if (min > 0 && values.length <= min) {
-      return;
-    }
-    values.remove(value);
-    notifyListeners();
-  }
-
-  void toggle(T value) {
-    if (values.contains(value)) {
-      close(value);
-    } else {
-      open(value);
-    }
-    notifyListeners();
-  }
-
-  void clear() {
-    values.clear();
-    notifyListeners();
-  }
-
-  void openAll(List<T> newValues) {
-    values.addAll(newValues);
-    notifyListeners();
-  }
-
-  bool contains(T value) => values.contains(value);
-}
-
-/// A container widget for accordion items with no default styling.
-///
-/// NakedAccordion provides the structure for organizing collapsible sections
-/// but leaves the visual styling entirely to the consumer. It uses an
-/// [AccordionController] to manage which sections are expanded or collapsed.
-///
-/// Generic type [T] should match the type used in the [AccordionController].
 class NakedAccordion<T> extends StatefulWidget {
   /// The accordion items to display.
   final List<Widget> children;

--- a/packages/naked/lib/src/naked_accordion.dart
+++ b/packages/naked/lib/src/naked_accordion.dart
@@ -14,7 +14,12 @@ class AccordionController<T> with ChangeNotifier {
   /// [min] specifies the minimum number of expanded items (default: 0).
   /// [max] specifies the maximum number of expanded items (optional).
   /// When [max] is specified and reached, opening a new item will close the oldest one.
-  AccordionController({this.min = 0, this.max});
+  AccordionController({this.min = 0, this.max})
+      : assert(min >= 0, 'min must be greater than or equal to 0'),
+        assert(
+          max == null || max >= min,
+          'max must be greater than or equal to min',
+        );
 
   /// The minimum number of expanded items allowed.
   final int min;
@@ -32,7 +37,7 @@ class AccordionController<T> with ChangeNotifier {
   /// this will close the oldest expanded item to maintain the limit.
   void open(T value) {
     if (max != null && values.length >= max!) {
-      close(values.first);
+      values.remove(values.first);
       values.add(value);
     } else {
       values.add(value);
@@ -44,7 +49,7 @@ class AccordionController<T> with ChangeNotifier {
   ///
   /// Will not close if doing so would violate the [min] constraint.
   void close(T value) {
-    if (min > 0 && values.length < min) {
+    if (min > 0 && values.length <= min) {
       return;
     }
     values.remove(value);

--- a/packages/naked/lib/src/naked_accordion.dart
+++ b/packages/naked/lib/src/naked_accordion.dart
@@ -44,7 +44,7 @@ class AccordionController<T> with ChangeNotifier {
   ///
   /// Will not close if doing so would violate the [min] constraint.
   void close(T value) {
-    if (min > 0 && values.length <= min) {
+    if (min > 0 && values.length < min) {
       return;
     }
     values.remove(value);

--- a/packages/naked/lib/src/naked_accordion.dart
+++ b/packages/naked/lib/src/naked_accordion.dart
@@ -1,495 +1,128 @@
-// import 'package:flutter/material.dart';
-
-// /// Defines the accordion expansion behavior.
-// enum NakedAccordionType {
-//   /// Only one item can be expanded at a time.
-//   single,
-
-//   /// Multiple items can be expanded simultaneously.
-//   multiple,
-// }
-
-// /// A fully customizable accordion with no default styling.
-// ///
-// /// NakedAccordion provides interaction behavior and accessibility features
-// /// for an expandable/collapsible content panel without imposing any visual styling,
-// /// giving consumers complete control over appearance through direct state callbacks.
-// ///
-// /// Example:
-// /// ```dart
-// /// class MyAccordion extends StatefulWidget {
-// ///   @override
-// ///   _MyAccordionState createState() => _MyAccordionState();
-// /// }
-// ///
-// /// class _MyAccordionState extends State<MyAccordion> {
-// ///   Set<String> _expandedItems = {};
-// ///
-// ///   @override
-// ///   Widget build(BuildContext context) {
-// ///     return NakedAccordion(
-// ///       expandedValues: _expandedItems,
-// ///       onExpandedValuesChanged: (values) {
-// ///         setState(() {
-// ///           _expandedItems = values;
-// ///         });
-// ///       },
-// ///       child: Column(
-// ///         children: [
-// ///           NakedAccordionItem(
-// ///             value: 'item1',
-// ///             child: Column(
-// ///               children: [
-// ///                 NakedAccordionTrigger(
-// ///                   isExpanded: _expandedItems.contains('item1'),
-// ///                   onPressed: () {
-// ///                     setState(() {
-// ///                       if (_expandedItems.contains('item1')) {
-// ///                         _expandedItems.remove('item1');
-// ///                       } else {
-// ///                         _expandedItems.add('item1');
-// ///                       }
-// ///                     });
-// ///                   },
-// ///                   child: Container(
-// ///                     padding: EdgeInsets.all(16),
-// ///                     color: _expandedItems.contains('item1')
-// ///                         ? Colors.blue.shade100
-// ///                         : Colors.grey.shade200,
-// ///                     child: Row(
-// ///                       children: [
-// ///                         Text('Section 1'),
-// ///                         Spacer(),
-// ///                         Icon(_expandedItems.contains('item1')
-// ///                             ? Icons.expand_less
-// ///                             : Icons.expand_more),
-// ///                       ],
-// ///                     ),
-// ///                   ),
-// ///                 ),
-// ///                 NakedAccordionContent(
-// ///                   isExpanded: _expandedItems.contains('item1'),
-// ///                   child: Container(
-// ///                     padding: EdgeInsets.all(16),
-// ///                     color: Colors.blue.shade50,
-// ///                     child: Text('Content for section 1'),
-// ///                   ),
-// ///                 ),
-// ///               ],
-// ///             ),
-// ///           ),
-// ///           // Additional NakedAccordionItems...
-// ///         ],
-// ///       ),
-// ///     );
-// ///   }
-// /// }
-// /// ```
-// /// A multi-expandable accordion component.
-// ///
-// /// This component manages the state of multiple expandable sections,
-// /// and can be configured to allow multiple sections to be expanded at once
-// /// or just a single section.
-// class NakedAccordion extends StatefulWidget {
-//   /// The type of accordion: single or multiple expanded items allowed.
-//   ///
-//   /// If [type] is [NakedAccordionType.single], only one item can be expanded at a time.
-//   /// If [type] is [NakedAccordionType.multiple], multiple items can be expanded.
-//   final NakedAccordionType type;
-
-//   /// List of values of initially expanded items.
-//   ///
-//   /// For [NakedAccordionType.single], only the first value in this list will be used.
-//   final List<String> initialExpandedValues;
-
-//   /// Whether the accordion is enabled.
-//   ///
-//   /// When disabled, no items can be expanded or collapsed.
-//   final bool enabled;
-
-//   /// Called when an item's expanded state changes.
-//   ///
-//   /// The callback provides the item's value and whether it's expanded.
-//   final void Function(String value, bool isExpanded)? onExpandedChange;
-
-//   /// Called when an item receives focus.
-//   ///
-//   /// The callback provides the focused item's value.
-//   final void Function(String value)? onFocusItem;
-
-//   /// The child widgets of the accordion.
-//   ///
-//   /// Typically a list of [NakedAccordionItem] widgets.
-//   final List<Widget> children;
-
-//   /// Creates a naked accordion.
-//   ///
-//   /// The [children] parameter is required.
-//   const NakedAccordion({
-//     super.key,
-//     this.type = NakedAccordionType.single,
-//     this.initialExpandedValues = const [],
-//     this.enabled = true,
-//     this.onExpandedChange,
-//     this.onFocusItem,
-//     required this.children,
-//   });
-
-//   @override
-//   State<NakedAccordion> createState() => _NakedAccordionState();
-// }
-
-// class _NakedAccordionState extends State<NakedAccordion> {
-//   /// Set of expanded item values
-//   late Set<String> _expandedValues;
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     _initExpandedValues();
-//   }
-
-//   @override
-//   void didUpdateWidget(NakedAccordion oldWidget) {
-//     super.didUpdateWidget(oldWidget);
-
-//     // Reset expanded values if type changes
-//     if (oldWidget.type != widget.type) {
-//       _initExpandedValues();
-//     }
-//   }
-
-//   void _initExpandedValues() {
-//     _expandedValues = Set<String>.from(widget.initialExpandedValues);
-
-//     // For single type, ensure only one item is expanded
-//     if (widget.type == NakedAccordionType.single &&
-//         _expandedValues.length > 1) {
-//       final firstValue = _expandedValues.first;
-//       _expandedValues = {firstValue};
-//     }
-//   }
-
-//   bool isItemExpanded(String value) {
-//     return _expandedValues.contains(value);
-//   }
-
-//   void toggleItem(String value) {
-//     if (!widget.enabled) return;
-
-//     setState(() {
-//       if (_expandedValues.contains(value)) {
-//         // Collapse the item
-//         _expandedValues.remove(value);
-//       } else {
-//         // Expand the item
-//         if (widget.type == NakedAccordionType.single) {
-//           // For single type, collapse other items
-//           _expandedValues = {value};
-//         } else {
-//           // For multiple type, add to expanded items
-//           _expandedValues.add(value);
-//         }
-//       }
-//     });
-
-//     // Notify about the change
-//     final isExpanded = _expandedValues.contains(value);
-//     widget.onExpandedChange?.call(value, isExpanded);
-//   }
-
-//   void focusItem(String value) {
-//     widget.onFocusItem?.call(value);
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return _NakedAccordionScope(
-//       state: this,
-//       child: Column(
-//         mainAxisSize: MainAxisSize.min,
-//         crossAxisAlignment: CrossAxisAlignment.start,
-//         children: widget.children,
-//       ),
-//     );
-//   }
-// }
-
-// /// Internal scope for propagating accordion state to children.
-// class _NakedAccordionScope extends InheritedWidget {
-//   /// The accordion state
-//   final _NakedAccordionState state;
-
-//   /// Creates an accordion scope.
-//   const _NakedAccordionScope({
-//     required super.child,
-//     required this.state,
-//   });
-
-//   /// Whether the accordion is enabled.
-//   bool get enabled => state.widget.enabled;
-
-//   /// The type of accordion.
-//   NakedAccordionType get type => state.widget.type;
-
-//   /// Checks if an item is expanded.
-//   bool isItemExpanded(String value) => state.isItemExpanded(value);
-
-//   /// Toggles an item's expanded state.
-//   void toggleItem(String value) => state.toggleItem(value);
-
-//   /// Focuses an item.
-//   void onFocusItem(String value) => state.focusItem(value);
-
-//   @override
-//   bool updateShouldNotify(_NakedAccordionScope oldWidget) {
-//     return oldWidget.state != state ||
-//         oldWidget.state.widget.enabled != state.widget.enabled ||
-//         oldWidget.state.widget.type != state.widget.type;
-//   }
-
-//   /// Gets the accordion scope from the given context.
-//   static _NakedAccordionScope? of(BuildContext context) {
-//     return context.dependOnInheritedWidgetOfExactType<_NakedAccordionScope>();
-//   }
-// }
-
-// /// Content part of an accordion item that can be expanded or collapsed.
-// ///
-// /// This component is typically used as the content part of a NakedAccordionItem
-// /// and is controlled by the parent item's expanded state.
-// class NakedAccordionContent extends StatefulWidget {
-//   /// The content to display when expanded.
-//   final Widget child;
-
-//   /// Optional - Whether the content is expanded.
-//   ///
-//   /// If provided, this will override the parent accordion item's state.
-//   final bool? isExpanded;
-
-//   /// Optional - Called when the content's animation state changes.
-//   ///
-//   /// This allows tracking when the animation completes.
-//   final ValueChanged<AnimationStatus>? onAnimationStatusChanged;
-
-//   /// Creates a naked accordion content.
-//   ///
-//   /// The [child] parameter is required.
-//   const NakedAccordionContent({
-//     super.key,
-//     required this.child,
-//     this.isExpanded,
-//     this.onAnimationStatusChanged,
-//   });
-
-//   @override
-//   State<NakedAccordionContent> createState() => _NakedAccordionContentState();
-// }
-
-// class _NakedAccordionContentState extends State<NakedAccordionContent>
-//     with SingleTickerProviderStateMixin {
-//   late AnimationController _controller;
-//   late Animation<double> _animation;
-//   bool? _lastKnownExpandedState;
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     _controller = AnimationController(
-//       vsync: this,
-//       duration: const Duration(milliseconds: 200),
-//     );
-//     _animation = CurvedAnimation(
-//       parent: _controller,
-//       curve: Curves.easeInOut,
-//     );
-
-//     // Listen for animation status changes
-//     if (widget.onAnimationStatusChanged != null) {
-//       _animation.addStatusListener(widget.onAnimationStatusChanged!);
-//     }
-//   }
-
-//   @override
-//   void dispose() {
-//     // Remove listener before disposing
-//     if (widget.onAnimationStatusChanged != null) {
-//       _animation.removeStatusListener(widget.onAnimationStatusChanged!);
-//     }
-//     _controller.dispose();
-//     super.dispose();
-//   }
-
-//   bool _getExpandedState() {
-//     // Priority 1: Widget's own isExpanded property
-//     if (widget.isExpanded != null) return widget.isExpanded!;
-
-//     // Priority 2: Parent accordion's expanded value for this item
-//     final item = _NakedAccordionItemScope.of(context);
-//     final accordion = _NakedAccordionScope.of(context);
-
-//     if (item != null && accordion != null) {
-//       return accordion.isItemExpanded(item.value);
-//     }
-
-//     return false;
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final bool isExpanded = _getExpandedState();
-
-//     // Update animation if expanded state changed
-//     if (_lastKnownExpandedState != isExpanded) {
-//       _lastKnownExpandedState = isExpanded;
-//       if (isExpanded) {
-//         _controller.forward();
-//       } else {
-//         _controller.reverse();
-//       }
-//     }
-
-//     return SizeTransition(
-//       sizeFactor: _animation,
-//       child: Semantics(
-//         hidden: !isExpanded,
-//         child: widget.child,
-//       ),
-//     );
-//   }
-// }
-
-// /// An item within an accordion.
-// ///
-// /// This component represents a single expandable section within an accordion.
-// class NakedAccordionItem extends StatefulWidget {
-//   /// The unique value for this accordion item.
-//   ///
-//   /// This value is used to track the expanded state of the item.
-//   final String value;
-
-//   /// Whether this accordion item is enabled.
-//   ///
-//   /// When false, the item cannot be expanded or collapsed.
-//   final bool? enabled;
-
-//   /// Whether this accordion item is expanded.
-//   ///
-//   /// If not provided, the item will use the expanded state from
-//   /// the parent accordion.
-//   final bool? isExpanded;
-
-//   /// The trigger widget that controls expansion.
-//   ///
-//   /// This is typically a [NakedAccordionTrigger] widget.
-//   final Widget trigger;
-
-//   /// The content that is shown when the accordion item is expanded.
-//   ///
-//   /// This is typically a [NakedAccordionContent] widget.
-//   final Widget content;
-
-//   /// Called when the expanded state changes.
-//   ///
-//   /// This event is fired after the state has changed, and can be used to
-//   /// perform additional actions like scrolling to the item.
-//   final ValueChanged<bool>? onExpandedStateChange;
-
-//   /// Creates an accordion item.
-//   ///
-//   /// The [value], [trigger], and [content] parameters are required.
-//   const NakedAccordionItem({
-//     super.key,
-//     required this.value,
-//     this.enabled,
-//     this.isExpanded,
-//     required this.trigger,
-//     required this.content,
-//     this.onExpandedStateChange,
-//   });
-
-//   @override
-//   State<NakedAccordionItem> createState() => _NakedAccordionItemState();
-// }
-
-// class _NakedAccordionItemState extends State<NakedAccordionItem> {
-//   bool? _lastKnownExpandedState;
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final accordion = _NakedAccordionScope.of(context);
-
-//     // Determine if the item is expanded from the accordion or local prop
-//     final bool isExpanded =
-//         widget.isExpanded ?? (accordion?.isItemExpanded(widget.value) ?? false);
-
-//     // Check if expanded state changed
-//     if (_lastKnownExpandedState != isExpanded) {
-//       _lastKnownExpandedState = isExpanded;
-//       // Notify of expanded state change, but after build completes
-//       if (widget.onExpandedStateChange != null) {
-//         WidgetsBinding.instance.addPostFrameCallback((_) {
-//           widget.onExpandedStateChange!(isExpanded);
-//         });
-//       }
-//     }
-
-//     // Determine if the item is enabled from the accordion or local prop
-//     final bool enabled = widget.enabled ?? (accordion?.enabled ?? false);
-
-//     return _NakedAccordionItemScope(
-//       value: widget.value,
-//       enabled: enabled,
-//       child: Column(
-//         mainAxisSize: MainAxisSize.min,
-//         crossAxisAlignment: CrossAxisAlignment.stretch,
-//         children: [
-//           widget.trigger,
-//           widget.content,
-//         ],
-//       ),
-//     );
-//   }
-// }
-
-// /// The scope that provides accordion item state to its descendants.
-// class _NakedAccordionItemScope extends InheritedWidget {
-//   /// The unique value that identifies this accordion item.
-//   final String value;
-
-//   /// Whether the accordion item is enabled.
-//   final bool enabled;
-
-//   const _NakedAccordionItemScope({
-//     required this.value,
-//     required this.enabled,
-//     required super.child,
-//   });
-
-//   static _NakedAccordionItemScope? of(BuildContext context) {
-//     return context
-//         .dependOnInheritedWidgetOfExactType<_NakedAccordionItemScope>();
-//   }
-
-//   @override
-//   bool updateShouldNotify(_NakedAccordionItemScope oldWidget) {
-//     return value != oldWidget.value || enabled != oldWidget.enabled;
-//   }
-// }
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-class AccordionController<T> {
+/// A fully customizable accordion with no default styling.
+///
+/// NakedAccordion provides expandable/collapsible sections with accessibility features
+/// without imposing any visual styling, giving consumers complete design freedom.
+/// It manages the state of expanded sections through an [AccordionController] and provides
+/// callbacks for custom state handling.
+///
+/// This component includes:
+/// - [AccordionController]: Manages which sections are expanded/collapsed
+/// - [NakedAccordion]: The container for accordion items
+/// - [NakedAccordionItem]: Individual collapsible sections
+/// - [NakedAccordionTrigger]: Handles user interaction for expanding/collapsing
+///
+/// Example:
+/// ```dart
+/// class MyAccordion extends StatefulWidget {
+///   @override
+///   _MyAccordionState createState() => _MyAccordionState();
+/// }
+///
+/// class _MyAccordionState extends State<MyAccordion> {
+///   final AccordionController<String> controller = AccordionController<String>();
+///   bool isHovered = false;
+///   bool isPressed = false;
+///   bool isFocused = false;
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return NakedAccordion<String>(
+///       controller: controller,
+///       initialExpandedValues: ['section1'],
+///       children: [
+///         NakedAccordionItem<String>(
+///           value: 'section1',
+///           trigger: (isExpanded) => NakedAccordionTrigger<String>(
+///             onHoverState: (hover) => setState(() => isHovered = hover),
+///             onPressedState: (pressed) => setState(() => isPressed = pressed),
+///             onFocusState: (focused) => setState(() => isFocused = focused),
+///             child: Container(
+///               padding: EdgeInsets.all(16),
+///               decoration: BoxDecoration(
+///                 color: isPressed
+///                     ? Colors.blue.shade700
+///                     : isHovered
+///                         ? Colors.blue.shade600
+///                         : Colors.blue.shade500,
+///                 borderRadius: BorderRadius.circular(4),
+///               ),
+///               child: Row(
+///                 children: [
+///                   Text('Section 1', style: TextStyle(color: Colors.white)),
+///                   Spacer(),
+///                   Icon(
+///                     isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+///                     color: Colors.white,
+///                   ),
+///                 ],
+///               ),
+///             ),
+///           ),
+///           child: Container(
+///             padding: EdgeInsets.all(16),
+///             child: Text('Content for section 1'),
+///           ),
+///           transitionBuilder: (child) => AnimatedSwitcher(
+///             duration: Duration(milliseconds: 300),
+///             child: child,
+///           ),
+///         ),
+///         // Add more NakedAccordionItems as needed
+///       ],
+///     );
+///   }
+/// }
+/// ```
+
+/// Controller that manages the state of an accordion.
+///
+/// This controller keeps track of which accordion items are expanded or collapsed
+/// and provides methods to open, close, or toggle items. It can also enforce
+/// minimum and maximum limits on the number of expanded items.
+///
+/// Generic type [T] represents the unique identifier for each accordion item.
+class AccordionController<T> with ChangeNotifier {
+  /// Creates an accordion controller.
+  ///
+  /// [min] specifies the minimum number of expanded items (default: 0).
+  /// [max] specifies the maximum number of expanded items (optional).
+  /// When [max] is specified and reached, opening a new item will close the oldest one.
+  AccordionController({this.min = 0, this.max});
+
+  /// The minimum number of expanded items allowed.
+  final int min;
+
+  /// The maximum number of expanded items allowed.
+  /// If null, there is no maximum limit.
+  final int? max;
+
+  /// Set of currently expanded values.
   final Set<T> values = {};
 
+  /// Opens the accordion item with the given [value].
+  ///
+  /// If [max] is specified and the maximum number of expanded items is reached,
+  /// this will close the oldest expanded item to maintain the limit.
   void open(T value) {
-    values.add(value);
+    if (max != null && values.length >= max!) {
+      close(values.first);
+      values.add(value);
+    } else {
+      values.add(value);
+    }
+    notifyListeners();
   }
 
   void close(T value) {
+    if (min > 0 && values.length <= min) {
+      return;
+    }
     values.remove(value);
+    notifyListeners();
   }
 
   void toggle(T value) {
@@ -498,15 +131,20 @@ class AccordionController<T> {
     } else {
       open(value);
     }
+    notifyListeners();
   }
 
   void clear() {
     values.clear();
+    notifyListeners();
   }
 
   void openAll(List<T> newValues) {
     values.addAll(newValues);
+    notifyListeners();
   }
+
+  bool contains(T value) => values.contains(value);
 
   @override
   bool operator ==(Object other) {
@@ -519,11 +157,32 @@ class AccordionController<T> {
   int get hashCode => values.hashCode;
 }
 
+/// A container widget for accordion items with no default styling.
+///
+/// NakedAccordion provides the structure for organizing collapsible sections
+/// but leaves the visual styling entirely to the consumer. It uses an
+/// [AccordionController] to manage which sections are expanded or collapsed.
+///
+/// Generic type [T] should match the type used in the [AccordionController].
 class NakedAccordion<T> extends StatefulWidget {
-  final List<NakedAccordionItem<T>> children;
+  /// The accordion items to display.
+  final List<Widget> children;
+
+  /// The controller that manages which items are expanded or collapsed.
   final AccordionController<T> controller;
+
+  /// Values that should be expanded when the accordion is first built.
   final List<T> initialExpandedValues;
+
+  /// Called when an accordion trigger is pressed.
+  ///
+  /// This callback receives the value of the item whose trigger was pressed.
   final void Function(T value)? onTriggerPressed;
+
+  /// Creates a naked accordion.
+  ///
+  /// The [children] should be [NakedAccordionItem] widgets with the same
+  /// generic type [T] as the [controller].
   const NakedAccordion({
     super.key,
     required this.children,
@@ -537,74 +196,78 @@ class NakedAccordion<T> extends StatefulWidget {
 }
 
 class _NakedAccordionState<T> extends State<NakedAccordion<T>> {
+  late final _controller = widget.controller;
+
   @override
   void initState() {
     super.initState();
-    widget.controller.values.addAll(widget.initialExpandedValues);
+    _controller.values.addAll(widget.initialExpandedValues);
   }
 
   @override
   void didUpdateWidget(covariant NakedAccordion<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.initialExpandedValues != widget.initialExpandedValues) {
-      widget.controller.clear();
-      widget.controller.openAll(widget.initialExpandedValues);
+      _controller.clear();
+      _controller.openAll(widget.initialExpandedValues);
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return _NakedAccordionScope<T>(
-      controller: widget.controller,
-      onTriggerPressed: widget.onTriggerPressed,
-      child: Column(
-        children: widget.children,
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: widget.children,
     );
   }
 }
 
-class _NakedAccordionScope<T> extends InheritedWidget {
-  final AccordionController<T> controller;
-  final void Function(T value)? onTriggerPressed;
+typedef BooleanWidgetBuilder = Widget Function(bool isExpanded);
 
-  const _NakedAccordionScope({
-    required this.controller,
-    required this.onTriggerPressed,
-    required super.child,
-  });
-
-  static _NakedAccordionScope<T> of<T>(BuildContext context) {
-    final scope =
-        context.dependOnInheritedWidgetOfExactType<_NakedAccordionScope<T>>();
-    if (scope == null) {
-      throw Exception('No _NakedAccordionScope found in context');
-    }
-    return scope;
-  }
-
-  @override
-  bool updateShouldNotify(_NakedAccordionScope<T> oldWidget) {
-    return controller != oldWidget.controller ||
-        onTriggerPressed != oldWidget.onTriggerPressed;
-  }
-}
-
+/// An individual item in a [NakedAccordion].
+///
+/// Each item consists of a trigger widget that toggles expansion state
+/// and content that is shown when expanded. The [transitionBuilder] can be
+/// used to customize how content appears/disappears.
+///
+/// Generic type [T] should match the type used in the [AccordionController].
 class NakedAccordionItem<T> extends StatefulWidget {
-  final Widget trigger;
-  final Widget content;
+  /// Builder function that creates the trigger widget.
+  ///
+  /// The boolean parameter indicates whether the item is currently expanded.
+  final BooleanWidgetBuilder trigger;
+
+  /// Optional builder to customize the transition when expanding/collapsing.
+  ///
+  /// If not provided, content will appear/disappear instantly.
+  final Widget Function(Widget child)? transitionBuilder;
+
+  /// The content displayed when this item is expanded.
+  final Widget child;
+
+  /// The unique identifier for this accordion item.
+  ///
+  /// This value is used by the [AccordionController] to track expansion state.
   final T value;
 
   /// Optional semantic label describing the section for screen readers.
   final String? semanticLabel;
 
+  /// Whether this accordion item can be interacted with.
+  ///
+  /// When false, the trigger cannot be used to expand/collapse the item.
   final bool enabled;
 
+  /// Creates a naked accordion item.
+  ///
+  /// The [trigger] and [child] parameters are required.
+  /// The [value] must be unique among all items controlled by the same controller.
   const NakedAccordionItem({
     super.key,
     required this.trigger,
-    required this.content,
     required this.value,
+    required this.child,
+    this.transitionBuilder,
     this.semanticLabel,
     this.enabled = true,
   });
@@ -616,60 +279,69 @@ class NakedAccordionItem<T> extends StatefulWidget {
 class _NakedAccordionItemState<T> extends State<NakedAccordionItem<T>> {
   @override
   Widget build(BuildContext context) {
-    final scope = _NakedAccordionScope.of<T>(context);
-    final controller = scope.controller;
-    final isExpanded = controller.values.contains(widget.value);
+    final state = context.findAncestorStateOfType<_NakedAccordionState<T>>();
+    return ListenableBuilder(
+      listenable: state!._controller,
+      builder: (context, child) {
+        final isExpanded = state._controller.contains(widget.value);
+        final child = isExpanded ? widget.child : const SizedBox.shrink();
 
-    return _NakedAccordionItemScope<T>(
-      value: widget.value,
-      enabled: widget.enabled,
-      child: Semantics(
-        container: true,
-        label: widget.semanticLabel,
-        explicitChildNodes: true,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            widget.trigger,
-            if (isExpanded)
-              Semantics(
-                container: true,
-                liveRegion: true, // Announces changes when content appears
-                child: widget.content,
-              ),
-          ],
-        ),
-      ),
+        return AccordionItemScope(
+          expanded: isExpanded,
+          child: Semantics(
+            container: true,
+            label: widget.semanticLabel,
+            explicitChildNodes: true,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                widget.trigger(isExpanded),
+                Semantics(
+                  container: true,
+                  liveRegion: true,
+                  child: widget.transitionBuilder != null
+                      ? widget.transitionBuilder!(child)
+                      : child,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }
 
-class _NakedAccordionItemScope<T> extends InheritedWidget {
-  final T value;
-  final bool enabled;
+class AccordionItemScope extends InheritedWidget {
+  final bool expanded;
 
-  const _NakedAccordionItemScope({
-    required this.value,
-    required this.enabled,
+  const AccordionItemScope({
+    super.key,
+    required this.expanded,
     required super.child,
   });
 
-  static _NakedAccordionItemScope<T> of<T>(BuildContext context) {
-    final scope = context
-        .dependOnInheritedWidgetOfExactType<_NakedAccordionItemScope<T>>();
-    if (scope == null) {
-      throw Exception('No _NakedAccordionItemScope found in context');
-    }
-    return scope;
+  static AccordionItemScope of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<AccordionItemScope>()!;
   }
 
   @override
-  bool updateShouldNotify(_NakedAccordionItemScope<T> oldWidget) {
-    return value != oldWidget.value || enabled != oldWidget.enabled;
+  bool updateShouldNotify(AccordionItemScope oldWidget) {
+    return expanded != oldWidget.expanded;
   }
 }
 
+/// A trigger widget for expanding and collapsing a [NakedAccordionItem].
+///
+/// This widget provides interaction handling and accessibility features
+/// without imposing any visual styling. It supports mouse hover, press,
+/// and keyboard focus states with callbacks to allow custom styling.
+///
+/// Generic type [T] should match the type used in the [AccordionController].
 class NakedAccordionTrigger<T> extends StatefulWidget {
+  /// The child widget to display.
+  ///
+  /// This widget should represent the visual appearance of the trigger.
   final Widget child;
 
   /// Called when hover state changes.
@@ -697,6 +369,10 @@ class NakedAccordionTrigger<T> extends StatefulWidget {
   /// Provides the current focus state (true when focused, false otherwise).
   final ValueChanged<bool>? onFocusState;
 
+  /// Creates a naked accordion trigger.
+  ///
+  /// The [child] parameter is required and represents the visual appearance
+  /// of the trigger in all states.
   const NakedAccordionTrigger({
     super.key,
     required this.child,
@@ -725,14 +401,16 @@ class _NakedAccordionTriggerState<T> extends State<NakedAccordionTrigger<T>> {
 
   @override
   Widget build(BuildContext context) {
-    final accordionScope = _NakedAccordionScope.of<T>(context);
-    final itemScope = _NakedAccordionItemScope.of<T>(context);
-    final isExpanded =
-        accordionScope.controller.values.contains(itemScope.value);
-    final isInteractive = itemScope.enabled;
+    final accordionScope =
+        context.findAncestorStateOfType<_NakedAccordionState<T>>();
+
+    final itemScope =
+        context.findAncestorStateOfType<_NakedAccordionItemState<T>>()!;
+    final isExpanded = AccordionItemScope.of(context).expanded;
+    final isInteractive = itemScope.widget.enabled;
 
     void handleTap() {
-      accordionScope.onTriggerPressed?.call(itemScope.value);
+      accordionScope?.widget.onTriggerPressed?.call(itemScope.widget.value);
     }
 
     return Focus(
@@ -794,168 +472,3 @@ extension on LogicalKeyboardKey {
   bool get isSpaceOrEnter =>
       this == LogicalKeyboardKey.space || this == LogicalKeyboardKey.enter;
 }
-
-// /// A component that serves as the trigger for an accordion item.
-// ///
-// /// This component is typically used as the trigger part of a NakedAccordionItem
-// /// and controls the expansion state of its associated content. It uses a pure
-// /// callback pattern, reporting interaction states (hover, press, focus) via
-// /// callbacks without managing internal state.
-// class NakedAccordionTrigger extends StatefulWidget {
-//   /// Whether the trigger is enabled.
-//   ///
-//   /// When disabled, the trigger will not respond to user interaction.
-//   /// This overrides any parent accordion or item enabled state.
-//   final bool? enabled;
-
-//   /// Called when the trigger is tapped.
-//   ///
-//   /// If provided, this will override the default behavior of toggling
-//   /// the accordion item's expanded state.
-//   final VoidCallback? onTap;
-
-//   /// Optional icon to indicate the expanded/collapsed state.
-//   ///
-//   /// If not provided, no icon will be shown.
-//   final Widget? icon;
-
-//   /// The main content of the trigger.
-//   final Widget child;
-
-//   /// Called when hover state changes (true if hovered, false otherwise).
-//   final ValueChanged<bool>? onHoverState;
-
-//   /// Called when pressed state changes (true if pressed, false otherwise).
-//   final ValueChanged<bool>? onPressedState;
-
-//   /// Called when focus state changes (true if focused, false otherwise).
-//   final ValueChanged<bool>? onFocusState;
-
-//   /// The cursor to display when hovering over the trigger.
-//   final MouseCursor cursor;
-
-//   /// Creates a naked accordion trigger.
-//   ///
-//   /// The [child] parameter is required.
-//   const NakedAccordionTrigger({
-//     super.key,
-//     this.enabled,
-//     this.onTap,
-//     this.icon,
-//     required this.child,
-//     this.onHoverState,
-//     this.onPressedState,
-//     this.onFocusState,
-//     this.cursor = SystemMouseCursors.click, // Default cursor
-//   });
-
-//   @override
-//   State<NakedAccordionTrigger> createState() => _NakedAccordionTriggerState();
-// }
-
-// class _NakedAccordionTriggerState extends State<NakedAccordionTrigger> {
-//   final FocusNode _focusNode = FocusNode();
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     // Add listener to report focus changes via callback
-//     _focusNode.addListener(_handleFocusChange);
-//   }
-
-//   @override
-//   void dispose() {
-//     _focusNode.removeListener(_handleFocusChange);
-//     _focusNode.dispose();
-//     super.dispose();
-//   }
-
-//   void _handleFocusChange() {
-//     widget.onFocusState?.call(_focusNode.hasFocus);
-//   }
-
-//   void _handleTap() {
-//     final item = _NakedAccordionItemScope.of(context);
-//     if (item == null) return;
-
-//     final accordion = _NakedAccordionScope.of(context);
-//     if (accordion == null) return;
-
-//     // Check for enabled state from widget, item, or accordion scope
-//     final bool isEnabled = widget.enabled ?? item.enabled && accordion.enabled;
-
-//     // Don't allow changes if not enabled
-//     if (!isEnabled) return;
-
-//     // Request focus when tapped, but only if not already focused
-//     if (!_focusNode.hasFocus) {
-//       _focusNode.requestFocus();
-//     }
-
-//     // If custom onTap is provided, use that instead of default behavior
-//     if (widget.onTap != null) {
-//       widget.onTap!();
-//       return;
-//     }
-
-//     // Toggle the expanded state via the accordion scope
-//     accordion.toggleItem(item.value);
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     final item = _NakedAccordionItemScope.of(context);
-//     final accordion = _NakedAccordionScope.of(context);
-
-//     // Determine if the item is expanded from accordion state
-//     final bool isExpanded = item != null && accordion != null
-//         ? accordion.isItemExpanded(item.value)
-//         : false;
-
-//     // Determine if the component is effectively enabled
-//     final bool isEffectivelyEnabled = widget.enabled ??
-//         (item?.enabled ?? false) && (accordion?.enabled ?? false);
-//     final bool isInteractive = isEffectivelyEnabled;
-
-//     return MouseRegion(
-//       cursor: isInteractive ? widget.cursor : SystemMouseCursors.forbidden,
-//       onEnter: isInteractive ? (_) => widget.onHoverState?.call(true) : null,
-//       onExit: isInteractive ? (_) => widget.onHoverState?.call(false) : null,
-//       child: GestureDetector(
-//         onTapDown:
-//             isInteractive ? (_) => widget.onPressedState?.call(true) : null,
-//         onTapUp:
-//             isInteractive ? (_) => widget.onPressedState?.call(false) : null,
-//         onTapCancel:
-//             isInteractive ? () => widget.onPressedState?.call(false) : null,
-//         onTap: isInteractive ? _handleTap : null,
-//         child: Focus(
-//           focusNode: _focusNode,
-//           // No Builder needed here anymore
-//           child: DefaultTextStyle(
-//             style: DefaultTextStyle.of(context).style,
-//             child: IconTheme(
-//               data: IconTheme.of(context),
-//               child: AnimatedContainer(
-//                 // Keep animation for visual feedback
-//                 duration: const Duration(milliseconds: 100),
-//                 child: Row(
-//                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-//                   children: [
-//                     Expanded(child: widget.child),
-//                     if (widget.icon != null)
-//                       AnimatedRotation(
-//                         turns: isExpanded ? 0.5 : 0,
-//                         duration: const Duration(milliseconds: 200),
-//                         child: widget.icon!,
-//                       ),
-//                   ],
-//                 ),
-//               ),
-//             ),
-//           ),
-//         ),
-//       ),
-//     );
-//   }
-// }

--- a/packages/naked/test/src/helpers/simulate_hover.dart
+++ b/packages/naked/test/src/helpers/simulate_hover.dart
@@ -42,10 +42,10 @@ extension WidgetTesterExtension on WidgetTester {
   }
 
   void expectCursor(SystemMouseCursor cursor, {required Key on}) async {
-    final region = widget<FocusableActionDetector>(find
-        .descendant(of: find.byKey(on), matching: find.byType(FocusableActionDetector))
+    final region = widget<MouseRegion>(find
+        .descendant(of: find.byKey(on), matching: find.byType(MouseRegion))
         .first);
 
-    expect(region.mouseCursor, cursor);
+    expect(region.cursor, cursor);
   }
 }

--- a/packages/naked/test/src/naked_accordion_test.dart
+++ b/packages/naked/test/src/naked_accordion_test.dart
@@ -254,6 +254,40 @@ void main() {
       expect(find.text('Content 2'), findsOneWidget);
     });
 
+    testWidgets('controller respects both min and max constraints',
+        (WidgetTester tester) async {
+      controller = AccordionController<String>(min: 1, max: 1);
+
+      await tester.pumpMaterialWidget(buildControlledAccordion());
+
+      // Open first item
+      controller.open('item1');
+      await tester.pump();
+
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsNothing);
+
+      // Open second item - both should remain open since max=2
+      controller.open('item2');
+      await tester.pump();
+
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Close 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsOneWidget);
+
+      // Try to close item1 - should fail since min=1 and item2 would be only one open
+      controller.close('item2');
+      await tester.pump();
+
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Close 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsOneWidget);
+    });
+
     testWidgets('controller.clear() collapses all items',
         (WidgetTester tester) async {
       controller.open('item1');

--- a/packages/naked/test/src/naked_accordion_test.dart
+++ b/packages/naked/test/src/naked_accordion_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:naked/naked.dart';
 
@@ -21,12 +19,12 @@ void main() {
         children: [
           NakedAccordionItem<String>(
             value: 'item1',
-            trigger: (_) => const Text('Trigger 1'),
+            trigger: (_, __, ___) => const Text('Trigger 1'),
             child: const Text('Content 1'),
           ),
           NakedAccordionItem<String>(
             value: 'item2',
-            trigger: (_) => const Text('Trigger 2'),
+            trigger: (_, __, ___) => const Text('Trigger 2'),
             child: const Text('Content 2'),
           ),
         ],
@@ -60,434 +58,238 @@ void main() {
     });
   });
 
-  group('Expansion Behavior', () {
-    StatefulBuilder buildAccordionWIthTrigger({
-      required AccordionController<String> controller,
-      List<String> initialExpandedValues = const [],
-    }) {
-      return StatefulBuilder(builder: (context, setState) {
-        return NakedAccordion<String>(
-          controller: controller,
-          onTriggerPressed: (value) => setState(() {
-            controller.toggle(value);
-          }),
-          initialExpandedValues: initialExpandedValues,
-          children: [
-            NakedAccordionItem<String>(
-              value: 'item1',
-              trigger: (_) => const NakedAccordionTrigger<String>(
-                child: Text('Trigger 1'),
-              ),
-              child: const Text('Content 1'),
-            ),
-            NakedAccordionItem(
-              value: 'item2',
-              trigger: (_) => const NakedAccordionTrigger<String>(
-                child: Text('Trigger 2'),
-              ),
-              child: const Text('Content 2'),
-            ),
-          ],
-        );
-      });
-    }
+  group('Focus State', () {
+    late bool focusState;
 
-    testWidgets('expands and collapses items correctly when clicked',
-        (WidgetTester tester) async {
-      final controller = AccordionController<String>();
-
-      await tester.pumpMaterialWidget(
-        buildAccordionWIthTrigger(controller: controller),
-      );
-
-      // Initially both items should be collapsed
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsNothing);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsNothing);
-
-      // Clicking first trigger should expand first item
-      await tester.tap(find.text('Trigger 1'));
-      await tester.pump();
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsOneWidget);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsNothing);
-
-      // Clicking second trigger should expand second item
-      await tester.tap(find.text('Trigger 2'));
-      await tester.pump();
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsOneWidget);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsOneWidget);
-
-      // Clicking first trigger again should collapse first item
-      await tester.tap(find.text('Trigger 1'));
-      await tester.pump();
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsNothing);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsOneWidget);
-    });
-
-    testWidgets(
-        'expands and collapses items correctly even with initialExpandedValues',
-        (WidgetTester tester) async {
-      final controller = AccordionController<String>();
-      await tester.pumpMaterialWidget(
-        buildAccordionWIthTrigger(
-          controller: controller,
-          initialExpandedValues: const ['item1'],
-        ),
-      );
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsOneWidget);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsNothing);
-
-      await tester.tap(find.text('Trigger 1'));
-      await tester.pump();
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsNothing);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsNothing);
-
-      await tester.tap(find.text('Trigger 2'));
-      await tester.pump();
-
-      expect(find.text('Trigger 1'), findsOneWidget);
-      expect(find.text('Content 1'), findsNothing);
-      expect(find.text('Trigger 2'), findsOneWidget);
-      expect(find.text('Content 2'), findsOneWidget);
-    });
-  });
-
-  group('State Management and Callbacks', () {
-    testWidgets(
-        'onTriggerPressed callback is fired when any trigger is pressed',
-        (WidgetTester tester) async {
-      String? lastPressedTriggerValue;
-
-      await tester.pumpMaterialWidget(
-        NakedAccordion<String>(
-          controller: AccordionController(),
-          onTriggerPressed: (value) => lastPressedTriggerValue = value,
-          children: [
-            NakedAccordionItem(
-              value: 'item1',
-              trigger: (_) => const NakedAccordionTrigger<String>(
-                child: Text('Trigger 1'),
-              ),
-              child: const Text('Content 1'),
-            ),
-            NakedAccordionItem<String>(
-              value: 'item2',
-              trigger: (_) => const NakedAccordionTrigger<String>(
-                child: Text('Trigger 2'),
-              ),
-              child: const Text('Content 2'),
-            ),
-          ],
-        ),
-      );
-
-      // Expand item
-      await tester.tap(find.text('Trigger 1'));
-      await tester.pump();
-
-      expect(lastPressedTriggerValue, 'item1');
-
-      // Collapse item
-      await tester.tap(find.text('Trigger 2'));
-      await tester.pumpAndSettle();
-
-      expect(lastPressedTriggerValue, 'item2');
-    });
-  });
-
-  group('Trigger Interaction', () {
-    final triggerKey = UniqueKey();
-    Widget buildAccordionUseCase({
-      void Function(bool)? onHoverState,
-      void Function(bool)? onPressedState,
-      void Function(bool)? onFocusState,
-      List<String> initialExpandedValues = const [],
-      FocusNode? focusNode,
+    Widget buildFocusableAccordion({
+      required FocusNode focusNode,
+      required bool autoFocus,
     }) {
       return NakedAccordion<String>(
-        initialExpandedValues: initialExpandedValues,
-        controller: AccordionController(),
+        controller: AccordionController<String>(),
         children: [
-          NakedAccordionItem(
+          NakedAccordionItem<String>(
             value: 'item1',
-            trigger: (_) => NakedAccordionTrigger<String>(
-              key: triggerKey,
-              onHoverState: onHoverState,
-              onPressedState: onPressedState,
-              onFocusState: onFocusState,
-              focusNode: focusNode,
-              child: const Text('Trigger 1'),
-            ),
+            trigger: (_, __, ___) => const Text('Trigger 1'),
+            onFocusState: (focused) => focusState = focused,
+            autoFocus: autoFocus,
+            focusNode: focusNode,
             child: const Text('Content 1'),
           ),
         ],
       );
     }
 
-    testWidgets('calls onHoverState when hovered', (WidgetTester tester) async {
-      bool isHovered = false;
-
-      await tester.pumpMaterialWidget(
-        buildAccordionUseCase(
-          onHoverState: (value) => isHovered = value,
-        ),
-      );
-
-      await tester.simulateHover(
-        triggerKey,
-        onHover: () {
-          expect(isHovered, true);
-        },
-      );
+    setUp(() {
+      focusState = false;
     });
 
-    testWidgets('calls onPressedState on tap down/up',
+    testWidgets('onFocusState callback is triggered when focused',
         (WidgetTester tester) async {
-      bool isPressed = false;
-
-      await tester.pumpMaterialWidget(
-        buildAccordionUseCase(
-          onPressedState: (value) => isPressed = value,
-        ),
-      );
-
-      final gesture =
-          await tester.press(find.byType(NakedAccordionTrigger<String>));
-      await tester.pump();
-      expect(isPressed, true);
-
-      await gesture.up();
-      await tester.pump();
-      expect(isPressed, false);
-    });
-
-    testWidgets('calls onFocusState when focused/unfocused',
-        (WidgetTester tester) async {
-      bool isFocused = false;
       final focusNode = FocusNode();
+      await tester.pumpMaterialWidget(buildFocusableAccordion(
+        focusNode: focusNode,
+        autoFocus: false,
+      ));
 
-      await tester.pumpMaterialWidget(
-        buildAccordionUseCase(
-          focusNode: focusNode,
-          onFocusState: (value) => isFocused = value,
-        ),
-      );
-
+      // Focus the accordion item
       focusNode.requestFocus();
       await tester.pump();
-      expect(isFocused, true);
+      expect(focusState, true);
 
+      // Remove focus
       focusNode.unfocus();
       await tester.pump();
-      expect(isFocused, false);
+      expect(focusState, false);
+    });
+
+    testWidgets('autofocus works correctly', (WidgetTester tester) async {
+      await tester.pumpMaterialWidget(
+        NakedAccordion<String>(
+          controller: AccordionController<String>(),
+          children: [
+            NakedAccordionItem<String>(
+              value: 'item1',
+              trigger: (_, __, ___) => const Text('Trigger 1'),
+              onFocusState: (focused) => focusState = focused,
+              autoFocus: true,
+              child: const Text('Content 1'),
+            ),
+          ],
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(focusState, true);
     });
   });
 
-  group('Accessibility', () {
-    testWidgets('triggers have proper semantic properties',
-        (WidgetTester tester) async {
-      final controller = AccordionController<String>();
+  group('Controlled Expansion', () {
+    late AccordionController<String> controller;
 
-      await tester.pumpMaterialWidget(
-        StatefulBuilder(builder: (context, setState) {
-          return NakedAccordion<String>(
-            controller: controller,
-            onTriggerPressed: (value) => setState(() {
-              controller.toggle(value);
-            }),
-            children: [
-              NakedAccordionItem(
-                value: 'item1',
-                semanticLabel: 'First Section',
-                trigger: (_) => const NakedAccordionTrigger<String>(
-                  semanticLabel: 'First Section Header',
-                  child: Text('Trigger 1'),
-                ),
-                child: const Text('Content 1'),
-              ),
-            ],
-          );
-        }),
+    setUp(() {
+      controller = AccordionController<String>();
+    });
+
+    Widget buildControlledAccordion() {
+      return NakedAccordion<String>(
+        controller: controller,
+        children: [
+          NakedAccordionItem<String>(
+            value: 'item1',
+            trigger: (context, isExpanded, toggle) {
+              return GestureDetector(
+                onTap: toggle,
+                child: Text(isExpanded ? 'Close 1' : 'Open 1'),
+              );
+            },
+            child: const Text('Content 1'),
+          ),
+          NakedAccordionItem<String>(
+            value: 'item2',
+            trigger: (context, isExpanded, toggle) {
+              return GestureDetector(
+                onTap: toggle,
+                child: Text(isExpanded ? 'Close 2' : 'Open 2'),
+              );
+            },
+            child: const Text('Content 2'),
+          ),
+        ],
       );
+    }
 
-      // Get semantic node for trigger
-      final SemanticsNode triggerNode =
-          tester.getSemantics(find.text('Trigger 1'));
+    testWidgets('controller.open() expands an item',
+        (WidgetTester tester) async {
+      await tester.pumpMaterialWidget(buildControlledAccordion());
 
-      // Verify semantic properties
-      expect(triggerNode.label, 'First Section Header');
-      expect(triggerNode.hasFlag(SemanticsFlag.isButton), true);
-      expect(triggerNode.hasFlag(SemanticsFlag.isToggled), false);
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Content 2'), findsNothing);
 
-      // Expand the accordion
-      await tester.tap(find.text('Trigger 1'));
+      controller.open('item1');
       await tester.pump();
 
-      // Get semantic node for trigger again after expansion
-      final SemanticsNode expandedTriggerNode =
-          tester.getSemantics(find.text('Trigger 1'));
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+      expect(find.text('Content 2'), findsNothing);
+    });
 
-      // Verify it's now toggled
-      expect(expandedTriggerNode.hasFlag(SemanticsFlag.isToggled), true);
+    testWidgets('controller.close() collapses an item',
+        (WidgetTester tester) async {
+      controller.open('item1');
+      await tester.pumpMaterialWidget(buildControlledAccordion());
 
-      // Verify content is accessible
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+
+      controller.close('item1');
+      await tester.pump();
+
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+    });
+
+    testWidgets('controller.toggle() toggles item expansion',
+        (WidgetTester tester) async {
+      await tester.pumpMaterialWidget(buildControlledAccordion());
+
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+
+      controller.toggle('item1');
+      await tester.pump();
+
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+
+      controller.toggle('item1');
+      await tester.pump();
+
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+    });
+
+    testWidgets('controller respects min expanded items',
+        (WidgetTester tester) async {
+      controller = AccordionController<String>(min: 1);
+      controller.open('item1');
+
+      await tester.pumpMaterialWidget(buildControlledAccordion());
+
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+
+      controller.close('item1');
+      await tester.pump();
+
+      // Should not close because min=1
+      expect(find.text('Close 1'), findsOneWidget);
       expect(find.text('Content 1'), findsOneWidget);
     });
 
-    testWidgets('supports keyboard activation', (WidgetTester tester) async {
-      final controller = AccordionController<String>();
-      const triggerTextKey = Key('trigger');
-      const triggerTextKey2 = Key('trigger2');
-      await tester.pumpMaterialWidget(
-        StatefulBuilder(builder: (context, setState) {
-          return NakedAccordion<String>(
-            controller: controller,
-            onTriggerPressed: (value) => setState(() {
-              controller.toggle(value);
-            }),
-            children: [
-              NakedAccordionItem<String>(
-                value: 'item1',
-                trigger: (_) => const NakedAccordionTrigger<String>(
-                  child: Text(
-                    'Trigger 1',
-                    key: triggerTextKey,
-                  ),
-                ),
-                child: const Text('Content 1'),
-              ),
-              NakedAccordionItem<String>(
-                value: 'item2',
-                trigger: (_) => const NakedAccordionTrigger<String>(
-                  child: Text(
-                    'Trigger 2',
-                    key: triggerTextKey2,
-                  ),
-                ),
-                child: const Text('Content 2'),
-              ),
-            ],
-          );
-        }),
-      );
+    testWidgets('controller respects max expanded items',
+        (WidgetTester tester) async {
+      controller = AccordionController<String>(max: 1);
 
-      // Initially content is hidden
-      expect(find.text('Content 1'), findsNothing);
+      await tester.pumpMaterialWidget(buildControlledAccordion());
 
-      // Focus the trigger
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      controller.open('item1');
       await tester.pump();
 
-      final triggerTextFinder = find.byKey(triggerTextKey);
-
-      // Ensure it's focused
-      final focusNode = Focus.of(tester.element(triggerTextFinder));
-      expect(focusNode.hasFocus, true);
-
-      // Press space to activate
-      await tester.sendKeyEvent(LogicalKeyboardKey.space);
-      await tester.pump();
-
-      // Verify the accordion expanded
+      expect(find.text('Close 1'), findsOneWidget);
       expect(find.text('Content 1'), findsOneWidget);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsNothing);
 
-      // press tab to focus on the next trigger
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      controller.open('item2');
       await tester.pump();
 
-      final triggerTextFinder2 = find.byKey(triggerTextKey2);
-      final focusNode2 = Focus.of(tester.element(triggerTextFinder2));
-      expect(focusNode2.hasFocus, true);
-
-      // press space to activate
-      await tester.sendKeyEvent(LogicalKeyboardKey.space);
-      await tester.pump();
-
+      // item1 should close when item2 opens because max=1
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Close 2'), findsOneWidget);
       expect(find.text('Content 2'), findsOneWidget);
     });
-  });
 
-  group('Disabled States', () {
-    testWidgets('disabled item prevents interaction',
+    testWidgets('controller.clear() collapses all items',
         (WidgetTester tester) async {
-      final controller = AccordionController<String>();
-      final triggerKey = UniqueKey();
-      final triggerKey2 = UniqueKey();
+      controller.open('item1');
+      controller.open('item2');
 
-      await tester.pumpMaterialWidget(
-        StatefulBuilder(builder: (context, setState) {
-          void handlePress(String value) {
-            setState(() {
-              controller.toggle(value);
-            });
-          }
+      await tester.pumpMaterialWidget(buildControlledAccordion());
 
-          return NakedAccordion<String>(
-            controller: controller,
-            onTriggerPressed: handlePress,
-            children: [
-              NakedAccordionItem<String>(
-                value: 'item1',
-                enabled: false,
-                trigger: (_) => NakedAccordionTrigger<String>(
-                  key: triggerKey,
-                  child: const Text('Trigger 1'),
-                ),
-                child: const Text('Content 1'),
-              ),
-              NakedAccordionItem(
-                value: 'item2',
-                trigger: (_) => NakedAccordionTrigger<String>(
-                  key: triggerKey2,
-                  child: const Text('Trigger 2'),
-                ),
-                child: const Text('Content 2'),
-              ),
-            ],
-          );
-        }),
-      );
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+      expect(find.text('Close 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsOneWidget);
 
-      // Attempt to expand disabled item
-      await tester.tap(find.text('Trigger 1'));
-      await tester.pumpAndSettle();
+      controller.clear();
+      await tester.pump();
 
-      // Content should remain collapsed
+      expect(find.text('Open 1'), findsOneWidget);
       expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsNothing);
+    });
 
-      // Check cursor is forbidden for disabled item
-      tester.expectCursor(
-        SystemMouseCursors.forbidden,
-        on: triggerKey,
-      );
+    testWidgets('controller.openAll() expands multiple items',
+        (WidgetTester tester) async {
+      await tester.pumpMaterialWidget(buildControlledAccordion());
 
-      // Non-disabled item should have click cursor and work normally
-      tester.expectCursor(
-        SystemMouseCursors.click,
-        on: triggerKey2,
-      );
+      expect(find.text('Open 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsNothing);
+      expect(find.text('Open 2'), findsOneWidget);
+      expect(find.text('Content 2'), findsNothing);
 
-      // Expand enabled item
-      await tester.tap(find.text('Trigger 2'));
-      await tester.pumpAndSettle();
+      controller.openAll(['item1', 'item2']);
+      await tester.pump();
 
-      // Content should expand
+      expect(find.text('Close 1'), findsOneWidget);
+      expect(find.text('Content 1'), findsOneWidget);
+      expect(find.text('Close 2'), findsOneWidget);
       expect(find.text('Content 2'), findsOneWidget);
     });
   });


### PR DESCRIPTION
### Description

This PR refactors the accordion examples and related docs/tests to use the new trigger-builder API, standardizes opacity calls, renames private example classes to public, and adds official NakedAccordion documentation.

### Changes

- Updated the `simulate_hover` test helper to use `MouseRegion` and its `cursor` property.
- Refactored `naked_accordion_example.dart` by replacing `_buildSection` and private widgets with a reusable `SectionWidget`, inline trigger closures, and public class names.
- Added a full API example (`naked_accordion.0..dart`) and updated documentation (`docs/accordion.mdx`, `docs.json`) plus renamed CodeGroup titles in other docs.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [x] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [x] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
