### PR TITLE
fix: Change default `autofocus` to false in Menu and Select

### DIFF
--- a/docs/menu.mdx
+++ b/docs/menu.mdx
@@ -142,7 +142,7 @@ const NakedMenu({
   this.consumeOutsideTaps = true,
   this.useRootOverlay = false,
   this.closeOnSelect = true,
-  this.autofocus = true,
+  this.autofocus = false,
   this.menuAlignment = const PositionConfig(
     target: Alignment.bottomLeft,
     follower: Alignment.topLeft,
@@ -182,7 +182,7 @@ Whether to use the root overlay for rendering the menu. Defaults to false.
 Whether to close the menu when an item is selected. Defaults to true.
 
 #### autofocus → `bool`
-Whether to automatically focus the menu when opened. Defaults to true.
+Whether to automatically focus the menu when opened. Defaults to false.
 
 #### menuAlignment → `PositionConfig`
 The alignment of the menu relative to its target. Specifies how the menu should be positioned.

--- a/docs/select.mdx
+++ b/docs/select.mdx
@@ -132,7 +132,7 @@ const NakedSelect({
   this.enabled = true,
   this.semanticLabel,
   this.closeOnSelect = true,
-  this.autofocus = true,
+  this.autofocus = false,
   this.enableTypeAhead = true,
   this.typeAheadDebounceTime = const Duration(milliseconds: 500),
   this.menuAlignment = const PositionConfig(
@@ -195,7 +195,7 @@ Semantic label for accessibility. Used by screen readers to identify the select 
 Whether to automatically close the dropdown when an item is selected. Defaults to true.
 
 #### autofocus → `bool`
-Whether to automatically focus the menu when opened. Defaults to true.
+Whether to automatically focus the menu when opened. Defaults to false.
 
 #### enableTypeAhead → `bool`
 Whether to enable type-ahead selection for quick keyboard navigation. Defaults to true.
@@ -226,7 +226,7 @@ const NakedSelectTrigger({
   this.cursor = SystemMouseCursors.click,
   this.enableHapticFeedback = true,
   this.focusNode,
-  this.autofocus = true,
+  this.autofocus = false,
 })
 ```
 
@@ -257,7 +257,7 @@ Whether to provide haptic feedback when tapped. Defaults to true.
 Optional focus node to control focus behavior.
 
 #### autofocus → `bool`
-Whether to automatically focus the trigger when opened. Defaults to true.
+Whether to automatically focus the trigger when opened. Defaults to false.
 
 
 ## NakedSelectItem
@@ -275,7 +275,7 @@ const NakedSelectItem({
   this.cursor = SystemMouseCursors.click,
   this.enableHapticFeedback = true,
   this.focusNode,
-  this.autofocus = true,
+  this.autofocus = false,
 })
 ```
 
@@ -312,4 +312,4 @@ Whether to provide haptic feedback when selected. Defaults to true.
 Optional focus node to control focus behavior.
 
 #### autofocus → `bool`
-Whether to automatically focus this item. Defaults to true.
+Whether to automatically focus this item. Defaults to false.

--- a/packages/naked/lib/src/naked_menu.dart
+++ b/packages/naked/lib/src/naked_menu.dart
@@ -114,7 +114,7 @@ class NakedMenu extends StatefulWidget {
     this.consumeOutsideTaps = true,
     this.useRootOverlay = false,
     this.closeOnSelect = true,
-    this.autofocus = true,
+    this.autofocus = false,
     this.menuAlignment = const PositionConfig(
       target: Alignment.bottomLeft,
       follower: Alignment.topLeft,

--- a/packages/naked/lib/src/naked_select.dart
+++ b/packages/naked/lib/src/naked_select.dart
@@ -148,7 +148,7 @@ class NakedSelect<T> extends StatefulWidget implements OverlayChildLifecycle {
     this.enabled = true,
     this.semanticLabel,
     this.closeOnSelect = true,
-    this.autofocus = true,
+    this.autofocus = false,
     this.enableTypeAhead = true,
     this.typeAheadDebounceTime = const Duration(milliseconds: 500),
     this.menuAlignment = const PositionConfig(
@@ -443,7 +443,7 @@ class NakedSelectTrigger extends StatefulWidget {
     this.cursor = SystemMouseCursors.click,
     this.enableHapticFeedback = true,
     this.focusNode,
-    this.autofocus = true,
+    this.autofocus = false,
   });
 
   @override
@@ -559,7 +559,7 @@ class NakedSelectItem<T> extends StatefulWidget {
     this.cursor = SystemMouseCursors.click,
     this.enableHapticFeedback = true,
     this.focusNode,
-    this.autofocus = true,
+    this.autofocus = false,
   });
 
   @override

--- a/packages/naked/test/src/naked_select_test.dart
+++ b/packages/naked/test/src/naked_select_test.dart
@@ -217,7 +217,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pumpAndSettle();
 
-      expect(selectedValue, 'banana');
+      expect(selectedValue, 'apple');
     });
   });
 


### PR DESCRIPTION
### Description

This PR changes the default value of the autofocus property from `true` to `false` for `Menu` and `Select` components to improve the user interaction behavior. The changes update the widget constructors in the core library, adjust the expected values in unit tests, and update the documentation accordingly.

### Changes


- Changed default autofocus in NakedSelect, NakedSelectTrigger, NakedSelectItem, and NakedMenu
- Updated expected output in the select unit tests
- Revised documentation to reflect the new autofocus default

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
