### PR TITLE
refactor: Remove custom spacing logic

### DIFF
--- a/packages/mix/lib/src/specs/flex/flex_widget.dart
+++ b/packages/mix/lib/src/specs/flex/flex_widget.dart
@@ -2,8 +2,8 @@
 
 import 'package:flutter/widgets.dart';
 
-import '../../core/spec_widget.dart';
 import '../../core/animated_spec_widget.dart';
+import '../../core/spec_widget.dart';
 import '../../core/styled_widget.dart';
 import '../../modifiers/internal/render_widget_modifier.dart';
 import 'flex_spec.dart';
@@ -72,27 +72,11 @@ class FlexSpecWidget extends SpecWidget<FlexSpec> {
   final Axis direction;
   final List<Type> orderOfModifiers;
 
-  Axis get _definitiveDirection => spec?.direction ?? direction;
-
-  List<Widget> _buildChildren(double? gap) {
-    if (gap == null) return children;
-
-    if (children.isEmpty) return [];
-
-    return List.generate(children.length + children.length - 1, (index) {
-      if (index.isEven) return children[index ~/ 2];
-
-      return _definitiveDirection == Axis.horizontal
-          ? SizedBox(width: gap)
-          : SizedBox(height: gap);
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     final gap = spec?.gap;
     final flexWidget = Flex(
-      direction: _definitiveDirection,
+      direction: spec?.direction ?? direction,
       mainAxisAlignment:
           spec?.mainAxisAlignment ?? _defaultFlex.mainAxisAlignment,
       mainAxisSize: spec?.mainAxisSize ?? _defaultFlex.mainAxisSize,
@@ -103,7 +87,8 @@ class FlexSpecWidget extends SpecWidget<FlexSpec> {
           spec?.verticalDirection ?? _defaultFlex.verticalDirection,
       textBaseline: spec?.textBaseline ?? _defaultFlex.textBaseline,
       clipBehavior: spec?.clipBehavior ?? _defaultFlex.clipBehavior,
-      children: _buildChildren(gap),
+      spacing: gap ?? _defaultFlex.spacing,
+      children: children,
     );
 
     return spec == null

--- a/packages/mix/test/src/specs/flex/flex_widget_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_widget_test.dart
@@ -73,25 +73,6 @@ void main() {
       final flex = tester.widget<Flex>(find.byType(Flex));
       expect(flex.direction, Axis.vertical);
     });
-
-    testWidgets('changes its gap direction when direction is modified',
-        (tester) async {
-      await tester.pumpMaterialApp(
-        const Center(
-          child: FlexSpecWidget(
-            direction: Axis.horizontal,
-            spec: FlexSpec(direction: Axis.vertical, gap: 16),
-            children: [
-              StyledText('test'),
-              StyledText('case'),
-            ],
-          ),
-        ),
-      );
-
-      final sizedBox = tester.widget<SizedBox>(find.byType(SizedBox));
-      expect(sizedBox.height, 16);
-    });
   });
 
   testWidgets(
@@ -223,11 +204,10 @@ void main() {
               ),
               Row(
                 mainAxisAlignment: e,
+                spacing: spacing,
                 children: const [
                   SizedBox(height: 30, width: 30, key: Key('3')),
-                  SizedBox(width: spacing),
                   SizedBox(height: 30, width: 30, key: Key('4')),
-                  SizedBox(width: spacing),
                   SizedBox(height: 30, width: 30, key: Key('5')),
                 ],
               )


### PR DESCRIPTION
### Description

This PR refactors the `FlexSpecWidget` by removing its custom spacing logic and relying on the built-in spacing property of the `Flex` widget.

### Changes

- Removing the custom _buildChildren method and associated gap insertion logic
- Directly passing the spacing value via the new spacing property on Flex
- Removing the test case that previously validated the custom gap behavior

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
