### PR TITLE
docs: Add introduction documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2,9 +2,18 @@
     "name": "naked",
     "description": "A widget library providing unstyled, behavior-focused components for Flutter.",
     "sidebar": [
-    {
-      "group": "Widgets",
-      "pages": [
+      {
+        "group": "Introduction",
+        "pages": [
+          {
+            "title": "Getting Started",
+            "href": "/index"
+          }
+        ]
+      },
+      {
+        "group": "Widgets",
+        "pages": [
         {
           "title": "NakedAccordion",
           "href": "/accordion"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -35,7 +35,7 @@ Add the Naked UI library to your Flutter project:
 
 ```yaml
 dependencies:
-  naked: ^latest_version  # Replace with the actual version
+  naked: ^latest_version  # Check for the latest version at https://pub.dev/packages/naked
 ```
 
 Then run:

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,56 +1,152 @@
 ---
-title: Welcome to docs.page!
-description: Get started with docs.page
+title: Getting Started
+description: Zero-styling UI components giving you complete design freedom
 ---
 
-Welcome to docs.page! The init command you just ran has created a basic file struture in your project to help you get started.
+The **Naked** library provides UI components that handle only the functionality, behavior, and accessibility aspects of UI elements without imposing any visual styling. This approach gives you complete control over your design system while ensuring all components work correctly and meet accessibility standards.
 
-## Walkthrough
+## Key Features
 
-### Configuration
+- **Zero-styling approach**: Components handle behavior only, you control 100% of the visual design
+- **Accessibility built-in**: All components implement proper ARIA roles and keyboard navigation
+- **Flexible state management**: Callback functions for all component states (hover, focus, pressed, etc.)
+- **Customizable**: Simple API with sensible defaults and extensive customization options
 
-In the root of your directory a new `docs.json` file has been created. This file is used to configure your documentation site. You can customize the name, description, and sidebar, theme, logos and more using this file.
+## Available Components
 
-Here's a basic example of what the file looks like:
+The library includes the following components:
 
+- **NakedButton**: Interactive button behavior with state callbacks
+- **NakedCheckbox**: Toggle component with customizable states
+- **NakedTooltip**: Positioned tooltip behavior with lifecycle management
+- **NakedTextField**: Text input with validation and state management
+- **NakedSelect**: Dropdown/select implementation with keyboard navigation
+- **NakedSlider**: Draggable slider with keyboard support and value constraints
+- **NakedTabs**: Tab navigation behavior with accessibility controls
+- **NakedRadioGroup**: Radio button group behavior with selection management
+- **NakedAccordion**: Expandable/collapsible section behavior
+- **NakedMenu**: Menu component with keyboard navigation
+
+## Getting Started
+
+### Installation
+
+Add the Naked UI library to your Flutter project:
+
+```yaml
+dependencies:
+  naked: ^latest_version  # Replace with the actual version
 ```
-{
-  "name": "My Docs",
-  "description": "My documentation site",
-  "sidebar": [
-  {
-    "group": "Getting Started",
-    "pages": [
-      {
-        "title": "Getting to know docs.page",
-        "href": "/",
-        "icon": "rocket"
-      },
-      {
-        "title": "Next Steps",
-        "href": "/next-steps",
-        "icon": "arrow-right"
-      }
-    ]
+
+Then run:
+
+```bash
+flutter pub get
+```
+
+### Basic Usage Pattern
+
+All Naked components follow a similar pattern:
+
+1. **Create your visual design**: Design your UI components using standard Flutter widgets
+2. **Wrap with Naked behavior**: Wrap your design with the appropriate Naked component
+3. **Handle state changes**: Use the provided callbacks to update your visual design based on component state
+
+## Example: Creating a Custom Button
+
+```dart
+class MyCustomButton extends StatefulWidget {
+  final String text;
+  final VoidCallback onPressed;
+  
+  const MyCustomButton({
+    Key? key,
+    required this.text,
+    required this.onPressed,
+  }) : super(key: key);
+
+  @override
+  _MyCustomButtonState createState() => _MyCustomButtonState();
+}
+
+class _MyCustomButtonState extends State<MyCustomButton> {
+  bool _isHovered = false;
+  bool _isPressed = false;
+  bool _isFocused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedButton(
+      onPressed: widget.onPressed,
+      onHoverState: (isHovered) => setState(() => _isHovered = isHovered),
+      onPressedState: (isPressed) => setState(() => _isPressed = isPressed),
+      onFocusState: (isFocused) => setState(() => _isFocused = isFocused),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        decoration: BoxDecoration(
+          color: _isPressed
+              ? Colors.blue.shade800  // Darker when pressed
+              : _isHovered
+                  ? Colors.blue.shade600  // Slightly darker when hovered
+                  : Colors.blue.shade500, // Default color
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(
+            color: _isFocused ? Colors.white : Colors.transparent,
+            width: 2,
+          ),
+        ),
+        child: Text(
+          widget.text,
+          style: TextStyle(color: Colors.white),
+        ),
+      ),
+    );
   }
-]
 }
 ```
 
-To learn more about the advanced configuration options, check out the [docs](https://use.docs.page/configuration).
+## Configuration
 
-### Content
+Each component has its own set of configuration options. Here are some common patterns:
 
-docs.page uses the `docs` directory to store your documentation pages. Two pages have been created for you:
+### State Callbacks
 
-- `index.mdx` - The home page of your documentation site, resolves to the root URL.
-- `next-steps.mdx` - A page to help you get started with docs.page, resolves to `/next-steps`.
+Most components provide state callbacks that notify you when the component's state changes:
 
-Documentation can be written using the standard [GitHub Flavored Markdown Spec](https://github.github.com/gfm/) and also supports the use of [MDX](https://mdxjs.com/), 
-with the ability to render custom [components](https://use.docs.page/components) for more advanced use cases.
+```dart
+NakedButton(
+  onHoverState: (isHovered) => handleHover(isHovered),
+  onPressedState: (isPressed) => handlePress(isPressed),
+  onFocusState: (isFocused) => handleFocus(isFocused),
+  // Other properties...
+)
+```
 
-## Preview
+### Accessibility Options
 
-To preview your documentation site, head over to [https://docs.page/preview](https://docs.page/preview) in your browser and open this directory.
+Components offer accessibility configuration:
 
-Previewing your documentation site will allow you to see the changes you make in real-time before you publish to the world.
+```dart
+NakedButton(
+  semanticLabel: 'Submit form',
+  isSemanticButton: true,
+  // Other properties...
+)
+```
+
+### Custom Focus Handling
+
+You can provide your own focus nodes for advanced focus management:
+
+```dart
+final FocusNode _myFocusNode = FocusNode();
+
+// In your widget build method:
+NakedButton(
+  focusNode: _myFocusNode,
+  autofocus: true,
+  // Other properties...
+)
+```
+
+See each component's documentation for details on all available configuration options.


### PR DESCRIPTION
### Description

Adds a new `Getting Started` guide for the Naked UI library and wires it into the sidebar.

### Changes

- Replaces the default docs.page template with an introduction to Naked, key features, and component list.
- Introduces Installation, Example, and Configuration sections with code snippets.
- Updates `docs.json` to include an “Introduction” sidebar group linking to the new index page.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [x] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [x] **Website Updates**: Is the website containing the updates you make on documentation?
