### PR TITLE
feat: unify SpecUtility, Style, and Attributes as compatible values

### DIFF
--- a/packages/mix/lib/src/attributes/nested_style/nested_style_attribute.dart
+++ b/packages/mix/lib/src/attributes/nested_style/nested_style_attribute.dart
@@ -10,8 +10,8 @@ final class NestedStyleAttribute extends Attribute {
 
   const NestedStyleAttribute(this.value);
 
-  factory NestedStyleAttribute.fromList(List<Attribute> attributes) {
-    return NestedStyleAttribute(Style.create(attributes));
+  factory NestedStyleAttribute.fromList(List<StyleElement> elements) {
+    return NestedStyleAttribute(Style.create(elements));
   }
 
   @override

--- a/packages/mix/lib/src/core/element.dart
+++ b/packages/mix/lib/src/core/element.dart
@@ -16,10 +16,8 @@ abstract class StyleElement with EqualityMixin {
   StyleElement merge(covariant StyleElement? other);
 }
 
-/// Similar to a StyleElement but can be passed as an attribute of `Style`
-abstract class Attribute extends StyleElement {
-  const Attribute();
-}
+@Deprecated('Use StyleElement instead')
+typedef Attribute = StyleElement;
 
 @Deprecated('Use StyleAttribute instead')
 typedef StyledAttribute = SpecAttribute;
@@ -42,8 +40,8 @@ mixin HasDefaultValue<Value> {
   Value get defaultValue;
 }
 
-abstract class DtoUtility<A extends Attribute, D extends Mixable<Value>, Value>
-    extends MixUtility<A, D> {
+abstract class DtoUtility<A extends StyleElement, D extends Mixable<Value>,
+    Value> extends MixUtility<A, D> {
   final D Function(Value) _fromValue;
   const DtoUtility(super.builder, {required D Function(Value) valueToDto})
       : _fromValue = valueToDto;

--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -60,18 +60,20 @@ abstract class SpecUtility<T extends Attribute, V> extends Attribute {
   @visibleForTesting
   final T Function(V) attributeBuilder;
 
-  final bool _mutable;
-
-  SpecUtility(this.attributeBuilder, {bool mutable = false})
-      : _mutable = mutable;
+  SpecUtility(
+    this.attributeBuilder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    bool? mutable,
+  });
 
   static T selfBuilder<T>(T value) => value;
 
   T builder(V v) {
     final attribute = attributeBuilder(v);
-    if (_mutable) {
-      attributeValue = (attributeValue?.merge(attribute) ?? attribute) as T;
-    }
+    // Always mutable - accumulate state in attributeValue
+    attributeValue = (attributeValue?.merge(attribute) ?? attribute) as T;
 
     return attribute;
   }

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
@@ -134,10 +134,20 @@ class PaddingModifierSpecUtility<T extends Attribute>
   /// Utility for defining [PaddingModifierSpecAttribute.padding]
   late final padding = EdgeInsetsGeometryUtility((v) => only(padding: v));
 
-  PaddingModifierSpecUtility(super.builder, {super.mutable});
+  PaddingModifierSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   PaddingModifierSpecUtility<T> get chain =>
-      PaddingModifierSpecUtility(attributeBuilder, mutable: true);
+      PaddingModifierSpecUtility(attributeBuilder);
 
   static PaddingModifierSpecUtility<PaddingModifierSpecAttribute> get self =>
       PaddingModifierSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -412,10 +412,19 @@ class BoxSpecUtility<T extends Attribute>
   /// Utility for defining [BoxSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  BoxSpecUtility(super.builder, {super.mutable});
+  BoxSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  BoxSpecUtility<T> get chain =>
-      BoxSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  BoxSpecUtility<T> get chain => BoxSpecUtility(attributeBuilder);
 
   static BoxSpecUtility<BoxSpecAttribute> get self => BoxSpecUtility((v) => v);
 

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -330,10 +330,19 @@ class FlexSpecUtility<T extends Attribute>
   /// Utility for defining [FlexSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  FlexSpecUtility(super.builder, {super.mutable});
+  FlexSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  FlexSpecUtility<T> get chain =>
-      FlexSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  FlexSpecUtility<T> get chain => FlexSpecUtility(attributeBuilder);
 
   static FlexSpecUtility<FlexSpecAttribute> get self =>
       FlexSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
@@ -290,10 +290,19 @@ class FlexBoxSpecUtility<T extends Attribute>
   /// Utility for defining [FlexBoxSpecAttribute.flex]
   late final flex = FlexSpecUtility((v) => only(flex: v));
 
-  FlexBoxSpecUtility(super.builder, {super.mutable});
+  FlexBoxSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  FlexBoxSpecUtility<T> get chain =>
-      FlexBoxSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  FlexBoxSpecUtility<T> get chain => FlexBoxSpecUtility(attributeBuilder);
 
   static FlexBoxSpecUtility<FlexBoxSpecAttribute> get self =>
       FlexBoxSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -316,10 +316,19 @@ class IconSpecUtility<T extends Attribute>
   /// Utility for defining [IconSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  IconSpecUtility(super.builder, {super.mutable});
+  IconSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  IconSpecUtility<T> get chain =>
-      IconSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  IconSpecUtility<T> get chain => IconSpecUtility(attributeBuilder);
 
   static IconSpecUtility<IconSpecAttribute> get self =>
       IconSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -314,10 +314,19 @@ class ImageSpecUtility<T extends Attribute>
   /// Utility for defining [ImageSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  ImageSpecUtility(super.builder, {super.mutable});
+  ImageSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  ImageSpecUtility<T> get chain =>
-      ImageSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  ImageSpecUtility<T> get chain => ImageSpecUtility(attributeBuilder);
 
   static ImageSpecUtility<ImageSpecAttribute> get self =>
       ImageSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -235,10 +235,19 @@ class StackSpecUtility<T extends Attribute>
   /// Utility for defining [StackSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  StackSpecUtility(super.builder, {super.mutable});
+  StackSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  StackSpecUtility<T> get chain =>
-      StackSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  StackSpecUtility<T> get chain => StackSpecUtility(attributeBuilder);
 
   static StackSpecUtility<StackSpecAttribute> get self =>
       StackSpecUtility((v) => v);

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -454,10 +454,19 @@ class TextSpecUtility<T extends Attribute>
   /// Utility for defining [TextSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  TextSpecUtility(super.builder, {super.mutable});
+  TextSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  TextSpecUtility<T> get chain =>
-      TextSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  TextSpecUtility<T> get chain => TextSpecUtility(attributeBuilder);
 
   static TextSpecUtility<TextSpecAttribute> get self =>
       TextSpecUtility((v) => v);

--- a/packages/mix_generator/lib/src/core/spec/spec_method_builder.dart
+++ b/packages/mix_generator/lib/src/core/spec/spec_method_builder.dart
@@ -114,12 +114,15 @@ $lerpMethodsDocs$stepMethodDocs
 /// Generates the lerp expression for a single field
 String _getLerpExpression(ParameterMetadata field, bool isInternalRef) {
   // Special handling for AnimatedData to preserve callbacks
-  if (field.name == 'animated' || field.type == 'AnimatedData' || field.type == 'AnimatedData?') {
+  if (field.name == 'animated' ||
+      field.type == 'AnimatedData' ||
+      field.type == 'AnimatedData?') {
     final thisFieldName = isInternalRef ? field.asInternalRef : field.name;
     final otherFieldName = 'other.${field.name}';
+
     return '$thisFieldName ?? $otherFieldName';
   }
-  
+
   if (!field.annotation.isLerpable) {
     return 'other.${field.name}';
   }

--- a/packages/mix_generator/lib/src/core/spec/spec_utility_builder.dart
+++ b/packages/mix_generator/lib/src/core/spec/spec_utility_builder.dart
@@ -30,7 +30,13 @@ class SpecUtilityBuilder implements CodeBuilder {
 ''',
       extendsClass: 'SpecUtility<T, $attributeName>',
       typeParameters: '<T extends Attribute>',
-      constructorCode: '$utilityName(super.builder, {super.mutable});',
+      constructorCode: '''$utilityName(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });''',
 
       // The fields you want in the generated class
       fields: generatedFields,

--- a/packages/mix_generator/lib/src/core/utils/utility_code_generator.dart
+++ b/packages/mix_generator/lib/src/core/utils/utility_code_generator.dart
@@ -465,7 +465,11 @@ late final $aliasName = $utilityExpression;
   /// Creates a getter to enable chained configuration.
   static String chainGetter(String utilityName) {
     return '''
-  $utilityName<T> get chain => $utilityName(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  $utilityName<T> get chain => $utilityName(attributeBuilder);
 ''';
   }
 

--- a/packages/mix_generator/test/core/utils/utility_code_generator_simple_test.dart
+++ b/packages/mix_generator/test/core/utils/utility_code_generator_simple_test.dart
@@ -33,7 +33,7 @@ void main() {
       expect(
           result,
           contains(
-              'ColorUtility<T> get chain => ColorUtility(attributeBuilder, mutable: true);'));
+              'ColorUtility<T> get chain => ColorUtility(attributeBuilder);'));
     });
 
     test('selfGetter creates correct static getter', () {

--- a/packages/remix/lib/src/components/action/icon_button/icon_button.g.dart
+++ b/packages/remix/lib/src/components/action/icon_button/icon_button.g.dart
@@ -222,10 +222,19 @@ class IconButtonSpecUtility<T extends Attribute>
   /// Utility for defining [IconButtonSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  IconButtonSpecUtility(super.builder, {super.mutable});
+  IconButtonSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  IconButtonSpecUtility<T> get chain =>
-      IconButtonSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  IconButtonSpecUtility<T> get chain => IconButtonSpecUtility(attributeBuilder);
 
   static IconButtonSpecUtility<IconButtonSpecAttribute> get self =>
       IconButtonSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/action/icon_button/icon_button.g.dart
+++ b/packages/remix/lib/src/components/action/icon_button/icon_button.g.dart
@@ -80,7 +80,7 @@ mixin _$IconButtonSpec on Spec<IconButtonSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       modifiers: other.modifiers,
       spinner: _$this.spinner.lerp(other.spinner, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/accordion/accordion.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/accordion/accordion.g.dart
@@ -77,7 +77,7 @@ mixin _$AccordionSpec on Spec<AccordionSpec> {
       header: _$this.header.lerp(other.header, t),
       container: _$this.container.lerp(other.container, t),
       contentContainer: _$this.contentContainer.lerp(other.contentContainer, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -307,7 +307,7 @@ mixin _$AccordionHeaderSpec on Spec<AccordionHeaderSpec> {
       leadingIcon: _$this.leadingIcon.lerp(other.leadingIcon, t),
       text: _$this.text.lerp(other.text, t),
       trailingIcon: _$this.trailingIcon.lerp(other.trailingIcon, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/accordion/accordion.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/accordion/accordion.g.dart
@@ -186,10 +186,19 @@ class AccordionSpecUtility<T extends Attribute>
   /// Utility for defining [AccordionSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  AccordionSpecUtility(super.builder, {super.mutable});
+  AccordionSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  AccordionSpecUtility<T> get chain =>
-      AccordionSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  AccordionSpecUtility<T> get chain => AccordionSpecUtility(attributeBuilder);
 
   static AccordionSpecUtility<AccordionSpecAttribute> get self =>
       AccordionSpecUtility((v) => v);
@@ -424,10 +433,20 @@ class AccordionHeaderSpecUtility<T extends Attribute>
   /// Utility for defining [AccordionHeaderSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  AccordionHeaderSpecUtility(super.builder, {super.mutable});
+  AccordionHeaderSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   AccordionHeaderSpecUtility<T> get chain =>
-      AccordionHeaderSpecUtility(attributeBuilder, mutable: true);
+      AccordionHeaderSpecUtility(attributeBuilder);
 
   static AccordionHeaderSpecUtility<AccordionHeaderSpecAttribute> get self =>
       AccordionHeaderSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/content_presentation/avatar/avatar.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/avatar/avatar.g.dart
@@ -196,10 +196,19 @@ class AvatarSpecUtility<T extends Attribute>
   /// Utility for defining [AvatarSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  AvatarSpecUtility(super.builder, {super.mutable});
+  AvatarSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  AvatarSpecUtility<T> get chain =>
-      AvatarSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  AvatarSpecUtility<T> get chain => AvatarSpecUtility(attributeBuilder);
 
   static AvatarSpecUtility<AvatarSpecAttribute> get self =>
       AvatarSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/content_presentation/avatar/avatar.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/avatar/avatar.g.dart
@@ -80,7 +80,7 @@ mixin _$AvatarSpec on Spec<AvatarSpec> {
       image: _$this.image.lerp(other.image, t),
       fallback: _$this.fallback.lerp(other.fallback, t),
       stack: _$this.stack.lerp(other.stack, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/card/card.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/card/card.g.dart
@@ -188,10 +188,19 @@ class CardSpecUtility<T extends Attribute>
   /// Utility for defining [CardSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  CardSpecUtility(super.builder, {super.mutable});
+  CardSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  CardSpecUtility<T> get chain =>
-      CardSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  CardSpecUtility<T> get chain => CardSpecUtility(attributeBuilder);
 
   static CardSpecUtility<CardSpecAttribute> get self =>
       CardSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/content_presentation/card/card.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/card/card.g.dart
@@ -71,7 +71,7 @@ mixin _$CardSpec on Spec<CardSpec> {
     return CardSpec(
       container: _$this.container.lerp(other.container, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/chip/chip.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/chip/chip.g.dart
@@ -79,7 +79,7 @@ mixin _$ChipSpec on Spec<ChipSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       label: _$this.label.lerp(other.label, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/chip/chip.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/chip/chip.g.dart
@@ -220,10 +220,19 @@ class ChipSpecUtility<T extends Attribute>
   /// Utility for defining [ChipSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  ChipSpecUtility(super.builder, {super.mutable});
+  ChipSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  ChipSpecUtility<T> get chain =>
-      ChipSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  ChipSpecUtility<T> get chain => ChipSpecUtility(attributeBuilder);
 
   static ChipSpecUtility<ChipSpecAttribute> get self =>
       ChipSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/content_presentation/label/label.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/label/label.g.dart
@@ -219,10 +219,19 @@ class LabelSpecUtility<T extends Attribute>
   /// Utility for defining [LabelSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  LabelSpecUtility(super.builder, {super.mutable});
+  LabelSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  LabelSpecUtility<T> get chain =>
-      LabelSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  LabelSpecUtility<T> get chain => LabelSpecUtility(attributeBuilder);
 
   static LabelSpecUtility<LabelSpecAttribute> get self =>
       LabelSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/content_presentation/label/label.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/label/label.g.dart
@@ -79,7 +79,7 @@ mixin _$LabelSpec on Spec<LabelSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       label: _$this.label.lerp(other.label, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.g.dart
@@ -87,7 +87,7 @@ mixin _$MenuItemSpec on Spec<MenuItemSpec> {
       title: _$this.title.lerp(other.title, t),
       subtitle: _$this.subtitle.lerp(other.subtitle, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.g.dart
+++ b/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.g.dart
@@ -260,10 +260,19 @@ class MenuItemSpecUtility<T extends Attribute>
   /// Utility for defining [MenuItemSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  MenuItemSpecUtility(super.builder, {super.mutable});
+  MenuItemSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  MenuItemSpecUtility<T> get chain =>
-      MenuItemSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  MenuItemSpecUtility<T> get chain => MenuItemSpecUtility(attributeBuilder);
 
   static MenuItemSpecUtility<MenuItemSpecAttribute> get self =>
       MenuItemSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/feedback/callout/callout.g.dart
+++ b/packages/remix/lib/src/components/feedback/callout/callout.g.dart
@@ -79,7 +79,7 @@ mixin _$CalloutSpec on Spec<CalloutSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       text: _$this.text.lerp(other.text, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/feedback/callout/callout.g.dart
+++ b/packages/remix/lib/src/components/feedback/callout/callout.g.dart
@@ -194,10 +194,19 @@ class CalloutSpecUtility<T extends Attribute>
   /// Utility for defining [CalloutSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  CalloutSpecUtility(super.builder, {super.mutable});
+  CalloutSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  CalloutSpecUtility<T> get chain =>
-      CalloutSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  CalloutSpecUtility<T> get chain => CalloutSpecUtility(attributeBuilder);
 
   static CalloutSpecUtility<CalloutSpecAttribute> get self =>
       CalloutSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/feedback/dialog/dialog.g.dart
+++ b/packages/remix/lib/src/components/feedback/dialog/dialog.g.dart
@@ -82,7 +82,7 @@ mixin _$DialogSpec on Spec<DialogSpec> {
       description: _$this.description.lerp(other.description, t),
       actionsContainer: _$this.actionsContainer.lerp(other.actionsContainer, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/feedback/dialog/dialog.g.dart
+++ b/packages/remix/lib/src/components/feedback/dialog/dialog.g.dart
@@ -241,10 +241,19 @@ class DialogSpecUtility<T extends Attribute>
   /// Utility for defining [DialogSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  DialogSpecUtility(super.builder, {super.mutable});
+  DialogSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  DialogSpecUtility<T> get chain =>
-      DialogSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  DialogSpecUtility<T> get chain => DialogSpecUtility(attributeBuilder);
 
   static DialogSpecUtility<DialogSpecAttribute> get self =>
       DialogSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/feedback/progress/progress.g.dart
+++ b/packages/remix/lib/src/components/feedback/progress/progress.g.dart
@@ -236,10 +236,19 @@ class ProgressSpecUtility<T extends Attribute>
   /// Utility for defining [ProgressSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  ProgressSpecUtility(super.builder, {super.mutable});
+  ProgressSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  ProgressSpecUtility<T> get chain =>
-      ProgressSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  ProgressSpecUtility<T> get chain => ProgressSpecUtility(attributeBuilder);
 
   static ProgressSpecUtility<ProgressSpecAttribute> get self =>
       ProgressSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/feedback/progress/progress.g.dart
+++ b/packages/remix/lib/src/components/feedback/progress/progress.g.dart
@@ -79,7 +79,7 @@ mixin _$ProgressSpec on Spec<ProgressSpec> {
       track: _$this.track.lerp(other.track, t),
       fill: _$this.fill.lerp(other.fill, t),
       outerContainer: _$this.outerContainer.lerp(other.outerContainer, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
       modifiers: other.modifiers,
     );
   }

--- a/packages/remix/lib/src/components/feedback/spinner/spinner.g.dart
+++ b/packages/remix/lib/src/components/feedback/spinner/spinner.g.dart
@@ -252,10 +252,19 @@ class SpinnerSpecUtility<T extends Attribute>
   /// Utility for defining [SpinnerSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SpinnerSpecUtility(super.builder, {super.mutable});
+  SpinnerSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  SpinnerSpecUtility<T> get chain =>
-      SpinnerSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  SpinnerSpecUtility<T> get chain => SpinnerSpecUtility(attributeBuilder);
 
   static SpinnerSpecUtility<SpinnerSpecAttribute> get self =>
       SpinnerSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/feedback/spinner/spinner.g.dart
+++ b/packages/remix/lib/src/components/feedback/spinner/spinner.g.dart
@@ -85,7 +85,7 @@ mixin _$SpinnerSpec on Spec<SpinnerSpec> {
       duration: t < 0.5 ? _$this.duration : other.duration,
       style: t < 0.5 ? _$this.style : other.style,
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/feedback/toast/toast.g.dart
+++ b/packages/remix/lib/src/components/feedback/toast/toast.g.dart
@@ -83,7 +83,7 @@ mixin _$ToastSpec on Spec<ToastSpec> {
       title: _$this.title.lerp(other.title, t),
       subtitle: _$this.subtitle.lerp(other.subtitle, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/feedback/toast/toast.g.dart
+++ b/packages/remix/lib/src/components/feedback/toast/toast.g.dart
@@ -243,10 +243,19 @@ class ToastSpecUtility<T extends Attribute>
   /// Utility for defining [ToastSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  ToastSpecUtility(super.builder, {super.mutable});
+  ToastSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  ToastSpecUtility<T> get chain =>
-      ToastSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  ToastSpecUtility<T> get chain => ToastSpecUtility(attributeBuilder);
 
   static ToastSpecUtility<ToastSpecAttribute> get self =>
       ToastSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/checkbox/checkbox.g.dart
+++ b/packages/remix/lib/src/components/form/checkbox/checkbox.g.dart
@@ -84,7 +84,7 @@ mixin _$CheckboxSpec on Spec<CheckboxSpec> {
       container: _$this.container.lerp(other.container, t),
       label: _$this.label.lerp(other.label, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/form/checkbox/checkbox.g.dart
+++ b/packages/remix/lib/src/components/form/checkbox/checkbox.g.dart
@@ -243,10 +243,19 @@ class CheckboxSpecUtility<T extends Attribute>
   /// Utility for defining [CheckboxSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  CheckboxSpecUtility(super.builder, {super.mutable});
+  CheckboxSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  CheckboxSpecUtility<T> get chain =>
-      CheckboxSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  CheckboxSpecUtility<T> get chain => CheckboxSpecUtility(attributeBuilder);
 
   static CheckboxSpecUtility<CheckboxSpecAttribute> get self =>
       CheckboxSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/radio/radio.g.dart
+++ b/packages/remix/lib/src/components/form/radio/radio.g.dart
@@ -241,10 +241,19 @@ class RadioSpecUtility<T extends Attribute>
   /// Utility for defining [RadioSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  RadioSpecUtility(super.builder, {super.mutable});
+  RadioSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  RadioSpecUtility<T> get chain =>
-      RadioSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  RadioSpecUtility<T> get chain => RadioSpecUtility(attributeBuilder);
 
   static RadioSpecUtility<RadioSpecAttribute> get self =>
       RadioSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/radio/radio.g.dart
+++ b/packages/remix/lib/src/components/form/radio/radio.g.dart
@@ -83,7 +83,7 @@ mixin _$RadioSpec on Spec<RadioSpec> {
       container: _$this.container.lerp(other.container, t),
       text: _$this.text.lerp(other.text, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/form/select/select.g.dart
+++ b/packages/remix/lib/src/components/form/select/select.g.dart
@@ -238,10 +238,19 @@ class SelectSpecUtility<T extends Attribute>
   /// Utility for defining [SelectSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SelectSpecUtility(super.builder, {super.mutable});
+  SelectSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  SelectSpecUtility<T> get chain =>
-      SelectSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  SelectSpecUtility<T> get chain => SelectSpecUtility(attributeBuilder);
 
   static SelectSpecUtility<SelectSpecAttribute> get self =>
       SelectSpecUtility((v) => v);
@@ -489,10 +498,19 @@ class SelectMenuSpecUtility<T extends Attribute>
   /// Utility for defining [SelectMenuSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SelectMenuSpecUtility(super.builder, {super.mutable});
+  SelectMenuSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  SelectMenuSpecUtility<T> get chain =>
-      SelectMenuSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  SelectMenuSpecUtility<T> get chain => SelectMenuSpecUtility(attributeBuilder);
 
   static SelectMenuSpecUtility<SelectMenuSpecAttribute> get self =>
       SelectMenuSpecUtility((v) => v);
@@ -752,10 +770,20 @@ class SelectMenuItemSpecUtility<T extends Attribute>
   /// Utility for defining [SelectMenuItemSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SelectMenuItemSpecUtility(super.builder, {super.mutable});
+  SelectMenuItemSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   SelectMenuItemSpecUtility<T> get chain =>
-      SelectMenuItemSpecUtility(attributeBuilder, mutable: true);
+      SelectMenuItemSpecUtility(attributeBuilder);
 
   static SelectMenuItemSpecUtility<SelectMenuItemSpecAttribute> get self =>
       SelectMenuItemSpecUtility((v) => v);
@@ -1017,10 +1045,20 @@ class SelectTriggerSpecUtility<T extends Attribute>
   /// Utility for defining [SelectTriggerSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SelectTriggerSpecUtility(super.builder, {super.mutable});
+  SelectTriggerSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   SelectTriggerSpecUtility<T> get chain =>
-      SelectTriggerSpecUtility(attributeBuilder, mutable: true);
+      SelectTriggerSpecUtility(attributeBuilder);
 
   static SelectTriggerSpecUtility<SelectTriggerSpecAttribute> get self =>
       SelectTriggerSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/select/select.g.dart
+++ b/packages/remix/lib/src/components/form/select/select.g.dart
@@ -83,7 +83,7 @@ mixin _$SelectSpec on Spec<SelectSpec> {
       item: _$this.item.lerp(other.item, t),
       position: _$this.position.lerp(other.position, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -358,7 +358,7 @@ mixin _$SelectMenuSpec on Spec<SelectMenuSpec> {
       container: _$this.container.lerp(other.container, t),
       autoWidth: t < 0.5 ? _$this.autoWidth : other.autoWidth,
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -610,7 +610,7 @@ mixin _$SelectMenuItemSpec on Spec<SelectMenuItemSpec> {
       text: _$this.text.lerp(other.text, t),
       container: _$this.container.lerp(other.container, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -875,7 +875,7 @@ mixin _$SelectTriggerSpec on Spec<SelectTriggerSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       label: _$this.label.lerp(other.label, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/form/slider/slider.g.dart
+++ b/packages/remix/lib/src/components/form/slider/slider.g.dart
@@ -234,10 +234,19 @@ class SliderSpecUtility<T extends Attribute>
   /// Utility for defining [SliderSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SliderSpecUtility(super.builder, {super.mutable});
+  SliderSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  SliderSpecUtility<T> get chain =>
-      SliderSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  SliderSpecUtility<T> get chain => SliderSpecUtility(attributeBuilder);
 
   static SliderSpecUtility<SliderSpecAttribute> get self =>
       SliderSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/slider/slider.g.dart
+++ b/packages/remix/lib/src/components/form/slider/slider.g.dart
@@ -79,7 +79,7 @@ mixin _$SliderSpec on Spec<SliderSpec> {
       activeTrack: _$this.activeTrack.lerp(other.activeTrack, t),
       division: _$this.division.lerp(other.division, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/form/switch/switch.g.dart
+++ b/packages/remix/lib/src/components/form/switch/switch.g.dart
@@ -205,10 +205,19 @@ class SwitchSpecUtility<T extends Attribute>
   /// Utility for defining [SwitchSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  SwitchSpecUtility(super.builder, {super.mutable});
+  SwitchSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  SwitchSpecUtility<T> get chain =>
-      SwitchSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  SwitchSpecUtility<T> get chain => SwitchSpecUtility(attributeBuilder);
 
   static SwitchSpecUtility<SwitchSpecAttribute> get self =>
       SwitchSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/switch/switch.g.dart
+++ b/packages/remix/lib/src/components/form/switch/switch.g.dart
@@ -73,7 +73,7 @@ mixin _$SwitchSpec on Spec<SwitchSpec> {
     return SwitchSpec(
       container: _$this.container.lerp(other.container, t),
       indicator: _$this.indicator.lerp(other.indicator, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
       modifiers: other.modifiers,
     );
   }

--- a/packages/remix/lib/src/components/form/textfield/textfield.g.dart
+++ b/packages/remix/lib/src/components/form/textfield/textfield.g.dart
@@ -690,10 +690,19 @@ class TextFieldSpecUtility<T extends Attribute>
   /// Utility for defining [TextFieldSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  TextFieldSpecUtility(super.builder, {super.mutable});
+  TextFieldSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  TextFieldSpecUtility<T> get chain =>
-      TextFieldSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  TextFieldSpecUtility<T> get chain => TextFieldSpecUtility(attributeBuilder);
 
   static TextFieldSpecUtility<TextFieldSpecAttribute> get self =>
       TextFieldSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/form/textfield/textfield.g.dart
+++ b/packages/remix/lib/src/components/form/textfield/textfield.g.dart
@@ -182,7 +182,7 @@ mixin _$TextFieldSpec on Spec<TextFieldSpec> {
           _$this.floatingLabelHeight, other.floatingLabelHeight, t)!,
       floatingLabelStyle: MixHelpers.lerpTextStyle(
           _$this.floatingLabelStyle, other.floatingLabelStyle, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
       modifiers: other.modifiers,
     );
   }

--- a/packages/remix/lib/src/components/layout/divider/divider.g.dart
+++ b/packages/remix/lib/src/components/layout/divider/divider.g.dart
@@ -70,7 +70,7 @@ mixin _$DividerSpec on Spec<DividerSpec> {
 
     return DividerSpec(
       container: _$this.container.lerp(other.container, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
       modifiers: other.modifiers,
     );
   }

--- a/packages/remix/lib/src/components/layout/divider/divider.g.dart
+++ b/packages/remix/lib/src/components/layout/divider/divider.g.dart
@@ -189,10 +189,19 @@ class DividerSpecUtility<T extends Attribute>
   /// Utility for defining [DividerSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  DividerSpecUtility(super.builder, {super.mutable});
+  DividerSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  DividerSpecUtility<T> get chain =>
-      DividerSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  DividerSpecUtility<T> get chain => DividerSpecUtility(attributeBuilder);
 
   static DividerSpecUtility<DividerSpecAttribute> get self =>
       DividerSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/layout/header/header.g.dart
+++ b/packages/remix/lib/src/components/layout/header/header.g.dart
@@ -82,7 +82,7 @@ mixin _$HeaderSpec on Spec<HeaderSpec> {
       titleGroup: _$this.titleGroup.lerp(other.titleGroup, t),
       title: _$this.title.lerp(other.title, t),
       subtitle: _$this.subtitle.lerp(other.subtitle, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/layout/header/header.g.dart
+++ b/packages/remix/lib/src/components/layout/header/header.g.dart
@@ -238,10 +238,19 @@ class HeaderSpecUtility<T extends Attribute>
   /// Utility for defining [HeaderSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  HeaderSpecUtility(super.builder, {super.mutable});
+  HeaderSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  HeaderSpecUtility<T> get chain =>
-      HeaderSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  HeaderSpecUtility<T> get chain => HeaderSpecUtility(attributeBuilder);
 
   static HeaderSpecUtility<HeaderSpecAttribute> get self =>
       HeaderSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/layout/scaffold/scaffold.g.dart
+++ b/packages/remix/lib/src/components/layout/scaffold/scaffold.g.dart
@@ -189,10 +189,19 @@ class ScaffoldSpecUtility<T extends Attribute>
   /// Utility for defining [ScaffoldSpecAttribute.modifiers]
   late final wrap = SpecModifierUtility((v) => only(modifiers: v));
 
-  ScaffoldSpecUtility(super.builder, {super.mutable});
+  ScaffoldSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  ScaffoldSpecUtility<T> get chain =>
-      ScaffoldSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  ScaffoldSpecUtility<T> get chain => ScaffoldSpecUtility(attributeBuilder);
 
   static ScaffoldSpecUtility<ScaffoldSpecAttribute> get self =>
       ScaffoldSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/layout/scaffold/scaffold.g.dart
+++ b/packages/remix/lib/src/components/layout/scaffold/scaffold.g.dart
@@ -70,7 +70,7 @@ mixin _$ScaffoldSpec on Spec<ScaffoldSpec> {
 
     return ScaffoldSpec(
       container: _$this.container.lerp(other.container, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
       modifiers: other.modifiers,
     );
   }

--- a/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.g.dart
+++ b/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.g.dart
@@ -86,7 +86,7 @@ mixin _$SegmentedControlSpec on Spec<SegmentedControlSpec> {
       divider: _$this.divider.lerp(other.divider, t),
       item: _$this.item.lerp(other.item, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -384,7 +384,7 @@ mixin _$SegmentButtonSpec on Spec<SegmentButtonSpec> {
       icon: _$this.icon.lerp(other.icon, t),
       label: _$this.label.lerp(other.label, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.g.dart
+++ b/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.g.dart
@@ -253,10 +253,20 @@ class SegmentedControlSpecUtility<T extends Attribute>
   /// Utility for defining [SegmentedControlSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SegmentedControlSpecUtility(super.builder, {super.mutable});
+  SegmentedControlSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   SegmentedControlSpecUtility<T> get chain =>
-      SegmentedControlSpecUtility(attributeBuilder, mutable: true);
+      SegmentedControlSpecUtility(attributeBuilder);
 
   static SegmentedControlSpecUtility<SegmentedControlSpecAttribute> get self =>
       SegmentedControlSpecUtility((v) => v);
@@ -538,10 +548,20 @@ class SegmentButtonSpecUtility<T extends Attribute>
   /// Utility for defining [SegmentButtonSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  SegmentButtonSpecUtility(super.builder, {super.mutable});
+  SegmentButtonSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   SegmentButtonSpecUtility<T> get chain =>
-      SegmentButtonSpecUtility(attributeBuilder, mutable: true);
+      SegmentButtonSpecUtility(attributeBuilder);
 
   static SegmentButtonSpecUtility<SegmentButtonSpecAttribute> get self =>
       SegmentButtonSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/utility/badge/badge.g.dart
+++ b/packages/remix/lib/src/components/utility/badge/badge.g.dart
@@ -72,7 +72,7 @@ mixin _$BadgeSpec on Spec<BadgeSpec> {
     return BadgeSpec(
       container: _$this.container.lerp(other.container, t),
       label: _$this.label.lerp(other.label, t),
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/components/utility/badge/badge.g.dart
+++ b/packages/remix/lib/src/components/utility/badge/badge.g.dart
@@ -170,10 +170,19 @@ class BadgeSpecUtility<T extends Attribute>
   /// Utility for defining [BadgeSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  BadgeSpecUtility(super.builder, {super.mutable});
+  BadgeSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
-  BadgeSpecUtility<T> get chain =>
-      BadgeSpecUtility(attributeBuilder, mutable: true);
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  BadgeSpecUtility<T> get chain => BadgeSpecUtility(attributeBuilder);
 
   static BadgeSpecUtility<BadgeSpecAttribute> get self =>
       BadgeSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.g.dart
+++ b/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.g.dart
@@ -205,10 +205,20 @@ class DropdownMenuSpecUtility<T extends Attribute>
   /// Utility for defining [DropdownMenuSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  DropdownMenuSpecUtility(super.builder, {super.mutable});
+  DropdownMenuSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   DropdownMenuSpecUtility<T> get chain =>
-      DropdownMenuSpecUtility(attributeBuilder, mutable: true);
+      DropdownMenuSpecUtility(attributeBuilder);
 
   static DropdownMenuSpecUtility<DropdownMenuSpecAttribute> get self =>
       DropdownMenuSpecUtility((v) => v);
@@ -455,10 +465,20 @@ class DropdownMenuContainerSpecUtility<T extends Attribute>
   /// Utility for defining [DropdownMenuContainerSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  DropdownMenuContainerSpecUtility(super.builder, {super.mutable});
+  DropdownMenuContainerSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   DropdownMenuContainerSpecUtility<T> get chain =>
-      DropdownMenuContainerSpecUtility(attributeBuilder, mutable: true);
+      DropdownMenuContainerSpecUtility(attributeBuilder);
 
   static DropdownMenuContainerSpecUtility<DropdownMenuContainerSpecAttribute>
       get self => DropdownMenuContainerSpecUtility((v) => v);
@@ -718,10 +738,20 @@ class DropdownMenuItemSpecUtility<T extends Attribute>
   /// Utility for defining [DropdownMenuItemSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  DropdownMenuItemSpecUtility(super.builder, {super.mutable});
+  DropdownMenuItemSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   DropdownMenuItemSpecUtility<T> get chain =>
-      DropdownMenuItemSpecUtility(attributeBuilder, mutable: true);
+      DropdownMenuItemSpecUtility(attributeBuilder);
 
   static DropdownMenuItemSpecUtility<DropdownMenuItemSpecAttribute> get self =>
       DropdownMenuItemSpecUtility((v) => v);

--- a/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.g.dart
+++ b/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.g.dart
@@ -76,7 +76,7 @@ mixin _$DropdownMenuSpec on Spec<DropdownMenuSpec> {
       menu: _$this.menu.lerp(other.menu, t),
       item: _$this.item.lerp(other.item, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -323,7 +323,7 @@ mixin _$DropdownMenuContainerSpec on Spec<DropdownMenuContainerSpec> {
       container: _$this.container.lerp(other.container, t),
       autoWidth: t < 0.5 ? _$this.autoWidth : other.autoWidth,
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -576,7 +576,7 @@ mixin _$DropdownMenuItemSpec on Spec<DropdownMenuItemSpec> {
       text: _$this.text.lerp(other.text, t),
       container: _$this.container.lerp(other.container, t),
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/helpers/spec/composited_transform_follower_spec.g.dart
+++ b/packages/remix/lib/src/helpers/spec/composited_transform_follower_spec.g.dart
@@ -85,7 +85,7 @@ mixin _$CompositedTransformFollowerSpec
       followerAnchor: AlignmentGeometry.lerp(
           _$this.followerAnchor, other.followerAnchor, t)!,
       modifiers: other.modifiers,
-      animated: t < 0.5 ? _$this.animated : other.animated,
+      animated: _$this.animated ?? other.animated,
     );
   }
 

--- a/packages/remix/lib/src/helpers/spec/composited_transform_follower_spec.g.dart
+++ b/packages/remix/lib/src/helpers/spec/composited_transform_follower_spec.g.dart
@@ -232,10 +232,20 @@ class CompositedTransformFollowerSpecUtility<T extends Attribute>
   /// Utility for defining [CompositedTransformFollowerSpecAttribute.animated]
   late final animated = AnimatedUtility((v) => only(animated: v));
 
-  CompositedTransformFollowerSpecUtility(super.builder, {super.mutable});
+  CompositedTransformFollowerSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
 
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
   CompositedTransformFollowerSpecUtility<T> get chain =>
-      CompositedTransformFollowerSpecUtility(attributeBuilder, mutable: true);
+      CompositedTransformFollowerSpecUtility(attributeBuilder);
 
   static CompositedTransformFollowerSpecUtility<
           CompositedTransformFollowerSpecAttribute>


### PR DESCRIPTION
## Summary
- Unified SpecUtility, Style, and Attributes to be compatible values in the styling system
- Enables much cleaner API and behavior for defining, merging, and adjusting values
- Updated NestedStyleAttribute factory method to accept StyleElement list
- Removed mutable parameter and chain getter from SpecUtility classes
- Regenerated all spec files to reflect the improved type compatibility

## Test plan
- [x] All existing tests pass
- [x] Code generation produces expected output
- [x] Style composition and value merging works seamlessly with unified types