### PR TITLE
feat: Add overlayLifecycle to select

### DIFF
--- a/docs/select.mdx
+++ b/docs/select.mdx
@@ -17,7 +17,7 @@ class SelectExample extends StatefulWidget {
   State<SelectExample> createState() => _SelectExampleState();
 }
 
-class _SelectExampleState extends State<SelectExample> {
+class _SelectExampleState extends State<SelectExample> with TickerProviderStateMixin {
   final _controller = OverlayPortalController();
   String? _selectedValue;
   bool _isHovered = false;
@@ -35,15 +35,9 @@ class _SelectExampleState extends State<SelectExample> {
       width: 200,
       child: NakedSelect<String>(
         selectedValue: _selectedValue,
+        closeOnSelect: true,
         onSelectedValueChanged: (value) {
           setState(() => _selectedValue = value);
-        },
-        controller: _controller,
-        onOpen: () {
-          _controller.show();
-        },
-        onClose: () {
-          _controller.hide();
         },
         menu: Container(
           margin: const EdgeInsets.only(top: 4),
@@ -119,19 +113,18 @@ class _SelectExampleState extends State<SelectExample> {
 ```
 </CodeGroup>
 
-## Constructor
-
-### NakedSelect
+## NakedSelect
 
 ```dart
 const NakedSelect({
   Key? key,
   required this.child,
   required this.menu,
-  required this.onClose,
-  required this.onOpen,
-  required this.controller,
+  this.onClose,
+  this.onOpen,
   this.selectedValue,
+  this.onStateChange,
+  this.removalDelay = Duration.zero,
   this.onSelectedValueChanged,
   this.selectedValues,
   this.onSelectedValuesChanged,
@@ -157,46 +150,7 @@ const NakedSelect({
   this.closeOnClickOutside = true,
 })
 ```
-
-### NakedSelectTrigger
-
-```dart
-const NakedSelectTrigger({
-  Key? key,
-  required this.child,
-  this.onHoverState,
-  this.onPressedState,
-  this.onFocusState,
-  this.semanticLabel,
-  this.cursor = SystemMouseCursors.click,
-  this.enableHapticFeedback = true,
-  this.focusNode,
-  this.autofocus = true,
-})
-```
-
-### NakedSelectItem
-
-```dart
-const NakedSelectItem({
-  Key? key,
-  required this.child,
-  required this.value,
-  this.onHoverState,
-  this.onPressedState,
-  this.onFocusState,
-  this.enabled = true,
-  this.semanticLabel,
-  this.cursor = SystemMouseCursors.click,
-  this.enableHapticFeedback = true,
-  this.focusNode,
-  this.autofocus = true,
-})
-```
-
-## Properties
-
-### NakedSelect
+### Properties
 
 #### child → `Widget`
 The target widget that triggers the select dropdown. This should typically be a `NakedSelectTrigger`.
@@ -210,8 +164,11 @@ Called when the menu closes, either through selection or external interaction.
 #### onOpen → `VoidCallback?`
 Called when the menu is opened.
 
-#### controller → `OverlayPortalController`
-Controller to manage the overlay portal state.
+#### removalDelay → `Duration`
+The duration to wait before removing the widget from the overlay after the menu is closed. Defaults to `Duration.zero`.
+
+#### onStateChange → `Function(OverlayChildLifecycleState state)?`
+Optional callback for handling overlay state changes.
 
 #### selectedValue → `T?`
 The currently selected value in single selection mode. Only used when `allowMultiple` is false.
@@ -255,7 +212,25 @@ Alternative alignments to try if the menu doesn't fit in the preferred position.
 #### closeOnClickOutside → `bool`
 Whether to close the menu when clicking outside. Defaults to true.
 
-### NakedSelectTrigger
+
+## NakedSelectTrigger
+
+```dart
+const NakedSelectTrigger({
+  Key? key,
+  required this.child,
+  this.onHoverState,
+  this.onPressedState,
+  this.onFocusState,
+  this.semanticLabel,
+  this.cursor = SystemMouseCursors.click,
+  this.enableHapticFeedback = true,
+  this.focusNode,
+  this.autofocus = true,
+})
+```
+
+### Properties
 
 #### child → `Widget`
 The child widget to display. This widget will be wrapped with interaction handlers.
@@ -284,7 +259,27 @@ Optional focus node to control focus behavior.
 #### autofocus → `bool`
 Whether to automatically focus the trigger when opened. Defaults to true.
 
-### NakedSelectItem
+
+## NakedSelectItem
+
+```dart
+const NakedSelectItem({
+  Key? key,
+  required this.child,
+  required this.value,
+  this.onHoverState,
+  this.onPressedState,
+  this.onFocusState,
+  this.enabled = true,
+  this.semanticLabel,
+  this.cursor = SystemMouseCursors.click,
+  this.enableHapticFeedback = true,
+  this.focusNode,
+  this.autofocus = true,
+})
+```
+
+### Properties
 
 #### child → `Widget`
 The child widget to display. This widget will be wrapped with interaction handlers.

--- a/packages/naked/example/lib/api/naked_select.0.dart
+++ b/packages/naked/example/lib/api/naked_select.0.dart
@@ -28,8 +28,7 @@ class SelectExample extends StatefulWidget {
   State<SelectExample> createState() => _SelectExampleState();
 }
 
-class _SelectExampleState extends State<SelectExample> {
-  final _controller = OverlayPortalController();
+class _SelectExampleState extends State<SelectExample> with TickerProviderStateMixin {
   String? _selectedValue;
   bool _isHovered = false;
   bool _isFocused = false;
@@ -46,15 +45,9 @@ class _SelectExampleState extends State<SelectExample> {
       width: 200,
       child: NakedSelect<String>(
         selectedValue: _selectedValue,
+        closeOnSelect: true,
         onSelectedValueChanged: (value) {
           setState(() => _selectedValue = value);
-        },
-        controller: _controller,
-        onOpen: () {
-          _controller.show();
-        },
-        onClose: () {
-          _controller.hide();
         },
         menu: Container(
           margin: const EdgeInsets.only(top: 4),

--- a/packages/naked/example/lib/api/naked_select.1.dart
+++ b/packages/naked/example/lib/api/naked_select.1.dart
@@ -28,8 +28,8 @@ class AnimatedSelectExample extends StatefulWidget {
   State<AnimatedSelectExample> createState() => _AnimatedSelectExampleState();
 }
 
-class _AnimatedSelectExampleState extends State<AnimatedSelectExample> with TickerProviderStateMixin {
-  final _controller = OverlayPortalController();
+class _AnimatedSelectExampleState extends State<AnimatedSelectExample>
+    with TickerProviderStateMixin {
   String? _selectedValue;
   bool _isHovered = false;
   bool _isFocused = false;
@@ -45,9 +45,40 @@ class _AnimatedSelectExampleState extends State<AnimatedSelectExample> with Tick
   );
 
   Color get borderColor {
-    if (_isFocused) return Colors.blue;
-    if (_isHovered) return Colors.grey.shade400;
+    if (_isFocused) return Colors.grey.shade800;
+    if (_isHovered) return Colors.grey.shade100;
     return Colors.grey.shade300;
+  }
+
+  Color get backgroundColor {
+    if (_isHovered) return Colors.grey.shade100;
+    return Colors.white;
+  }
+
+  List<BoxShadow> get boxShadow {
+    if (_isFocused) {
+      return [
+        BoxShadow(
+          color: Colors.grey.shade300,
+          blurRadius: 0,
+          spreadRadius: 4,
+          offset: Offset.zero,
+        ),
+        const BoxShadow(
+          color: Colors.white,
+          blurRadius: 0,
+          spreadRadius: 2,
+          offset: Offset.zero,
+        ),
+      ];
+    }
+    return [
+      BoxShadow(
+        color: Colors.black.withValues(alpha: 0.02),
+        blurRadius: 8,
+        offset: const Offset(0, 2),
+      ),
+    ];
   }
 
   @override
@@ -59,69 +90,69 @@ class _AnimatedSelectExampleState extends State<AnimatedSelectExample> with Tick
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 200,
+      width: 250,
       child: NakedSelect<String>(
         selectedValue: _selectedValue,
         onSelectedValueChanged: (value) {
           setState(() => _selectedValue = value);
         },
-        controller: _controller,
-        onOpen: () {
-          _controller.show();
-          _animationController.forward();
+        removalDelay: const Duration(milliseconds: 200),
+        onStateChange: (state) {
+          switch (state) {
+            case OverlayChildLifecycleState.present:
+              _animationController.forward();
+              break;
+            case OverlayChildLifecycleState.pendingRemoval:
+            case OverlayChildLifecycleState.removed:
+              _animationController.reverse();
+              break;
+          }
         },
-        onClose: () {
-          _animationController.reverse().then((_) {
-            _controller.hide();
-          });
-        },
-        menu: FadeTransition(
-          opacity: _animation,
-          child: Container(
-            margin: const EdgeInsets.only(top: 4),
-            padding: const EdgeInsets.symmetric(vertical: 4),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(8),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withOpacity(0.1),
-                  blurRadius: 8,
-                  offset: const Offset(0, 4),
+        menu: SlideTransition(
+          position: _animationController.drive(Tween<Offset>(
+            begin: const Offset(0, -0.05),
+            end: Offset.zero,
+          )),
+          child: FadeTransition(
+            opacity: _animation,
+            child: SizedBox(
+              width: 250,
+              child: Container(
+                margin: const EdgeInsets.only(top: 4),
+                padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 6),
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  border: Border.all(
+                    color: Colors.grey.shade300,
+                    width: 1,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      blurRadius: 8,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
                 ),
-              ],
-            ),
-            child: const SizedBox(
-              width: 200,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  NakedSelectItem<String>(
-                    value: 'Option 1',
-                    child: Padding(
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: Text('Option 1'),
+                child: const Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    SelectItem(
+                      value: 'Option 1',
+                      label: 'Option 1',
                     ),
-                  ),
-                  NakedSelectItem<String>(
-                    value: 'Option 2',
-                    child: Padding(
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: Text('Option 2'),
+                    SelectItem(
+                      value: 'Option 2',
+                      label: 'Option 2',
                     ),
-                  ),
-                  NakedSelectItem<String>(
-                    value: 'Option 3',
-                    child: Padding(
-                      padding:
-                          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                      child: Text('Option 3'),
+                    SelectItem(
+                      value: 'Option 3',
+                      label: 'Option 3',
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),
@@ -130,24 +161,72 @@ class _AnimatedSelectExampleState extends State<AnimatedSelectExample> with Tick
           onHoverState: (isHovered) => setState(() => _isHovered = isHovered),
           onFocusState: (isFocused) => setState(() => _isFocused = isFocused),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             decoration: BoxDecoration(
+              color: backgroundColor,
+              boxShadow: boxShadow,
               border: Border.all(
                 color: borderColor,
                 width: 1,
               ),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(_selectedValue ?? 'Select an option'),
-                const Icon(Icons.arrow_drop_down, size: 24),
+                Text(_selectedValue ?? 'Select your favorite fruit'),
+                const Icon(
+                  Icons.keyboard_arrow_down_rounded,
+                  size: 24,
+                  color: Colors.grey,
+                ),
               ],
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class SelectItem extends StatefulWidget {
+  const SelectItem({
+    super.key,
+    required this.value,
+    required this.label,
+  });
+
+  final String value;
+  final String label;
+
+  @override
+  State<SelectItem> createState() => _SelectItemState();
+}
+
+class _SelectItemState extends State<SelectItem> {
+  bool _isHovered = false;
+  bool _isFocused = false;
+
+  Color get backgroundColor {
+    if (_isHovered) return Colors.grey.shade100;
+    if (_isFocused) return Colors.grey.shade200;
+    return Colors.white;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NakedSelectItem<String>(
+      value: widget.value,
+      onHoverState: (isHovered) => setState(() => _isHovered = isHovered),
+      onFocusState: (isFocused) => setState(() => _isFocused = isFocused),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(widget.label),
       ),
     );
   }

--- a/packages/naked/example/lib/api/naked_tooltip.0.dart
+++ b/packages/naked/example/lib/api/naked_tooltip.0.dart
@@ -52,10 +52,10 @@ class _TooltipExampleState extends State<TooltipExample>
       removalDelay: const Duration(milliseconds: 300),
       onStateChange: (state) {
         switch (state) {
-          case TooltipLifecycleState.present:
+          case OverlayChildLifecycleState.present:
             _animationController.forward();
             break;
-          case TooltipLifecycleState.pendingRemoval:
+          case OverlayChildLifecycleState.pendingRemoval:
             _animationController.reverse();
             break;
           default:

--- a/packages/naked/test/src/naked_select_test.dart
+++ b/packages/naked/test/src/naked_select_test.dart
@@ -21,11 +21,6 @@ extension _WidgetTesterX on WidgetTester {
 
 void main() {
   const kMenuKey = Key('menu');
-  late OverlayPortalController overlayPortalController;
-
-  setUp(() {
-    overlayPortalController = OverlayPortalController();
-  });
 
   // Helper function to build select widget
   Widget buildSelect<T>({
@@ -42,12 +37,6 @@ void main() {
   }) {
     return Center(
       child: NakedSelect<T>(
-        controller: overlayPortalController,
-        onClose: () {
-          overlayPortalController.hide();
-          onMenuClose?.call();
-        },
-        onOpen: () => overlayPortalController.show(),
         selectedValue: selectedValue,
         onSelectedValueChanged: onSelectedValueChanged,
         selectedValues: selectedValues,
@@ -193,12 +182,8 @@ void main() {
 
   group('Keyboard Navigation', () {
     testWidgets('closes menu with Escape key', (WidgetTester tester) async {
-      bool menuClosed = false;
-
       await tester.pumpMaterialWidget(
-        buildSelect<String>(
-          onMenuClose: () => menuClosed = true,
-        ),
+        buildSelect<String>(),
       );
 
       // Open menu
@@ -206,9 +191,9 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.sendKeyEvent(LogicalKeyboardKey.escape);
-      await tester.pump();
+      await tester.pumpAndSettle();
 
-      expect(menuClosed, true);
+      expect(find.text('Apple'), findsNothing);
     });
 
     testWidgets('selects item with Enter key', (WidgetTester tester) async {
@@ -325,7 +310,6 @@ void main() {
           FocusHighlightStrategy.alwaysTraditional;
 
       bool isHovered = false;
-      final controller = OverlayPortalController();
       const key = Key('trigger');
 
       await tester.pumpMaterialWidget(
@@ -333,9 +317,6 @@ void main() {
           padding: const EdgeInsets.all(1),
           child: NakedSelect<String>(
             menu: const SizedBox(),
-            controller: controller,
-            onClose: () => controller.hide(),
-            onOpen: () => controller.show(),
             child: NakedSelectTrigger(
               key: key,
               onHoverState: (value) => isHovered = value,
@@ -358,9 +339,6 @@ void main() {
 
       await tester.pumpMaterialWidget(
         NakedSelect<String>(
-          controller: OverlayPortalController(),
-          onClose: () => overlayPortalController.hide(),
-          onOpen: () => overlayPortalController.show(),
           menu: const SizedBox(),
           child: NakedSelectTrigger(
             onPressedState: (value) => isPressed = value,
@@ -386,7 +364,6 @@ void main() {
 
       await tester.pumpMaterialWidget(
         NakedSelect<String>(
-          controller: overlayPortalController,
           onClose: () => overlayPortalController.hide(),
           onOpen: () => overlayPortalController.show(),
           menu: const SizedBox(),
@@ -416,13 +393,10 @@ void main() {
       bool itemPressed = false;
       const key = Key('item');
       String? selectedValue;
-      final overlayPortalController = OverlayPortalController();
+
       await tester.pumpMaterialWidget(
         Center(
           child: NakedSelect<String>(
-            controller: overlayPortalController,
-            onClose: () => overlayPortalController.hide(),
-            onOpen: () => overlayPortalController.show(),
             selectedValue: selectedValue,
             onSelectedValueChanged: (value) => selectedValue = value,
             menu: Container(
@@ -507,13 +481,11 @@ void main() {
     testWidgets('closes menu when closeOnSelect is true',
         (WidgetTester tester) async {
       String? selectedValue;
-      bool menuClosed = false;
 
       await tester.pumpMaterialWidget(
         buildSelect<String>(
           selectedValue: selectedValue,
           onSelectedValueChanged: (value) => selectedValue = value,
-          onMenuClose: () => menuClosed = true,
           closeOnSelect: true,
         ),
       );
@@ -526,38 +498,30 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(selectedValue, 'banana');
-      expect(menuClosed, true);
+      expect(find.text('Apple'), findsNothing);
     });
   });
 
   group('Cursor', () {
     testWidgets('shows appropriate cursor based on interactive state',
         (WidgetTester tester) async {
-      final overlayPortalController = OverlayPortalController();
-      final disabledOverlayPortalController = OverlayPortalController();
       const keyEnabledTrigger = Key('enabledTrigger');
       const keyDisabledTrigger = Key('disabledTrigger');
 
       await tester.pumpMaterialWidget(
-        Column(
+        const Column(
           children: [
             NakedSelect<String>(
-              controller: overlayPortalController,
-              onClose: () => overlayPortalController.hide(),
-              onOpen: () => overlayPortalController.show(),
-              menu: const SizedBox(),
-              child: const NakedSelectTrigger(
+              menu: SizedBox(),
+              child: NakedSelectTrigger(
                 key: keyEnabledTrigger,
                 child: Text('Enabled Trigger'),
               ),
             ),
             NakedSelect<String>(
-              controller: disabledOverlayPortalController,
-              onClose: () => disabledOverlayPortalController.hide(),
-              onOpen: () => disabledOverlayPortalController.show(),
               enabled: false,
-              menu: const SizedBox(),
-              child: const NakedSelectTrigger(
+              menu: SizedBox(),
+              child: NakedSelectTrigger(
                 key: keyDisabledTrigger,
                 child: Text('Disabled Trigger'),
               ),

--- a/packages/naked/test/src/naked_tooltip_test.dart
+++ b/packages/naked/test/src/naked_tooltip_test.dart
@@ -169,7 +169,7 @@ void main() {
     testWidgets('waitDuration delays tooltip appearance',
         (WidgetTester tester) async {
       final targetKey = GlobalKey();
-      final stateChanges = <TooltipLifecycleState>[];
+      final stateChanges = <OverlayChildLifecycleState>[];
 
       await tester.pumpMaterialWidget(
         Center(
@@ -208,7 +208,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 25));
       await tester.pump();
       expect(find.text('Tooltip Content'), findsOneWidget);
-      expect(stateChanges, [TooltipLifecycleState.present]);
+      expect(stateChanges, [OverlayChildLifecycleState.present]);
 
       await gesture.moveTo(Offset.zero);
       await tester.pumpAndSettle();
@@ -216,7 +216,7 @@ void main() {
 
     testWidgets('showDuration auto-hides tooltip', (WidgetTester tester) async {
       final targetKey = GlobalKey();
-      final stateChanges = <TooltipLifecycleState>[];
+      final stateChanges = <OverlayChildLifecycleState>[];
 
       await tester.pumpMaterialWidget(
         Center(
@@ -243,7 +243,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Tooltip Content'), findsOneWidget);
-      expect(stateChanges, [TooltipLifecycleState.present]);
+      expect(stateChanges, [OverlayChildLifecycleState.present]);
 
       // Move mouse away - tooltip should still be visible
       await gesture.moveTo(Offset.zero);
@@ -259,16 +259,16 @@ void main() {
       await tester.pump();
       expect(find.text('Tooltip Content'), findsNothing);
       expect(stateChanges, [
-        TooltipLifecycleState.present,
-        TooltipLifecycleState.pendingRemoval,
-        TooltipLifecycleState.removed
+        OverlayChildLifecycleState.present,
+        OverlayChildLifecycleState.pendingRemoval,
+        OverlayChildLifecycleState.removed
       ]);
     });
 
     testWidgets('removalDelay delays removing tooltip from overlay',
         (WidgetTester tester) async {
       final targetKey = GlobalKey();
-      final stateChanges = <TooltipLifecycleState>[];
+      final stateChanges = <OverlayChildLifecycleState>[];
 
       await tester.pumpMaterialWidget(
         Center(
@@ -295,15 +295,15 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Tooltip Content'), findsOneWidget);
-      expect(stateChanges, [TooltipLifecycleState.present]);
+      expect(stateChanges, [OverlayChildLifecycleState.present]);
 
       // Move mouse away - tooltip should still be visible
       await gesture.moveTo(Offset.zero);
       await tester.pumpAndSettle();
 
       expect(stateChanges, [
-        TooltipLifecycleState.present,
-        TooltipLifecycleState.pendingRemoval,
+        OverlayChildLifecycleState.present,
+        OverlayChildLifecycleState.pendingRemoval,
       ]);
       // Wait for half the show duration - tooltip should still be visible
       await tester.pump(const Duration(milliseconds: 250));
@@ -314,9 +314,9 @@ void main() {
       await tester.pump();
 
       expect(stateChanges, [
-        TooltipLifecycleState.present,
-        TooltipLifecycleState.pendingRemoval,
-        TooltipLifecycleState.removed
+        OverlayChildLifecycleState.present,
+        OverlayChildLifecycleState.pendingRemoval,
+        OverlayChildLifecycleState.removed
       ]);
     });
   });


### PR DESCRIPTION
### Description

This PR refactors the overlay components in Naked to use a unified lifecycle interface and mixin, replacing manual controller handling with a generic `OverlayChildLifecycleState` and `OverlayChildLifecycleMixin`.

### Changes

- Introduces `OverlayChildLifecycleState` enum and `OverlayChildLifecycleMixin` in naked_portal.dart
- Updates `NakedTooltip` and `NakedSelect` to implement the new interface and drive their visibility via the mixin
- Aligns tests, examples, and documentation by removing controller props in favor of onStateChange and removalDelay

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [x] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [x] **Website Updates**: Is the website containing the updates you make on documentation?
