### PR TITLE
Fix FVM path in test workflow

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         curl -fsSL https://fvm.app/install.sh | bash
-        export PATH="$HOME/.pub-cache/bin:$PATH"
+        echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
 
     - name: FVM use version
       shell: bash


### PR DESCRIPTION
## Summary
- add FVM to the PATH using `$GITHUB_PATH` so subsequent steps can run `fvm`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432338ad50832b8a99193a0cf3ada7