### PR TITLE
fix: Change Mixable to extend EqualityMixin instead of StyleElement

### DIFF
--- a/packages/mix/lib/src/core/element.dart
+++ b/packages/mix/lib/src/core/element.dart
@@ -28,8 +28,6 @@ typedef Dto<Value> = Mixable<Value>;
 abstract class Mixable<Value> with EqualityMixin {
   const Mixable();
 
-  Object get mergeKey => runtimeType;
-
   Value resolve(MixData mix);
   Mixable<Value> merge(covariant Mixable<Value>? other);
 }

--- a/packages/mix/lib/src/core/element.dart
+++ b/packages/mix/lib/src/core/element.dart
@@ -25,12 +25,12 @@ typedef StyledAttribute = SpecAttribute;
 @Deprecated('Use Mixable instead')
 typedef Dto<Value> = Mixable<Value>;
 
-abstract class Mixable<Value> extends StyleElement {
+abstract class Mixable<Value> with EqualityMixin {
   const Mixable();
 
-  Value resolve(MixData mix);
+  Object get mergeKey => runtimeType;
 
-  @override
+  Value resolve(MixData mix);
   Mixable<Value> merge(covariant Mixable<Value>? other);
 }
 

--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -51,6 +51,9 @@ abstract class SpecAttribute<Value> extends Mixable<Value>
 
   @override
   SpecAttribute<Value> merge(covariant SpecAttribute<Value>? other);
+
+  @override
+  Object get mergeKey => runtimeType;
 }
 
 abstract class SpecUtility<T extends StyleElement, V> extends StyleElement {

--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -39,8 +39,8 @@ abstract class Spec<T extends Spec<T>> with EqualityMixin {
 ///
 /// This class extends the [StyleElement] class and provides a generic type [Self] and [Value].
 /// The [Self] type represents the concrete implementation of the attribute, while the [Value] type represents the resolvable value.
-abstract class SpecAttribute<Value> extends Mixable<Value>
-    implements StyleElement {
+abstract class SpecAttribute<Value> extends StyleElement
+    implements Mixable<Value> {
   final AnimatedDataDto? animated;
   final WidgetModifiersDataDto? modifiers;
 
@@ -51,9 +51,6 @@ abstract class SpecAttribute<Value> extends Mixable<Value>
 
   @override
   SpecAttribute<Value> merge(covariant SpecAttribute<Value>? other);
-
-  @override
-  Object get mergeKey => runtimeType;
 }
 
 abstract class SpecUtility<T extends StyleElement, V> extends StyleElement {


### PR DESCRIPTION
## Summary
• Remove StyleElement inheritance from Mixable class
• Add EqualityMixin with mergeKey implementation  
• Maintain existing resolve and merge method signatures

## Test plan
- [ ] Verify existing tests pass
- [ ] Check that Mixable classes still function correctly
- [ ] Ensure merge behavior is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)