### PR TITLE
WIP: Introduce `Style.builder` and `$on.builder` variant

### DIFF
--- a/packages/mix/example/lib/main.dart
+++ b/packages/mix/example/lib/main.dart
@@ -45,6 +45,13 @@ Style style() => Style(
       $on.breakpoint(const Breakpoint(minWidth: 0, maxWidth: 365))(
         $flexbox.chain.flex.direction(Axis.vertical),
       ),
+      Style.builder((context) {
+        final isSmall = MediaQuery.of(context).size.width < 365;
+
+        return Style(
+          isSmall ? $icon.color.blue() : $icon.color.green(),
+        );
+      })(),
     ).animate(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,

--- a/packages/mix/lib/src/core/factory/style_mix.dart
+++ b/packages/mix/lib/src/core/factory/style_mix.dart
@@ -8,6 +8,7 @@ import '../../internal/compare_mixin.dart';
 import '../../internal/helper_util.dart';
 import '../../specs/spec_util.dart';
 import '../../variants/variant_attribute.dart';
+import '../../variants/widget_state_variant.dart';
 import '../attributes_map.dart';
 import '../element.dart';
 import '../spec.dart';
@@ -85,6 +86,10 @@ class Style with EqualityMixin {
     ].whereType<Attribute>();
 
     return Style.create(params);
+  }
+
+  factory Style.builder(Style Function(BuildContext context) builder) {
+    return Style.create([StyleVariantBuilder(builder).build()]);
   }
 
   /// Constructs a `Style` from an iterable of [Attribute] instances.

--- a/packages/mix/lib/src/variants/context_variant_util/on_util.dart
+++ b/packages/mix/lib/src/variants/context_variant_util/on_util.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../core/element.dart';
+import '../../core/factory/style_mix.dart';
 import '../../theme/tokens/breakpoints_token.dart';
 import '../widget_state_variant.dart';
 import 'on_breakpoint_util.dart';
@@ -62,7 +64,10 @@ class OnContextVariantUtility {
   /// For example, if the specified [variant] evaluates to `true`,
   /// the [OnNotVariant] with that variant will evaluate to `false`, and vice versa.
   final not = OnNotVariant.new;
-  static final self = OnContextVariantUtility._();
 
+  static final self = OnContextVariantUtility._();
   OnContextVariantUtility._();
+
+  Attribute builder(Style Function(BuildContext context) builder) =>
+      StyleVariantBuilder(builder).build();
 }

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -7,6 +7,17 @@ import '../core/widget_state/internal/mouse_region_mix_state.dart';
 import '../core/widget_state/widget_state_controller.dart';
 import 'context_variant.dart';
 
+class StyleVariantBuilder extends ContextVariant {
+  final Style Function(BuildContext context) builder;
+
+  const StyleVariantBuilder(this.builder);
+
+  @override
+  bool when(BuildContext context) => true;
+
+  ContextVariantBuilder build() => ContextVariantBuilder(builder, this);
+}
+
 @immutable
 abstract class MixWidgetStateVariant<Value> extends ContextVariant {
   @override


### PR DESCRIPTION
### Description

This PR introduces a new variant `builder`, enabling a builder-based approach for constructing styles using both a new `Style.builder` factory and a corresponding `$on.builder` variant.

#### Examples
```dart
Style.builder((context) {
  final isSmall = MediaQuery.of(context).size.width < 365;

  return Style(
    isSmall ? $icon.color.blue() : $icon.color.green(),
  );
})
```

or 

```dart
Style(
  $icon.color.red(),
  $on.builder((context) {
    final isSmall = MediaQuery.of(context).size.width < 365;

    return Style(
      isSmall ? $icon.color.blue() : $icon.color.green(),
    );
  })
 )
```

### Changes

- Adds the `StyleVariantBuilder` class extending `ContextVariant` for builder-based style creation.
- Introduces a new factory constructor in the `Style` class and a corresponding builder attribute in `OnContextVariantUtility`.
- Updates the example usage in main.dart to demonstrate dynamic style creation via a builder function.