### PR TITLE
chore: Update minimum compatibility version to Flutter 3.29.0

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,8 +1,8 @@
 {
-  "flutter": "3.27.0",
+  "flutter": "3.29.0",
   "flavors": {
     "prod": "stable",
-    "mincompat": "3.27.0"
+    "mincompat": "3.29.0"
   },
   "runPubGetOnSdkChanges": true,
   "updateGitIgnore": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
     "source.fixAll": "explicit",
     "source.dcm.fixAll": "explicit"
   },
-  "dart.flutterSdkPath": ".fvm/versions/3.27.0",
+  "dart.flutterSdkPath": ".fvm/versions/3.29.0",
   "dart.lineLength": 80,
   "search.exclude": {
     "**/.fvm/versions": true

--- a/examples/todo_list/pubspec.yaml
+++ b/examples/todo_list/pubspec.yaml
@@ -6,8 +6,8 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:
@@ -24,13 +24,13 @@ dependencies:
 dev_dependencies:
   mix_generator:
     path: ../../packages/mix_generator
-  build_runner: ^2.4.9
+  build_runner: ^2.5.0
   flutter_test:
     sdk: flutter
   mix_lint:
     path: ../../packages/mix_lint
 
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/melos.yaml
+++ b/melos.yaml
@@ -10,14 +10,14 @@ packages:
 command:
   bootstrap:
     environment:
-      sdk: ">=3.6.0 <4.0.0"
-      flutter: ">=3.27.0"
+      sdk: ">=3.7.0 <4.0.0"
+      flutter: ">=3.29.0"
     dependencies:
       meta: ^1.15.0
     dev_dependencies:
-      flutter_lints: ^4.0.0
-      dart_code_metrics_presets: ^2.14.0
-      build_runner: ^2.4.9
+      flutter_lints: ^5.0.0
+      dart_code_metrics_presets: ^2.22.0
+      build_runner: ^2.5.0
   publish:
     hooks:
       pre: melos run gen:build

--- a/mix.code-workspace
+++ b/mix.code-workspace
@@ -26,7 +26,7 @@
     }
   ],
   "settings": {
-    "dart.flutterSdkPath": ".fvm/versions/3.27.0",
+    "dart.flutterSdkPath": ".fvm/versions/3.29.0",
     "search.exclude": {
       ".fvm/**": true,
       "website": true

--- a/packages/mix/example/pubspec.yaml
+++ b/packages/mix/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 dependencies:
   flutter:
     sdk: flutter
@@ -15,7 +15,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/mix/lib/src/attributes/border/border_dto.g.dart
+++ b/packages/mix/lib/src/attributes/border/border_dto.g.dart
@@ -54,11 +54,11 @@ mixin _$BorderDto on Mixable<Border> {
   /// compare two [BorderDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.top,
-        _$this.bottom,
-        _$this.left,
-        _$this.right,
-      ];
+    _$this.top,
+    _$this.bottom,
+    _$this.left,
+    _$this.right,
+  ];
 
   /// Returns this instance as a [BorderDto].
   BorderDto get _$this => this as BorderDto;
@@ -131,11 +131,11 @@ mixin _$BorderDirectionalDto on Mixable<BorderDirectional> {
   /// compare two [BorderDirectionalDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.top,
-        _$this.bottom,
-        _$this.start,
-        _$this.end,
-      ];
+    _$this.top,
+    _$this.bottom,
+    _$this.start,
+    _$this.end,
+  ];
 
   /// Returns this instance as a [BorderDirectionalDto].
   BorderDirectionalDto get _$this => this as BorderDirectionalDto;
@@ -208,11 +208,11 @@ mixin _$BorderSideDto on Mixable<BorderSide>, HasDefaultValue<BorderSide> {
   /// compare two [BorderSideDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.color,
-        _$this.strokeAlign,
-        _$this.style,
-        _$this.width,
-      ];
+    _$this.color,
+    _$this.strokeAlign,
+    _$this.style,
+    _$this.width,
+  ];
 
   /// Returns this instance as a [BorderSideDto].
   BorderSideDto get _$this => this as BorderSideDto;
@@ -249,12 +249,14 @@ class BorderSideUtility<T extends StyleElement>
     BorderStyle? style,
     double? width,
   }) {
-    return builder(BorderSideDto(
-      color: color,
-      strokeAlign: strokeAlign,
-      style: style,
-      width: width,
-    ));
+    return builder(
+      BorderSideDto(
+        color: color,
+        strokeAlign: strokeAlign,
+        style: style,
+        width: width,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/border/border_radius_dto.g.dart
+++ b/packages/mix/lib/src/attributes/border/border_radius_dto.g.dart
@@ -36,11 +36,11 @@ mixin _$BorderRadiusDto on Mixable<BorderRadius> {
   /// compare two [BorderRadiusDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.topLeft,
-        _$this.topRight,
-        _$this.bottomLeft,
-        _$this.bottomRight,
-      ];
+    _$this.topLeft,
+    _$this.topRight,
+    _$this.bottomLeft,
+    _$this.bottomRight,
+  ];
 
   /// Returns this instance as a [BorderRadiusDto].
   BorderRadiusDto get _$this => this as BorderRadiusDto;
@@ -95,11 +95,11 @@ mixin _$BorderRadiusDirectionalDto on Mixable<BorderRadiusDirectional> {
   /// compare two [BorderRadiusDirectionalDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.topStart,
-        _$this.topEnd,
-        _$this.bottomStart,
-        _$this.bottomEnd,
-      ];
+    _$this.topStart,
+    _$this.topEnd,
+    _$this.bottomStart,
+    _$this.bottomEnd,
+  ];
 
   /// Returns this instance as a [BorderRadiusDirectionalDto].
   BorderRadiusDirectionalDto get _$this => this as BorderRadiusDirectionalDto;

--- a/packages/mix/lib/src/attributes/border/shape_border_dto.g.dart
+++ b/packages/mix/lib/src/attributes/border/shape_border_dto.g.dart
@@ -50,10 +50,7 @@ mixin _$RoundedRectangleBorderDto on Mixable<RoundedRectangleBorder> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [RoundedRectangleBorderDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.borderRadius,
-        _$this.side,
-      ];
+  List<Object?> get props => [_$this.borderRadius, _$this.side];
 
   /// Returns this instance as a [RoundedRectangleBorderDto].
   RoundedRectangleBorderDto get _$this => this as RoundedRectangleBorderDto;
@@ -66,35 +63,26 @@ mixin _$RoundedRectangleBorderDto on Mixable<RoundedRectangleBorder> {
 class RoundedRectangleBorderUtility<T extends StyleElement>
     extends DtoUtility<T, RoundedRectangleBorderDto, RoundedRectangleBorder> {
   /// Utility for defining [RoundedRectangleBorderDto.borderRadius]
-  late final borderRadius =
-      BorderRadiusGeometryUtility((v) => only(borderRadius: v));
+  late final borderRadius = BorderRadiusGeometryUtility(
+    (v) => only(borderRadius: v),
+  );
 
   /// Utility for defining [RoundedRectangleBorderDto.side]
   late final side = BorderSideUtility((v) => only(side: v));
 
   RoundedRectangleBorderUtility(super.builder)
-      : super(valueToDto: (v) => v.toDto());
+    : super(valueToDto: (v) => v.toDto());
 
   /// Returns a new [RoundedRectangleBorderDto] with the specified properties.
   @override
-  T only({
-    BorderRadiusGeometryDto? borderRadius,
-    BorderSideDto? side,
-  }) {
-    return builder(RoundedRectangleBorderDto(
-      borderRadius: borderRadius,
-      side: side,
-    ));
+  T only({BorderRadiusGeometryDto? borderRadius, BorderSideDto? side}) {
+    return builder(
+      RoundedRectangleBorderDto(borderRadius: borderRadius, side: side),
+    );
   }
 
-  T call({
-    BorderRadiusGeometry? borderRadius,
-    BorderSide? side,
-  }) {
-    return only(
-      borderRadius: borderRadius?.toDto(),
-      side: side?.toDto(),
-    );
+  T call({BorderRadiusGeometry? borderRadius, BorderSide? side}) {
+    return only(borderRadius: borderRadius?.toDto(), side: side?.toDto());
   }
 }
 
@@ -159,10 +147,7 @@ mixin _$BeveledRectangleBorderDto on Mixable<BeveledRectangleBorder> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [BeveledRectangleBorderDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.borderRadius,
-        _$this.side,
-      ];
+  List<Object?> get props => [_$this.borderRadius, _$this.side];
 
   /// Returns this instance as a [BeveledRectangleBorderDto].
   BeveledRectangleBorderDto get _$this => this as BeveledRectangleBorderDto;
@@ -175,35 +160,26 @@ mixin _$BeveledRectangleBorderDto on Mixable<BeveledRectangleBorder> {
 class BeveledRectangleBorderUtility<T extends StyleElement>
     extends DtoUtility<T, BeveledRectangleBorderDto, BeveledRectangleBorder> {
   /// Utility for defining [BeveledRectangleBorderDto.borderRadius]
-  late final borderRadius =
-      BorderRadiusGeometryUtility((v) => only(borderRadius: v));
+  late final borderRadius = BorderRadiusGeometryUtility(
+    (v) => only(borderRadius: v),
+  );
 
   /// Utility for defining [BeveledRectangleBorderDto.side]
   late final side = BorderSideUtility((v) => only(side: v));
 
   BeveledRectangleBorderUtility(super.builder)
-      : super(valueToDto: (v) => v.toDto());
+    : super(valueToDto: (v) => v.toDto());
 
   /// Returns a new [BeveledRectangleBorderDto] with the specified properties.
   @override
-  T only({
-    BorderRadiusGeometryDto? borderRadius,
-    BorderSideDto? side,
-  }) {
-    return builder(BeveledRectangleBorderDto(
-      borderRadius: borderRadius,
-      side: side,
-    ));
+  T only({BorderRadiusGeometryDto? borderRadius, BorderSideDto? side}) {
+    return builder(
+      BeveledRectangleBorderDto(borderRadius: borderRadius, side: side),
+    );
   }
 
-  T call({
-    BorderRadiusGeometry? borderRadius,
-    BorderSide? side,
-  }) {
-    return only(
-      borderRadius: borderRadius?.toDto(),
-      side: side?.toDto(),
-    );
+  T call({BorderRadiusGeometry? borderRadius, BorderSide? side}) {
+    return only(borderRadius: borderRadius?.toDto(), side: side?.toDto());
   }
 }
 
@@ -268,10 +244,7 @@ mixin _$ContinuousRectangleBorderDto on Mixable<ContinuousRectangleBorder> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ContinuousRectangleBorderDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.borderRadius,
-        _$this.side,
-      ];
+  List<Object?> get props => [_$this.borderRadius, _$this.side];
 
   /// Returns this instance as a [ContinuousRectangleBorderDto].
   ContinuousRectangleBorderDto get _$this =>
@@ -283,38 +256,29 @@ mixin _$ContinuousRectangleBorderDto on Mixable<ContinuousRectangleBorder> {
 /// This class provides methods to set individual properties of a [ContinuousRectangleBorder].
 /// Use the methods of this class to configure specific properties of a [ContinuousRectangleBorder].
 class ContinuousRectangleBorderUtility<T extends StyleElement>
-    extends DtoUtility<T, ContinuousRectangleBorderDto,
-        ContinuousRectangleBorder> {
+    extends
+        DtoUtility<T, ContinuousRectangleBorderDto, ContinuousRectangleBorder> {
   /// Utility for defining [ContinuousRectangleBorderDto.borderRadius]
-  late final borderRadius =
-      BorderRadiusGeometryUtility((v) => only(borderRadius: v));
+  late final borderRadius = BorderRadiusGeometryUtility(
+    (v) => only(borderRadius: v),
+  );
 
   /// Utility for defining [ContinuousRectangleBorderDto.side]
   late final side = BorderSideUtility((v) => only(side: v));
 
   ContinuousRectangleBorderUtility(super.builder)
-      : super(valueToDto: (v) => v.toDto());
+    : super(valueToDto: (v) => v.toDto());
 
   /// Returns a new [ContinuousRectangleBorderDto] with the specified properties.
   @override
-  T only({
-    BorderRadiusGeometryDto? borderRadius,
-    BorderSideDto? side,
-  }) {
-    return builder(ContinuousRectangleBorderDto(
-      borderRadius: borderRadius,
-      side: side,
-    ));
+  T only({BorderRadiusGeometryDto? borderRadius, BorderSideDto? side}) {
+    return builder(
+      ContinuousRectangleBorderDto(borderRadius: borderRadius, side: side),
+    );
   }
 
-  T call({
-    BorderRadiusGeometry? borderRadius,
-    BorderSide? side,
-  }) {
-    return only(
-      borderRadius: borderRadius?.toDto(),
-      side: side?.toDto(),
-    );
+  T call({BorderRadiusGeometry? borderRadius, BorderSide? side}) {
+    return only(borderRadius: borderRadius?.toDto(), side: side?.toDto());
   }
 }
 
@@ -379,10 +343,7 @@ mixin _$CircleBorderDto on Mixable<CircleBorder> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [CircleBorderDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.side,
-        _$this.eccentricity,
-      ];
+  List<Object?> get props => [_$this.side, _$this.eccentricity];
 
   /// Returns this instance as a [CircleBorderDto].
   CircleBorderDto get _$this => this as CircleBorderDto;
@@ -404,24 +365,12 @@ class CircleBorderUtility<T extends StyleElement>
 
   /// Returns a new [CircleBorderDto] with the specified properties.
   @override
-  T only({
-    BorderSideDto? side,
-    double? eccentricity,
-  }) {
-    return builder(CircleBorderDto(
-      side: side,
-      eccentricity: eccentricity,
-    ));
+  T only({BorderSideDto? side, double? eccentricity}) {
+    return builder(CircleBorderDto(side: side, eccentricity: eccentricity));
   }
 
-  T call({
-    BorderSide? side,
-    double? eccentricity,
-  }) {
-    return only(
-      side: side?.toDto(),
-      eccentricity: eccentricity,
-    );
+  T call({BorderSide? side, double? eccentricity}) {
+    return only(side: side?.toDto(), eccentricity: eccentricity);
   }
 }
 
@@ -429,10 +378,7 @@ class CircleBorderUtility<T extends StyleElement>
 extension CircleBorderMixExt on CircleBorder {
   /// Converts this [CircleBorder] to a [CircleBorderDto].
   CircleBorderDto toDto() {
-    return CircleBorderDto(
-      side: side.toDto(),
-      eccentricity: eccentricity,
-    );
+    return CircleBorderDto(side: side.toDto(), eccentricity: eccentricity);
   }
 }
 
@@ -496,14 +442,14 @@ mixin _$StarBorderDto on Mixable<StarBorder> {
   /// compare two [StarBorderDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.side,
-        _$this.points,
-        _$this.innerRadiusRatio,
-        _$this.pointRounding,
-        _$this.valleyRounding,
-        _$this.rotation,
-        _$this.squash,
-      ];
+    _$this.side,
+    _$this.points,
+    _$this.innerRadiusRatio,
+    _$this.pointRounding,
+    _$this.valleyRounding,
+    _$this.rotation,
+    _$this.squash,
+  ];
 
   /// Returns this instance as a [StarBorderDto].
   StarBorderDto get _$this => this as StarBorderDto;
@@ -549,15 +495,17 @@ class StarBorderUtility<T extends StyleElement>
     double? rotation,
     double? squash,
   }) {
-    return builder(StarBorderDto(
-      side: side,
-      points: points,
-      innerRadiusRatio: innerRadiusRatio,
-      pointRounding: pointRounding,
-      valleyRounding: valleyRounding,
-      rotation: rotation,
-      squash: squash,
-    ));
+    return builder(
+      StarBorderDto(
+        side: side,
+        points: points,
+        innerRadiusRatio: innerRadiusRatio,
+        pointRounding: pointRounding,
+        valleyRounding: valleyRounding,
+        rotation: rotation,
+        squash: squash,
+      ),
+    );
   }
 
   T call({
@@ -653,12 +601,12 @@ mixin _$LinearBorderDto on Mixable<LinearBorder> {
   /// compare two [LinearBorderDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.side,
-        _$this.start,
-        _$this.end,
-        _$this.top,
-        _$this.bottom,
-      ];
+    _$this.side,
+    _$this.start,
+    _$this.end,
+    _$this.top,
+    _$this.bottom,
+  ];
 
   /// Returns this instance as a [LinearBorderDto].
   LinearBorderDto get _$this => this as LinearBorderDto;
@@ -696,13 +644,15 @@ class LinearBorderUtility<T extends StyleElement>
     LinearBorderEdgeDto? top,
     LinearBorderEdgeDto? bottom,
   }) {
-    return builder(LinearBorderDto(
-      side: side,
-      start: start,
-      end: end,
-      top: top,
-      bottom: bottom,
-    ));
+    return builder(
+      LinearBorderDto(
+        side: side,
+        start: start,
+        end: end,
+        top: top,
+        bottom: bottom,
+      ),
+    );
   }
 
   T call({
@@ -785,10 +735,7 @@ mixin _$LinearBorderEdgeDto on Mixable<LinearBorderEdge> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [LinearBorderEdgeDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.size,
-        _$this.alignment,
-      ];
+  List<Object?> get props => [_$this.size, _$this.alignment];
 
   /// Returns this instance as a [LinearBorderEdgeDto].
   LinearBorderEdgeDto get _$this => this as LinearBorderEdgeDto;
@@ -810,24 +757,12 @@ class LinearBorderEdgeUtility<T extends StyleElement>
 
   /// Returns a new [LinearBorderEdgeDto] with the specified properties.
   @override
-  T only({
-    double? size,
-    double? alignment,
-  }) {
-    return builder(LinearBorderEdgeDto(
-      size: size,
-      alignment: alignment,
-    ));
+  T only({double? size, double? alignment}) {
+    return builder(LinearBorderEdgeDto(size: size, alignment: alignment));
   }
 
-  T call({
-    double? size,
-    double? alignment,
-  }) {
-    return only(
-      size: size,
-      alignment: alignment,
-    );
+  T call({double? size, double? alignment}) {
+    return only(size: size, alignment: alignment);
   }
 }
 
@@ -835,10 +770,7 @@ class LinearBorderEdgeUtility<T extends StyleElement>
 extension LinearBorderEdgeMixExt on LinearBorderEdge {
   /// Converts this [LinearBorderEdge] to a [LinearBorderEdgeDto].
   LinearBorderEdgeDto toDto() {
-    return LinearBorderEdgeDto(
-      size: size,
-      alignment: alignment,
-    );
+    return LinearBorderEdgeDto(size: size, alignment: alignment);
   }
 }
 
@@ -862,9 +794,7 @@ mixin _$StadiumBorderDto on Mixable<StadiumBorder> {
   /// ```
   @override
   StadiumBorder resolve(MixData mix) {
-    return StadiumBorder(
-      side: _$this.side?.resolve(mix) ?? BorderSide.none,
-    );
+    return StadiumBorder(side: _$this.side?.resolve(mix) ?? BorderSide.none);
   }
 
   /// Merges the properties of this [StadiumBorderDto] with the properties of [other].
@@ -879,9 +809,7 @@ mixin _$StadiumBorderDto on Mixable<StadiumBorder> {
   StadiumBorderDto merge(StadiumBorderDto? other) {
     if (other == null) return _$this;
 
-    return StadiumBorderDto(
-      side: _$this.side?.merge(other.side) ?? other.side,
-    );
+    return StadiumBorderDto(side: _$this.side?.merge(other.side) ?? other.side);
   }
 
   /// The list of properties that constitute the state of this [StadiumBorderDto].
@@ -889,9 +817,7 @@ mixin _$StadiumBorderDto on Mixable<StadiumBorder> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [StadiumBorderDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.side,
-      ];
+  List<Object?> get props => [_$this.side];
 
   /// Returns this instance as a [StadiumBorderDto].
   StadiumBorderDto get _$this => this as StadiumBorderDto;
@@ -910,20 +836,12 @@ class StadiumBorderUtility<T extends StyleElement>
 
   /// Returns a new [StadiumBorderDto] with the specified properties.
   @override
-  T only({
-    BorderSideDto? side,
-  }) {
-    return builder(StadiumBorderDto(
-      side: side,
-    ));
+  T only({BorderSideDto? side}) {
+    return builder(StadiumBorderDto(side: side));
   }
 
-  T call({
-    BorderSide? side,
-  }) {
-    return only(
-      side: side?.toDto(),
-    );
+  T call({BorderSide? side}) {
+    return only(side: side?.toDto());
   }
 }
 
@@ -931,9 +849,7 @@ class StadiumBorderUtility<T extends StyleElement>
 extension StadiumBorderMixExt on StadiumBorder {
   /// Converts this [StadiumBorder] to a [StadiumBorderDto].
   StadiumBorderDto toDto() {
-    return StadiumBorderDto(
-      side: side.toDto(),
-    );
+    return StadiumBorderDto(side: side.toDto());
   }
 }
 

--- a/packages/mix/lib/src/attributes/constraints/constraints_dto.g.dart
+++ b/packages/mix/lib/src/attributes/constraints/constraints_dto.g.dart
@@ -54,11 +54,11 @@ mixin _$BoxConstraintsDto on Mixable<BoxConstraints> {
   /// compare two [BoxConstraintsDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.minWidth,
-        _$this.maxWidth,
-        _$this.minHeight,
-        _$this.maxHeight,
-      ];
+    _$this.minWidth,
+    _$this.maxWidth,
+    _$this.minHeight,
+    _$this.maxHeight,
+  ];
 
   /// Returns this instance as a [BoxConstraintsDto].
   BoxConstraintsDto get _$this => this as BoxConstraintsDto;
@@ -92,12 +92,14 @@ class BoxConstraintsUtility<T extends StyleElement>
     double? minHeight,
     double? maxHeight,
   }) {
-    return builder(BoxConstraintsDto(
-      minWidth: minWidth,
-      maxWidth: maxWidth,
-      minHeight: minHeight,
-      maxHeight: maxHeight,
-    ));
+    return builder(
+      BoxConstraintsDto(
+        minWidth: minWidth,
+        maxWidth: maxWidth,
+        minHeight: minHeight,
+        maxHeight: maxHeight,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/decoration/decoration_dto.g.dart
+++ b/packages/mix/lib/src/attributes/decoration/decoration_dto.g.dart
@@ -64,15 +64,15 @@ mixin _$BoxDecorationDto on Mixable<BoxDecoration> {
   /// compare two [BoxDecorationDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.border,
-        _$this.borderRadius,
-        _$this.shape,
-        _$this.backgroundBlendMode,
-        _$this.color,
-        _$this.image,
-        _$this.gradient,
-        _$this.boxShadow,
-      ];
+    _$this.border,
+    _$this.borderRadius,
+    _$this.shape,
+    _$this.backgroundBlendMode,
+    _$this.color,
+    _$this.image,
+    _$this.gradient,
+    _$this.boxShadow,
+  ];
 
   /// Returns this instance as a [BoxDecorationDto].
   BoxDecorationDto get _$this => this as BoxDecorationDto;
@@ -91,8 +91,9 @@ class BoxDecorationUtility<T extends StyleElement>
   late final borderDirectional = border.directional;
 
   /// Utility for defining [BoxDecorationDto.borderRadius]
-  late final borderRadius =
-      BorderRadiusGeometryUtility((v) => only(borderRadius: v));
+  late final borderRadius = BorderRadiusGeometryUtility(
+    (v) => only(borderRadius: v),
+  );
 
   /// Utility for defining [BoxDecorationDto.borderRadius.directional]
   late final borderRadiusDirectional = borderRadius.directional;
@@ -101,8 +102,9 @@ class BoxDecorationUtility<T extends StyleElement>
   late final shape = BoxShapeUtility((v) => only(shape: v));
 
   /// Utility for defining [BoxDecorationDto.backgroundBlendMode]
-  late final backgroundBlendMode =
-      BlendModeUtility((v) => only(backgroundBlendMode: v));
+  late final backgroundBlendMode = BlendModeUtility(
+    (v) => only(backgroundBlendMode: v),
+  );
 
   /// Utility for defining [BoxDecorationDto.color]
   late final color = ColorUtility((v) => only(color: v));
@@ -136,16 +138,18 @@ class BoxDecorationUtility<T extends StyleElement>
     GradientDto? gradient,
     List<BoxShadowDto>? boxShadow,
   }) {
-    return builder(BoxDecorationDto(
-      border: border,
-      borderRadius: borderRadius,
-      shape: shape,
-      backgroundBlendMode: backgroundBlendMode,
-      color: color,
-      image: image,
-      gradient: gradient,
-      boxShadow: boxShadow,
-    ));
+    return builder(
+      BoxDecorationDto(
+        border: border,
+        borderRadius: borderRadius,
+        shape: shape,
+        backgroundBlendMode: backgroundBlendMode,
+        color: color,
+        image: image,
+        gradient: gradient,
+        boxShadow: boxShadow,
+      ),
+    );
   }
 
   T call({
@@ -214,7 +218,8 @@ mixin _$ShapeDecorationDto
       color: _$this.color?.resolve(mix) ?? defaultValue.color,
       image: _$this.image?.resolve(mix) ?? defaultValue.image,
       gradient: _$this.gradient?.resolve(mix) ?? defaultValue.gradient,
-      shadows: _$this.shadows?.map((e) => e.resolve(mix)).toList() ??
+      shadows:
+          _$this.shadows?.map((e) => e.resolve(mix)).toList() ??
           defaultValue.shadows,
     );
   }
@@ -246,12 +251,12 @@ mixin _$ShapeDecorationDto
   /// compare two [ShapeDecorationDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.shape,
-        _$this.color,
-        _$this.image,
-        _$this.gradient,
-        _$this.shadows,
-      ];
+    _$this.shape,
+    _$this.color,
+    _$this.image,
+    _$this.gradient,
+    _$this.shadows,
+  ];
 
   /// Returns this instance as a [ShapeDecorationDto].
   ShapeDecorationDto get _$this => this as ShapeDecorationDto;
@@ -289,13 +294,15 @@ class ShapeDecorationUtility<T extends StyleElement>
     GradientDto? gradient,
     List<BoxShadowDto>? shadows,
   }) {
-    return builder(ShapeDecorationDto(
-      shape: shape,
-      color: color,
-      image: image,
-      gradient: gradient,
-      shadows: shadows,
-    ));
+    return builder(
+      ShapeDecorationDto(
+        shape: shape,
+        color: color,
+        image: image,
+        gradient: gradient,
+        shadows: shadows,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/decoration/image/decoration_image_dto.g.dart
+++ b/packages/mix/lib/src/attributes/decoration/image/decoration_image_dto.g.dart
@@ -63,15 +63,15 @@ mixin _$DecorationImageDto
   /// compare two [DecorationImageDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.image,
-        _$this.fit,
-        _$this.alignment,
-        _$this.centerSlice,
-        _$this.repeat,
-        _$this.filterQuality,
-        _$this.invertColors,
-        _$this.isAntiAlias,
-      ];
+    _$this.image,
+    _$this.fit,
+    _$this.alignment,
+    _$this.centerSlice,
+    _$this.repeat,
+    _$this.filterQuality,
+    _$this.invertColors,
+    _$this.isAntiAlias,
+  ];
 
   /// Returns this instance as a [DecorationImageDto].
   DecorationImageDto get _$this => this as DecorationImageDto;
@@ -99,8 +99,9 @@ class DecorationImageUtility<T extends StyleElement>
   late final repeat = ImageRepeatUtility((v) => only(repeat: v));
 
   /// Utility for defining [DecorationImageDto.filterQuality]
-  late final filterQuality =
-      FilterQualityUtility((v) => only(filterQuality: v));
+  late final filterQuality = FilterQualityUtility(
+    (v) => only(filterQuality: v),
+  );
 
   /// Utility for defining [DecorationImageDto.invertColors]
   late final invertColors = BoolUtility((v) => only(invertColors: v));
@@ -122,16 +123,18 @@ class DecorationImageUtility<T extends StyleElement>
     bool? invertColors,
     bool? isAntiAlias,
   }) {
-    return builder(DecorationImageDto(
-      image: image,
-      fit: fit,
-      alignment: alignment,
-      centerSlice: centerSlice,
-      repeat: repeat,
-      filterQuality: filterQuality,
-      invertColors: invertColors,
-      isAntiAlias: isAntiAlias,
-    ));
+    return builder(
+      DecorationImageDto(
+        image: image,
+        fit: fit,
+        alignment: alignment,
+        centerSlice: centerSlice,
+        repeat: repeat,
+        filterQuality: filterQuality,
+        invertColors: invertColors,
+        isAntiAlias: isAntiAlias,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/gap/space_dto.g.dart
+++ b/packages/mix/lib/src/attributes/gap/space_dto.g.dart
@@ -22,9 +22,7 @@ mixin _$SpaceDto on Mixable<double> {
   SpaceDto merge(SpaceDto? other) {
     if (other == null) return _$this;
 
-    return SpaceDto._(
-      value: other.value ?? _$this.value,
-    );
+    return SpaceDto._(value: other.value ?? _$this.value);
   }
 
   /// The list of properties that constitute the state of this [SpaceDto].
@@ -32,9 +30,7 @@ mixin _$SpaceDto on Mixable<double> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [SpaceDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.value,
-      ];
+  List<Object?> get props => [_$this.value];
 
   /// Returns this instance as a [SpaceDto].
   SpaceDto get _$this => this as SpaceDto;

--- a/packages/mix/lib/src/attributes/gradient/gradient_dto.g.dart
+++ b/packages/mix/lib/src/attributes/gradient/gradient_dto.g.dart
@@ -26,7 +26,8 @@ mixin _$LinearGradientDto
       end: _$this.end ?? defaultValue.end,
       tileMode: _$this.tileMode ?? defaultValue.tileMode,
       transform: _$this.transform ?? defaultValue.transform,
-      colors: _$this.colors?.map((e) => e.resolve(mix)).toList() ??
+      colors:
+          _$this.colors?.map((e) => e.resolve(mix)).toList() ??
           defaultValue.colors,
       stops: _$this.stops ?? defaultValue.stops,
     );
@@ -60,13 +61,13 @@ mixin _$LinearGradientDto
   /// compare two [LinearGradientDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.begin,
-        _$this.end,
-        _$this.tileMode,
-        _$this.transform,
-        _$this.colors,
-        _$this.stops,
-      ];
+    _$this.begin,
+    _$this.end,
+    _$this.tileMode,
+    _$this.transform,
+    _$this.colors,
+    _$this.stops,
+  ];
 
   /// Returns this instance as a [LinearGradientDto].
   LinearGradientDto get _$this => this as LinearGradientDto;
@@ -108,14 +109,16 @@ class LinearGradientUtility<T extends StyleElement>
     List<ColorDto>? colors,
     List<double>? stops,
   }) {
-    return builder(LinearGradientDto(
-      begin: begin,
-      end: end,
-      tileMode: tileMode,
-      transform: transform,
-      colors: colors,
-      stops: stops,
-    ));
+    return builder(
+      LinearGradientDto(
+        begin: begin,
+        end: end,
+        tileMode: tileMode,
+        transform: transform,
+        colors: colors,
+        stops: stops,
+      ),
+    );
   }
 
   T call({
@@ -180,7 +183,8 @@ mixin _$RadialGradientDto
       focal: _$this.focal ?? defaultValue.focal,
       focalRadius: _$this.focalRadius ?? defaultValue.focalRadius,
       transform: _$this.transform ?? defaultValue.transform,
-      colors: _$this.colors?.map((e) => e.resolve(mix)).toList() ??
+      colors:
+          _$this.colors?.map((e) => e.resolve(mix)).toList() ??
           defaultValue.colors,
       stops: _$this.stops ?? defaultValue.stops,
     );
@@ -216,15 +220,15 @@ mixin _$RadialGradientDto
   /// compare two [RadialGradientDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.center,
-        _$this.radius,
-        _$this.tileMode,
-        _$this.focal,
-        _$this.focalRadius,
-        _$this.transform,
-        _$this.colors,
-        _$this.stops,
-      ];
+    _$this.center,
+    _$this.radius,
+    _$this.tileMode,
+    _$this.focal,
+    _$this.focalRadius,
+    _$this.transform,
+    _$this.colors,
+    _$this.stops,
+  ];
 
   /// Returns this instance as a [RadialGradientDto].
   RadialGradientDto get _$this => this as RadialGradientDto;
@@ -274,16 +278,18 @@ class RadialGradientUtility<T extends StyleElement>
     List<ColorDto>? colors,
     List<double>? stops,
   }) {
-    return builder(RadialGradientDto(
-      center: center,
-      radius: radius,
-      tileMode: tileMode,
-      focal: focal,
-      focalRadius: focalRadius,
-      transform: transform,
-      colors: colors,
-      stops: stops,
-    ));
+    return builder(
+      RadialGradientDto(
+        center: center,
+        radius: radius,
+        tileMode: tileMode,
+        focal: focal,
+        focalRadius: focalRadius,
+        transform: transform,
+        colors: colors,
+        stops: stops,
+      ),
+    );
   }
 
   T call({
@@ -353,7 +359,8 @@ mixin _$SweepGradientDto
       endAngle: _$this.endAngle ?? defaultValue.endAngle,
       tileMode: _$this.tileMode ?? defaultValue.tileMode,
       transform: _$this.transform ?? defaultValue.transform,
-      colors: _$this.colors?.map((e) => e.resolve(mix)).toList() ??
+      colors:
+          _$this.colors?.map((e) => e.resolve(mix)).toList() ??
           defaultValue.colors,
       stops: _$this.stops ?? defaultValue.stops,
     );
@@ -388,14 +395,14 @@ mixin _$SweepGradientDto
   /// compare two [SweepGradientDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.center,
-        _$this.startAngle,
-        _$this.endAngle,
-        _$this.tileMode,
-        _$this.transform,
-        _$this.colors,
-        _$this.stops,
-      ];
+    _$this.center,
+    _$this.startAngle,
+    _$this.endAngle,
+    _$this.tileMode,
+    _$this.transform,
+    _$this.colors,
+    _$this.stops,
+  ];
 
   /// Returns this instance as a [SweepGradientDto].
   SweepGradientDto get _$this => this as SweepGradientDto;
@@ -441,15 +448,17 @@ class SweepGradientUtility<T extends StyleElement>
     List<ColorDto>? colors,
     List<double>? stops,
   }) {
-    return builder(SweepGradientDto(
-      center: center,
-      startAngle: startAngle,
-      endAngle: endAngle,
-      tileMode: tileMode,
-      transform: transform,
-      colors: colors,
-      stops: stops,
-    ));
+    return builder(
+      SweepGradientDto(
+        center: center,
+        startAngle: startAngle,
+        endAngle: endAngle,
+        tileMode: tileMode,
+        transform: transform,
+        colors: colors,
+        stops: stops,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/scalars/scalar_util.g.dart
+++ b/packages/mix/lib/src/attributes/scalars/scalar_util.g.dart
@@ -477,10 +477,14 @@ mixin _$RectUtility<T extends StyleElement> on MixUtility<T, Rect> {
   }
 
   /// Creates a [StyleElement] instance using the [Rect.fromCenter] constructor.
-  T fromCenter(
-      {required Offset center, required double width, required double height}) {
+  T fromCenter({
+    required Offset center,
+    required double width,
+    required double height,
+  }) {
     return builder(
-        Rect.fromCenter(center: center, width: width, height: height));
+      Rect.fromCenter(center: center, width: width, height: height),
+    );
   }
 
   /// Creates a [StyleElement] instance using the [Rect.fromPoints] constructor.
@@ -630,22 +634,35 @@ mixin _$TableColumnWidthUtility<T extends StyleElement>
 mixin _$TableBorderUtility<T extends StyleElement>
     on MixUtility<T, TableBorder> {
   /// Creates a [StyleElement] instance using the [TableBorder.all] constructor.
-  T all(
-      {Color color = const Color(0xFF000000),
-      double width = 1.0,
-      BorderStyle style = BorderStyle.solid,
-      BorderRadius borderRadius = BorderRadius.zero}) {
-    return builder(TableBorder.all(
-        color: color, width: width, style: style, borderRadius: borderRadius));
+  T all({
+    Color color = const Color(0xFF000000),
+    double width = 1.0,
+    BorderStyle style = BorderStyle.solid,
+    BorderRadius borderRadius = BorderRadius.zero,
+  }) {
+    return builder(
+      TableBorder.all(
+        color: color,
+        width: width,
+        style: style,
+        borderRadius: borderRadius,
+      ),
+    );
   }
 
   /// Creates a [StyleElement] instance using the [TableBorder.symmetric] constructor.
-  T symmetric(
-      {BorderSide inside = BorderSide.none,
-      BorderSide outside = BorderSide.none,
-      BorderRadius borderRadius = BorderRadius.zero}) {
-    return builder(TableBorder.symmetric(
-        inside: inside, outside: outside, borderRadius: borderRadius));
+  T symmetric({
+    BorderSide inside = BorderSide.none,
+    BorderSide outside = BorderSide.none,
+    BorderRadius borderRadius = BorderRadius.zero,
+  }) {
+    return builder(
+      TableBorder.symmetric(
+        inside: inside,
+        outside: outside,
+        borderRadius: borderRadius,
+      ),
+    );
   }
 
   /// Creates a [StyleElement] instance with the specified TableBorder value.

--- a/packages/mix/lib/src/attributes/shadow/shadow_dto.g.dart
+++ b/packages/mix/lib/src/attributes/shadow/shadow_dto.g.dart
@@ -51,11 +51,7 @@ mixin _$ShadowDto on Mixable<Shadow>, HasDefaultValue<Shadow> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ShadowDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.blurRadius,
-        _$this.color,
-        _$this.offset,
-      ];
+  List<Object?> get props => [_$this.blurRadius, _$this.color, _$this.offset];
 
   /// Returns this instance as a [ShadowDto].
   ShadowDto get _$this => this as ShadowDto;
@@ -80,28 +76,14 @@ class ShadowUtility<T extends StyleElement>
 
   /// Returns a new [ShadowDto] with the specified properties.
   @override
-  T only({
-    double? blurRadius,
-    ColorDto? color,
-    Offset? offset,
-  }) {
-    return builder(ShadowDto(
-      blurRadius: blurRadius,
-      color: color,
-      offset: offset,
-    ));
+  T only({double? blurRadius, ColorDto? color, Offset? offset}) {
+    return builder(
+      ShadowDto(blurRadius: blurRadius, color: color, offset: offset),
+    );
   }
 
-  T call({
-    double? blurRadius,
-    Color? color,
-    Offset? offset,
-  }) {
-    return only(
-      blurRadius: blurRadius,
-      color: color?.toDto(),
-      offset: offset,
-    );
+  T call({double? blurRadius, Color? color, Offset? offset}) {
+    return only(blurRadius: blurRadius, color: color?.toDto(), offset: offset);
   }
 }
 
@@ -171,11 +153,11 @@ mixin _$BoxShadowDto on Mixable<BoxShadow>, HasDefaultValue<BoxShadow> {
   /// compare two [BoxShadowDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.color,
-        _$this.offset,
-        _$this.blurRadius,
-        _$this.spreadRadius,
-      ];
+    _$this.color,
+    _$this.offset,
+    _$this.blurRadius,
+    _$this.spreadRadius,
+  ];
 
   /// Returns this instance as a [BoxShadowDto].
   BoxShadowDto get _$this => this as BoxShadowDto;
@@ -209,12 +191,14 @@ class BoxShadowUtility<T extends StyleElement>
     double? blurRadius,
     double? spreadRadius,
   }) {
-    return builder(BoxShadowDto(
-      color: color,
-      offset: offset,
-      blurRadius: blurRadius,
-      spreadRadius: spreadRadius,
-    ));
+    return builder(
+      BoxShadowDto(
+        color: color,
+        offset: offset,
+        blurRadius: blurRadius,
+        spreadRadius: spreadRadius,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/spacing/edge_insets_dto.g.dart
+++ b/packages/mix/lib/src/attributes/spacing/edge_insets_dto.g.dart
@@ -36,11 +36,11 @@ mixin _$EdgeInsetsDto on Mixable<EdgeInsets> {
   /// compare two [EdgeInsetsDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.top,
-        _$this.bottom,
-        _$this.left,
-        _$this.right,
-      ];
+    _$this.top,
+    _$this.bottom,
+    _$this.left,
+    _$this.right,
+  ];
 
   /// Returns this instance as a [EdgeInsetsDto].
   EdgeInsetsDto get _$this => this as EdgeInsetsDto;
@@ -74,32 +74,14 @@ class EdgeInsetsUtility<T extends StyleElement>
 
   /// Returns a new [EdgeInsetsDto] with the specified properties.
   @override
-  T only({
-    double? top,
-    double? bottom,
-    double? left,
-    double? right,
-  }) {
-    return builder(EdgeInsetsDto(
-      top: top,
-      bottom: bottom,
-      left: left,
-      right: right,
-    ));
+  T only({double? top, double? bottom, double? left, double? right}) {
+    return builder(
+      EdgeInsetsDto(top: top, bottom: bottom, left: left, right: right),
+    );
   }
 
-  T call({
-    double? top,
-    double? bottom,
-    double? left,
-    double? right,
-  }) {
-    return only(
-      top: top,
-      bottom: bottom,
-      left: left,
-      right: right,
-    );
+  T call({double? top, double? bottom, double? left, double? right}) {
+    return only(top: top, bottom: bottom, left: left, right: right);
   }
 }
 
@@ -107,12 +89,7 @@ class EdgeInsetsUtility<T extends StyleElement>
 extension EdgeInsetsMixExt on EdgeInsets {
   /// Converts this [EdgeInsets] to a [EdgeInsetsDto].
   EdgeInsetsDto toDto() {
-    return EdgeInsetsDto(
-      top: top,
-      bottom: bottom,
-      left: left,
-      right: right,
-    );
+    return EdgeInsetsDto(top: top, bottom: bottom, left: left, right: right);
   }
 }
 
@@ -152,11 +129,11 @@ mixin _$EdgeInsetsDirectionalDto on Mixable<EdgeInsetsDirectional> {
   /// compare two [EdgeInsetsDirectionalDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.top,
-        _$this.bottom,
-        _$this.start,
-        _$this.end,
-      ];
+    _$this.top,
+    _$this.bottom,
+    _$this.start,
+    _$this.end,
+  ];
 
   /// Returns this instance as a [EdgeInsetsDirectionalDto].
   EdgeInsetsDirectionalDto get _$this => this as EdgeInsetsDirectionalDto;
@@ -181,7 +158,7 @@ class EdgeInsetsDirectionalUtility<T extends StyleElement>
   late final end = DoubleUtility((v) => only(end: v));
 
   EdgeInsetsDirectionalUtility(super.builder)
-      : super(valueToDto: (v) => v.toDto());
+    : super(valueToDto: (v) => v.toDto());
 
   /// Creates a [StyleElement] instance using the [EdgeInsetsDirectionalDto.all] constructor.
   T all(double value) => builder(EdgeInsetsDirectionalDto.all(value));
@@ -191,32 +168,19 @@ class EdgeInsetsDirectionalUtility<T extends StyleElement>
 
   /// Returns a new [EdgeInsetsDirectionalDto] with the specified properties.
   @override
-  T only({
-    double? top,
-    double? bottom,
-    double? start,
-    double? end,
-  }) {
-    return builder(EdgeInsetsDirectionalDto(
-      top: top,
-      bottom: bottom,
-      start: start,
-      end: end,
-    ));
+  T only({double? top, double? bottom, double? start, double? end}) {
+    return builder(
+      EdgeInsetsDirectionalDto(
+        top: top,
+        bottom: bottom,
+        start: start,
+        end: end,
+      ),
+    );
   }
 
-  T call({
-    double? top,
-    double? bottom,
-    double? start,
-    double? end,
-  }) {
-    return only(
-      top: top,
-      bottom: bottom,
-      start: start,
-      end: end,
-    );
+  T call({double? top, double? bottom, double? start, double? end}) {
+    return only(top: top, bottom: bottom, start: start, end: end);
   }
 }
 

--- a/packages/mix/lib/src/attributes/strut_style/strut_style_dto.g.dart
+++ b/packages/mix/lib/src/attributes/strut_style/strut_style_dto.g.dart
@@ -47,7 +47,9 @@ mixin _$StrutStyleDto on Mixable<StrutStyle> {
     return StrutStyleDto(
       fontFamily: other.fontFamily ?? _$this.fontFamily,
       fontFamilyFallback: MixHelpers.mergeList(
-          _$this.fontFamilyFallback, other.fontFamilyFallback),
+        _$this.fontFamilyFallback,
+        other.fontFamilyFallback,
+      ),
       fontSize: other.fontSize ?? _$this.fontSize,
       fontWeight: other.fontWeight ?? _$this.fontWeight,
       fontStyle: other.fontStyle ?? _$this.fontStyle,
@@ -63,15 +65,15 @@ mixin _$StrutStyleDto on Mixable<StrutStyle> {
   /// compare two [StrutStyleDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.fontFamily,
-        _$this.fontFamilyFallback,
-        _$this.fontSize,
-        _$this.fontWeight,
-        _$this.fontStyle,
-        _$this.height,
-        _$this.leading,
-        _$this.forceStrutHeight,
-      ];
+    _$this.fontFamily,
+    _$this.fontFamilyFallback,
+    _$this.fontSize,
+    _$this.fontWeight,
+    _$this.fontStyle,
+    _$this.height,
+    _$this.leading,
+    _$this.forceStrutHeight,
+  ];
 
   /// Returns this instance as a [StrutStyleDto].
   StrutStyleDto get _$this => this as StrutStyleDto;
@@ -87,8 +89,9 @@ class StrutStyleUtility<T extends StyleElement>
   late final fontFamily = FontFamilyUtility((v) => only(fontFamily: v));
 
   /// Utility for defining [StrutStyleDto.fontFamilyFallback]
-  late final fontFamilyFallback =
-      ListUtility<T, String>((v) => only(fontFamilyFallback: v));
+  late final fontFamilyFallback = ListUtility<T, String>(
+    (v) => only(fontFamilyFallback: v),
+  );
 
   /// Utility for defining [StrutStyleDto.fontSize]
   late final fontSize = FontSizeUtility((v) => only(fontSize: v));
@@ -122,16 +125,18 @@ class StrutStyleUtility<T extends StyleElement>
     double? leading,
     bool? forceStrutHeight,
   }) {
-    return builder(StrutStyleDto(
-      fontFamily: fontFamily,
-      fontFamilyFallback: fontFamilyFallback,
-      fontSize: fontSize,
-      fontWeight: fontWeight,
-      fontStyle: fontStyle,
-      height: height,
-      leading: leading,
-      forceStrutHeight: forceStrutHeight,
-    ));
+    return builder(
+      StrutStyleDto(
+        fontFamily: fontFamily,
+        fontFamilyFallback: fontFamilyFallback,
+        fontSize: fontSize,
+        fontWeight: fontWeight,
+        fontStyle: fontStyle,
+        height: height,
+        leading: leading,
+        forceStrutHeight: forceStrutHeight,
+      ),
+    );
   }
 
   T call({

--- a/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.g.dart
+++ b/packages/mix/lib/src/attributes/text_height_behavior/text_height_behavior_dto.g.dart
@@ -56,10 +56,10 @@ mixin _$TextHeightBehaviorDto on Mixable<TextHeightBehavior> {
   /// compare two [TextHeightBehaviorDto] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.applyHeightToFirstAscent,
-        _$this.applyHeightToLastDescent,
-        _$this.leadingDistribution,
-      ];
+    _$this.applyHeightToFirstAscent,
+    _$this.applyHeightToLastDescent,
+    _$this.leadingDistribution,
+  ];
 
   /// Returns this instance as a [TextHeightBehaviorDto].
   TextHeightBehaviorDto get _$this => this as TextHeightBehaviorDto;

--- a/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
+++ b/packages/mix/lib/src/attributes/text_style/text_style_dto.g.dart
@@ -59,23 +59,31 @@ mixin _$TextStyleData on Mixable<TextStyle> {
 
     return TextStyleData(
       background: other.background ?? _$this.background,
-      backgroundColor: _$this.backgroundColor?.merge(other.backgroundColor) ??
+      backgroundColor:
+          _$this.backgroundColor?.merge(other.backgroundColor) ??
           other.backgroundColor,
       color: _$this.color?.merge(other.color) ?? other.color,
       debugLabel: other.debugLabel ?? _$this.debugLabel,
       decoration: other.decoration ?? _$this.decoration,
-      decorationColor: _$this.decorationColor?.merge(other.decorationColor) ??
+      decorationColor:
+          _$this.decorationColor?.merge(other.decorationColor) ??
           other.decorationColor,
       decorationStyle: other.decorationStyle ?? _$this.decorationStyle,
       decorationThickness:
           other.decorationThickness ?? _$this.decorationThickness,
       fontFamily: other.fontFamily ?? _$this.fontFamily,
       fontFamilyFallback: MixHelpers.mergeList(
-          _$this.fontFamilyFallback, other.fontFamilyFallback),
-      fontVariations:
-          MixHelpers.mergeList(_$this.fontVariations, other.fontVariations),
-      fontFeatures:
-          MixHelpers.mergeList(_$this.fontFeatures, other.fontFeatures),
+        _$this.fontFamilyFallback,
+        other.fontFamilyFallback,
+      ),
+      fontVariations: MixHelpers.mergeList(
+        _$this.fontVariations,
+        other.fontVariations,
+      ),
+      fontFeatures: MixHelpers.mergeList(
+        _$this.fontFeatures,
+        other.fontFeatures,
+      ),
       fontSize: other.fontSize ?? _$this.fontSize,
       fontStyle: other.fontStyle ?? _$this.fontStyle,
       fontWeight: other.fontWeight ?? _$this.fontWeight,
@@ -94,28 +102,28 @@ mixin _$TextStyleData on Mixable<TextStyle> {
   /// compare two [TextStyleData] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.background,
-        _$this.backgroundColor,
-        _$this.color,
-        _$this.debugLabel,
-        _$this.decoration,
-        _$this.decorationColor,
-        _$this.decorationStyle,
-        _$this.decorationThickness,
-        _$this.fontFamily,
-        _$this.fontFamilyFallback,
-        _$this.fontVariations,
-        _$this.fontFeatures,
-        _$this.fontSize,
-        _$this.fontStyle,
-        _$this.fontWeight,
-        _$this.foreground,
-        _$this.height,
-        _$this.letterSpacing,
-        _$this.shadows,
-        _$this.textBaseline,
-        _$this.wordSpacing,
-      ];
+    _$this.background,
+    _$this.backgroundColor,
+    _$this.color,
+    _$this.debugLabel,
+    _$this.decoration,
+    _$this.decorationColor,
+    _$this.decorationStyle,
+    _$this.decorationThickness,
+    _$this.fontFamily,
+    _$this.fontFamilyFallback,
+    _$this.fontVariations,
+    _$this.fontFeatures,
+    _$this.fontSize,
+    _$this.fontStyle,
+    _$this.fontWeight,
+    _$this.foreground,
+    _$this.height,
+    _$this.letterSpacing,
+    _$this.shadows,
+    _$this.textBaseline,
+    _$this.wordSpacing,
+  ];
 
   /// Returns this instance as a [TextStyleData].
   TextStyleData get _$this => this as TextStyleData;
@@ -135,9 +143,7 @@ mixin _$TextStyleDto on Mixable<TextStyle> {
   TextStyleDto merge(TextStyleDto? other) {
     if (other == null) return _$this;
 
-    return TextStyleDto._(
-      value: [..._$this.value, ...other.value],
-    );
+    return TextStyleDto._(value: [..._$this.value, ...other.value]);
   }
 
   /// The list of properties that constitute the state of this [TextStyleDto].
@@ -145,9 +151,7 @@ mixin _$TextStyleDto on Mixable<TextStyle> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [TextStyleDto] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.value,
-      ];
+  List<Object?> get props => [_$this.value];
 
   /// Returns this instance as a [TextStyleDto].
   TextStyleDto get _$this => this as TextStyleDto;

--- a/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/align_widget_modifier.g.dart
@@ -46,10 +46,16 @@ mixin _$AlignModifierSpec on WidgetModifierSpec<AlignModifierSpec> {
 
     return AlignModifierSpec(
       alignment: AlignmentGeometry.lerp(_$this.alignment, other.alignment, t),
-      widthFactor:
-          MixHelpers.lerpDouble(_$this.widthFactor, other.widthFactor, t),
-      heightFactor:
-          MixHelpers.lerpDouble(_$this.heightFactor, other.heightFactor, t),
+      widthFactor: MixHelpers.lerpDouble(
+        _$this.widthFactor,
+        other.widthFactor,
+        t,
+      ),
+      heightFactor: MixHelpers.lerpDouble(
+        _$this.heightFactor,
+        other.heightFactor,
+        t,
+      ),
     );
   }
 
@@ -59,20 +65,31 @@ mixin _$AlignModifierSpec on WidgetModifierSpec<AlignModifierSpec> {
   /// compare two [AlignModifierSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.alignment,
-        _$this.widthFactor,
-        _$this.heightFactor,
-      ];
+    _$this.alignment,
+    _$this.widthFactor,
+    _$this.heightFactor,
+  ];
 
   AlignModifierSpec get _$this => this as AlignModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
-    properties.add(DiagnosticsProperty('widthFactor', _$this.widthFactor,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('heightFactor', _$this.heightFactor,
-        defaultValue: null));
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'widthFactor',
+        _$this.widthFactor,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'heightFactor',
+        _$this.heightFactor,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -84,7 +101,8 @@ mixin _$AlignModifierSpec on WidgetModifierSpec<AlignModifierSpec> {
 /// Use this class to configure the attributes of a [AlignModifierSpec] and pass it to
 /// the [AlignModifierSpec] constructor.
 class AlignModifierSpecAttribute
-    extends WidgetModifierSpecAttribute<AlignModifierSpec> with Diagnosticable {
+    extends WidgetModifierSpecAttribute<AlignModifierSpec>
+    with Diagnosticable {
   final AlignmentGeometry? alignment;
   final double? widthFactor;
   final double? heightFactor;
@@ -136,21 +154,20 @@ class AlignModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [AlignModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        alignment,
-        widthFactor,
-        heightFactor,
-      ];
+  List<Object?> get props => [alignment, widthFactor, heightFactor];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('widthFactor', widthFactor, defaultValue: null));
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('heightFactor', heightFactor, defaultValue: null));
+      DiagnosticsProperty('widthFactor', widthFactor, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('heightFactor', heightFactor, defaultValue: null),
+    );
   }
 }
 
@@ -159,10 +176,7 @@ class AlignModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [AlignModifierSpec] specifications.
 class AlignModifierSpecTween extends Tween<AlignModifierSpec?> {
-  AlignModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  AlignModifierSpecTween({super.begin, super.end});
 
   @override
   AlignModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_widget_modifier.g.dart
@@ -13,12 +13,8 @@ mixin _$AspectRatioModifierSpec on WidgetModifierSpec<AspectRatioModifierSpec> {
   /// Creates a copy of this [AspectRatioModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  AspectRatioModifierSpec copyWith({
-    double? aspectRatio,
-  }) {
-    return AspectRatioModifierSpec(
-      aspectRatio ?? _$this.aspectRatio,
-    );
+  AspectRatioModifierSpec copyWith({double? aspectRatio}) {
+    return AspectRatioModifierSpec(aspectRatio ?? _$this.aspectRatio);
   }
 
   /// Linearly interpolates between this [AspectRatioModifierSpec] and another [AspectRatioModifierSpec] based on the given parameter [t].
@@ -49,15 +45,18 @@ mixin _$AspectRatioModifierSpec on WidgetModifierSpec<AspectRatioModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [AspectRatioModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.aspectRatio,
-      ];
+  List<Object?> get props => [_$this.aspectRatio];
 
   AspectRatioModifierSpec get _$this => this as AspectRatioModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty('aspectRatio', _$this.aspectRatio,
-        defaultValue: null));
+    properties.add(
+      DiagnosticsProperty(
+        'aspectRatio',
+        _$this.aspectRatio,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -73,9 +72,7 @@ class AspectRatioModifierSpecAttribute
     with Diagnosticable {
   final double? aspectRatio;
 
-  const AspectRatioModifierSpecAttribute({
-    this.aspectRatio,
-  });
+  const AspectRatioModifierSpecAttribute({this.aspectRatio});
 
   /// Resolves to [AspectRatioModifierSpec] using the provided [MixData].
   ///
@@ -87,9 +84,7 @@ class AspectRatioModifierSpecAttribute
   /// ```
   @override
   AspectRatioModifierSpec resolve(MixData mix) {
-    return AspectRatioModifierSpec(
-      aspectRatio,
-    );
+    return AspectRatioModifierSpec(aspectRatio);
   }
 
   /// Merges the properties of this [AspectRatioModifierSpecAttribute] with the properties of [other].
@@ -102,7 +97,8 @@ class AspectRatioModifierSpecAttribute
   /// to the values from this instance.
   @override
   AspectRatioModifierSpecAttribute merge(
-      AspectRatioModifierSpecAttribute? other) {
+    AspectRatioModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return AspectRatioModifierSpecAttribute(
@@ -115,15 +111,14 @@ class AspectRatioModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [AspectRatioModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        aspectRatio,
-      ];
+  List<Object?> get props => [aspectRatio];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty('aspectRatio', aspectRatio, defaultValue: null));
+      DiagnosticsProperty('aspectRatio', aspectRatio, defaultValue: null),
+    );
   }
 }
 
@@ -132,10 +127,7 @@ class AspectRatioModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [AspectRatioModifierSpec] specifications.
 class AspectRatioModifierSpecTween extends Tween<AspectRatioModifierSpec?> {
-  AspectRatioModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  AspectRatioModifierSpecTween({super.begin, super.end});
 
   @override
   AspectRatioModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/clip_widget_modifier.g.dart
@@ -54,18 +54,21 @@ mixin _$ClipOvalModifierSpec on WidgetModifierSpec<ClipOvalModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipOvalModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.clipper,
-        _$this.clipBehavior,
-      ];
+  List<Object?> get props => [_$this.clipper, _$this.clipBehavior];
 
   ClipOvalModifierSpec get _$this => this as ClipOvalModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -82,10 +85,7 @@ class ClipOvalModifierSpecAttribute
   final CustomClipper<Rect>? clipper;
   final Clip? clipBehavior;
 
-  const ClipOvalModifierSpecAttribute({
-    this.clipper,
-    this.clipBehavior,
-  });
+  const ClipOvalModifierSpecAttribute({this.clipper, this.clipBehavior});
 
   /// Resolves to [ClipOvalModifierSpec] using the provided [MixData].
   ///
@@ -97,10 +97,7 @@ class ClipOvalModifierSpecAttribute
   /// ```
   @override
   ClipOvalModifierSpec resolve(MixData mix) {
-    return ClipOvalModifierSpec(
-      clipper: clipper,
-      clipBehavior: clipBehavior,
-    );
+    return ClipOvalModifierSpec(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   /// Merges the properties of this [ClipOvalModifierSpecAttribute] with the properties of [other].
@@ -126,17 +123,15 @@ class ClipOvalModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipOvalModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        clipper,
-        clipBehavior,
-      ];
+  List<Object?> get props => [clipper, clipBehavior];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('clipper', clipper, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -145,10 +140,7 @@ class ClipOvalModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ClipOvalModifierSpec] specifications.
 class ClipOvalModifierSpecTween extends Tween<ClipOvalModifierSpec?> {
-  ClipOvalModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ClipOvalModifierSpecTween({super.begin, super.end});
 
   @override
   ClipOvalModifierSpec lerp(double t) {
@@ -210,18 +202,21 @@ mixin _$ClipRectModifierSpec on WidgetModifierSpec<ClipRectModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipRectModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.clipper,
-        _$this.clipBehavior,
-      ];
+  List<Object?> get props => [_$this.clipper, _$this.clipBehavior];
 
   ClipRectModifierSpec get _$this => this as ClipRectModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -238,10 +233,7 @@ class ClipRectModifierSpecAttribute
   final CustomClipper<Rect>? clipper;
   final Clip? clipBehavior;
 
-  const ClipRectModifierSpecAttribute({
-    this.clipper,
-    this.clipBehavior,
-  });
+  const ClipRectModifierSpecAttribute({this.clipper, this.clipBehavior});
 
   /// Resolves to [ClipRectModifierSpec] using the provided [MixData].
   ///
@@ -253,10 +245,7 @@ class ClipRectModifierSpecAttribute
   /// ```
   @override
   ClipRectModifierSpec resolve(MixData mix) {
-    return ClipRectModifierSpec(
-      clipper: clipper,
-      clipBehavior: clipBehavior,
-    );
+    return ClipRectModifierSpec(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   /// Merges the properties of this [ClipRectModifierSpecAttribute] with the properties of [other].
@@ -282,17 +271,15 @@ class ClipRectModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipRectModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        clipper,
-        clipBehavior,
-      ];
+  List<Object?> get props => [clipper, clipBehavior];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('clipper', clipper, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -301,10 +288,7 @@ class ClipRectModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ClipRectModifierSpec] specifications.
 class ClipRectModifierSpecTween extends Tween<ClipRectModifierSpec?> {
-  ClipRectModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ClipRectModifierSpecTween({super.begin, super.end});
 
   @override
   ClipRectModifierSpec lerp(double t) {
@@ -359,8 +343,11 @@ mixin _$ClipRRectModifierSpec on WidgetModifierSpec<ClipRRectModifierSpec> {
     if (other == null) return _$this;
 
     return ClipRRectModifierSpec(
-      borderRadius:
-          BorderRadiusGeometry.lerp(_$this.borderRadius, other.borderRadius, t),
+      borderRadius: BorderRadiusGeometry.lerp(
+        _$this.borderRadius,
+        other.borderRadius,
+        t,
+      ),
       clipper: t < 0.5 ? _$this.clipper : other.clipper,
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
     );
@@ -372,20 +359,31 @@ mixin _$ClipRRectModifierSpec on WidgetModifierSpec<ClipRRectModifierSpec> {
   /// compare two [ClipRRectModifierSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.borderRadius,
-        _$this.clipper,
-        _$this.clipBehavior,
-      ];
+    _$this.borderRadius,
+    _$this.clipper,
+    _$this.clipBehavior,
+  ];
 
   ClipRRectModifierSpec get _$this => this as ClipRRectModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty('borderRadius', _$this.borderRadius,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty(
+        'borderRadius',
+        _$this.borderRadius,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -451,20 +449,18 @@ class ClipRRectModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipRRectModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        borderRadius,
-        clipper,
-        clipBehavior,
-      ];
+  List<Object?> get props => [borderRadius, clipper, clipBehavior];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty('borderRadius', borderRadius, defaultValue: null));
+      DiagnosticsProperty('borderRadius', borderRadius, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('clipper', clipper, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -473,10 +469,7 @@ class ClipRRectModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ClipRRectModifierSpec] specifications.
 class ClipRRectModifierSpecTween extends Tween<ClipRRectModifierSpec?> {
-  ClipRRectModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ClipRRectModifierSpecTween({super.begin, super.end});
 
   @override
   ClipRRectModifierSpec lerp(double t) {
@@ -538,18 +531,21 @@ mixin _$ClipPathModifierSpec on WidgetModifierSpec<ClipPathModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipPathModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.clipper,
-        _$this.clipBehavior,
-      ];
+  List<Object?> get props => [_$this.clipper, _$this.clipBehavior];
 
   ClipPathModifierSpec get _$this => this as ClipPathModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty('clipper', _$this.clipper, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -566,10 +562,7 @@ class ClipPathModifierSpecAttribute
   final CustomClipper<Path>? clipper;
   final Clip? clipBehavior;
 
-  const ClipPathModifierSpecAttribute({
-    this.clipper,
-    this.clipBehavior,
-  });
+  const ClipPathModifierSpecAttribute({this.clipper, this.clipBehavior});
 
   /// Resolves to [ClipPathModifierSpec] using the provided [MixData].
   ///
@@ -581,10 +574,7 @@ class ClipPathModifierSpecAttribute
   /// ```
   @override
   ClipPathModifierSpec resolve(MixData mix) {
-    return ClipPathModifierSpec(
-      clipper: clipper,
-      clipBehavior: clipBehavior,
-    );
+    return ClipPathModifierSpec(clipper: clipper, clipBehavior: clipBehavior);
   }
 
   /// Merges the properties of this [ClipPathModifierSpecAttribute] with the properties of [other].
@@ -610,17 +600,15 @@ class ClipPathModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipPathModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        clipper,
-        clipBehavior,
-      ];
+  List<Object?> get props => [clipper, clipBehavior];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('clipper', clipper, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -629,10 +617,7 @@ class ClipPathModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ClipPathModifierSpec] specifications.
 class ClipPathModifierSpecTween extends Tween<ClipPathModifierSpec?> {
-  ClipPathModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ClipPathModifierSpecTween({super.begin, super.end});
 
   @override
   ClipPathModifierSpec lerp(double t) {
@@ -654,9 +639,7 @@ mixin _$ClipTriangleModifierSpec
   /// Creates a copy of this [ClipTriangleModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  ClipTriangleModifierSpec copyWith({
-    Clip? clipBehavior,
-  }) {
+  ClipTriangleModifierSpec copyWith({Clip? clipBehavior}) {
     return ClipTriangleModifierSpec(
       clipBehavior: clipBehavior ?? _$this.clipBehavior,
     );
@@ -692,15 +675,18 @@ mixin _$ClipTriangleModifierSpec
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipTriangleModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.clipBehavior,
-      ];
+  List<Object?> get props => [_$this.clipBehavior];
 
   ClipTriangleModifierSpec get _$this => this as ClipTriangleModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -716,9 +702,7 @@ class ClipTriangleModifierSpecAttribute
     with Diagnosticable {
   final Clip? clipBehavior;
 
-  const ClipTriangleModifierSpecAttribute({
-    this.clipBehavior,
-  });
+  const ClipTriangleModifierSpecAttribute({this.clipBehavior});
 
   /// Resolves to [ClipTriangleModifierSpec] using the provided [MixData].
   ///
@@ -730,9 +714,7 @@ class ClipTriangleModifierSpecAttribute
   /// ```
   @override
   ClipTriangleModifierSpec resolve(MixData mix) {
-    return ClipTriangleModifierSpec(
-      clipBehavior: clipBehavior,
-    );
+    return ClipTriangleModifierSpec(clipBehavior: clipBehavior);
   }
 
   /// Merges the properties of this [ClipTriangleModifierSpecAttribute] with the properties of [other].
@@ -745,7 +727,8 @@ class ClipTriangleModifierSpecAttribute
   /// to the values from this instance.
   @override
   ClipTriangleModifierSpecAttribute merge(
-      ClipTriangleModifierSpecAttribute? other) {
+    ClipTriangleModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return ClipTriangleModifierSpecAttribute(
@@ -758,15 +741,14 @@ class ClipTriangleModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [ClipTriangleModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        clipBehavior,
-      ];
+  List<Object?> get props => [clipBehavior];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -775,10 +757,7 @@ class ClipTriangleModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ClipTriangleModifierSpec] specifications.
 class ClipTriangleModifierSpecTween extends Tween<ClipTriangleModifierSpec?> {
-  ClipTriangleModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ClipTriangleModifierSpecTween({super.begin, super.end});
 
   @override
   ClipTriangleModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/flexible_widget_modifier.g.dart
@@ -13,10 +13,7 @@ mixin _$FlexibleModifierSpec on WidgetModifierSpec<FlexibleModifierSpec> {
   /// Creates a copy of this [FlexibleModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  FlexibleModifierSpec copyWith({
-    int? flex,
-    FlexFit? fit,
-  }) {
+  FlexibleModifierSpec copyWith({int? flex, FlexFit? fit}) {
     return FlexibleModifierSpec(
       flex: flex ?? _$this.flex,
       fit: fit ?? _$this.fit,
@@ -54,16 +51,14 @@ mixin _$FlexibleModifierSpec on WidgetModifierSpec<FlexibleModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [FlexibleModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.flex,
-        _$this.fit,
-      ];
+  List<Object?> get props => [_$this.flex, _$this.fit];
 
   FlexibleModifierSpec get _$this => this as FlexibleModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties
-        .add(DiagnosticsProperty('flex', _$this.flex, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('flex', _$this.flex, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('fit', _$this.fit, defaultValue: null));
   }
 }
@@ -81,10 +76,7 @@ class FlexibleModifierSpecAttribute
   final int? flex;
   final FlexFit? fit;
 
-  const FlexibleModifierSpecAttribute({
-    this.flex,
-    this.fit,
-  });
+  const FlexibleModifierSpecAttribute({this.flex, this.fit});
 
   /// Resolves to [FlexibleModifierSpec] using the provided [MixData].
   ///
@@ -96,10 +88,7 @@ class FlexibleModifierSpecAttribute
   /// ```
   @override
   FlexibleModifierSpec resolve(MixData mix) {
-    return FlexibleModifierSpec(
-      flex: flex,
-      fit: fit,
-    );
+    return FlexibleModifierSpec(flex: flex, fit: fit);
   }
 
   /// Merges the properties of this [FlexibleModifierSpecAttribute] with the properties of [other].
@@ -125,10 +114,7 @@ class FlexibleModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [FlexibleModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        flex,
-        fit,
-      ];
+  List<Object?> get props => [flex, fit];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -143,10 +129,7 @@ class FlexibleModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [FlexibleModifierSpec] specifications.
 class FlexibleModifierSpecTween extends Tween<FlexibleModifierSpec?> {
-  FlexibleModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  FlexibleModifierSpecTween({super.begin, super.end});
 
   @override
   FlexibleModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_widget_modifier.g.dart
@@ -43,14 +43,22 @@ mixin _$FractionallySizedBoxModifierSpec
   /// different [FractionallySizedBoxModifierSpec] configurations.
   @override
   FractionallySizedBoxModifierSpec lerp(
-      FractionallySizedBoxModifierSpec? other, double t) {
+    FractionallySizedBoxModifierSpec? other,
+    double t,
+  ) {
     if (other == null) return _$this;
 
     return FractionallySizedBoxModifierSpec(
-      widthFactor:
-          MixHelpers.lerpDouble(_$this.widthFactor, other.widthFactor, t),
-      heightFactor:
-          MixHelpers.lerpDouble(_$this.heightFactor, other.heightFactor, t),
+      widthFactor: MixHelpers.lerpDouble(
+        _$this.widthFactor,
+        other.widthFactor,
+        t,
+      ),
+      heightFactor: MixHelpers.lerpDouble(
+        _$this.heightFactor,
+        other.heightFactor,
+        t,
+      ),
       alignment: AlignmentGeometry.lerp(_$this.alignment, other.alignment, t),
     );
   }
@@ -61,21 +69,32 @@ mixin _$FractionallySizedBoxModifierSpec
   /// compare two [FractionallySizedBoxModifierSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.widthFactor,
-        _$this.heightFactor,
-        _$this.alignment,
-      ];
+    _$this.widthFactor,
+    _$this.heightFactor,
+    _$this.alignment,
+  ];
 
   FractionallySizedBoxModifierSpec get _$this =>
       this as FractionallySizedBoxModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty('widthFactor', _$this.widthFactor,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('heightFactor', _$this.heightFactor,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
+      DiagnosticsProperty(
+        'widthFactor',
+        _$this.widthFactor,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'heightFactor',
+        _$this.heightFactor,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
   }
 }
 
@@ -126,7 +145,8 @@ class FractionallySizedBoxModifierSpecAttribute
   /// to the values from this instance.
   @override
   FractionallySizedBoxModifierSpecAttribute merge(
-      FractionallySizedBoxModifierSpecAttribute? other) {
+    FractionallySizedBoxModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return FractionallySizedBoxModifierSpecAttribute(
@@ -141,21 +161,20 @@ class FractionallySizedBoxModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [FractionallySizedBoxModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        widthFactor,
-        heightFactor,
-        alignment,
-      ];
+  List<Object?> get props => [widthFactor, heightFactor, alignment];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty('widthFactor', widthFactor, defaultValue: null));
+      DiagnosticsProperty('widthFactor', widthFactor, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('heightFactor', heightFactor, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
+      DiagnosticsProperty('heightFactor', heightFactor, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
   }
 }
 
@@ -165,10 +184,7 @@ class FractionallySizedBoxModifierSpecAttribute
 /// different [FractionallySizedBoxModifierSpec] specifications.
 class FractionallySizedBoxModifierSpecTween
     extends Tween<FractionallySizedBoxModifierSpec?> {
-  FractionallySizedBoxModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  FractionallySizedBoxModifierSpecTween({super.begin, super.end});
 
   @override
   FractionallySizedBoxModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/internal/reset_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/internal/reset_modifier.g.dart
@@ -57,7 +57,8 @@ mixin _$ResetModifierSpec on WidgetModifierSpec<ResetModifierSpec> {
 /// Use this class to configure the attributes of a [ResetModifierSpec] and pass it to
 /// the [ResetModifierSpec] constructor.
 class ResetModifierSpecAttribute
-    extends WidgetModifierSpecAttribute<ResetModifierSpec> with Diagnosticable {
+    extends WidgetModifierSpecAttribute<ResetModifierSpec>
+    with Diagnosticable {
   const ResetModifierSpecAttribute();
 
   /// Resolves to [ResetModifierSpec] using the provided [MixData].
@@ -107,10 +108,7 @@ class ResetModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ResetModifierSpec] specifications.
 class ResetModifierSpecTween extends Tween<ResetModifierSpec?> {
-  ResetModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ResetModifierSpecTween({super.begin, super.end});
 
   @override
   ResetModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_widget_modifier.g.dart
@@ -33,7 +33,9 @@ mixin _$IntrinsicHeightModifierSpec
   /// different [IntrinsicHeightModifierSpec] configurations.
   @override
   IntrinsicHeightModifierSpec lerp(
-      IntrinsicHeightModifierSpec? other, double t) {
+    IntrinsicHeightModifierSpec? other,
+    double t,
+  ) {
     if (other == null) return _$this;
 
     return const IntrinsicHeightModifierSpec();
@@ -87,7 +89,8 @@ class IntrinsicHeightModifierSpecAttribute
   /// to the values from this instance.
   @override
   IntrinsicHeightModifierSpecAttribute merge(
-      IntrinsicHeightModifierSpecAttribute? other) {
+    IntrinsicHeightModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return other;
@@ -112,10 +115,7 @@ class IntrinsicHeightModifierSpecAttribute
 /// different [IntrinsicHeightModifierSpec] specifications.
 class IntrinsicHeightModifierSpecTween
     extends Tween<IntrinsicHeightModifierSpec?> {
-  IntrinsicHeightModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  IntrinsicHeightModifierSpecTween({super.begin, super.end});
 
   @override
   IntrinsicHeightModifierSpec lerp(double t) {
@@ -209,7 +209,8 @@ class IntrinsicWidthModifierSpecAttribute
   /// to the values from this instance.
   @override
   IntrinsicWidthModifierSpecAttribute merge(
-      IntrinsicWidthModifierSpecAttribute? other) {
+    IntrinsicWidthModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return other;
@@ -234,10 +235,7 @@ class IntrinsicWidthModifierSpecAttribute
 /// different [IntrinsicWidthModifierSpec] specifications.
 class IntrinsicWidthModifierSpecTween
     extends Tween<IntrinsicWidthModifierSpec?> {
-  IntrinsicWidthModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  IntrinsicWidthModifierSpecTween({super.begin, super.end});
 
   @override
   IntrinsicWidthModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/mouse_cursor_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/mouse_cursor_modifier.g.dart
@@ -14,9 +14,7 @@ mixin _$MouseCursorDecoratorSpec
   /// Creates a copy of this [MouseCursorDecoratorSpec] but with the given fields
   /// replaced with the new values.
   @override
-  MouseCursorDecoratorSpec copyWith({
-    MouseCursor? mouseCursor,
-  }) {
+  MouseCursorDecoratorSpec copyWith({MouseCursor? mouseCursor}) {
     return MouseCursorDecoratorSpec(
       mouseCursor: mouseCursor ?? _$this.mouseCursor,
     );
@@ -52,9 +50,7 @@ mixin _$MouseCursorDecoratorSpec
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [MouseCursorDecoratorSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.mouseCursor,
-      ];
+  List<Object?> get props => [_$this.mouseCursor];
 
   MouseCursorDecoratorSpec get _$this => this as MouseCursorDecoratorSpec;
 }
@@ -70,9 +66,7 @@ class MouseCursorDecoratorSpecAttribute
     extends WidgetModifierSpecAttribute<MouseCursorDecoratorSpec> {
   final MouseCursor? mouseCursor;
 
-  const MouseCursorDecoratorSpecAttribute({
-    this.mouseCursor,
-  });
+  const MouseCursorDecoratorSpecAttribute({this.mouseCursor});
 
   /// Resolves to [MouseCursorDecoratorSpec] using the provided [MixData].
   ///
@@ -84,9 +78,7 @@ class MouseCursorDecoratorSpecAttribute
   /// ```
   @override
   MouseCursorDecoratorSpec resolve(MixData mix) {
-    return MouseCursorDecoratorSpec(
-      mouseCursor: mouseCursor,
-    );
+    return MouseCursorDecoratorSpec(mouseCursor: mouseCursor);
   }
 
   /// Merges the properties of this [MouseCursorDecoratorSpecAttribute] with the properties of [other].
@@ -99,7 +91,8 @@ class MouseCursorDecoratorSpecAttribute
   /// to the values from this instance.
   @override
   MouseCursorDecoratorSpecAttribute merge(
-      MouseCursorDecoratorSpecAttribute? other) {
+    MouseCursorDecoratorSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return MouseCursorDecoratorSpecAttribute(
@@ -112,9 +105,7 @@ class MouseCursorDecoratorSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [MouseCursorDecoratorSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        mouseCursor,
-      ];
+  List<Object?> get props => [mouseCursor];
 }
 
 /// A tween that interpolates between two [MouseCursorDecoratorSpec] instances.
@@ -122,10 +113,7 @@ class MouseCursorDecoratorSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [MouseCursorDecoratorSpec] specifications.
 class MouseCursorDecoratorSpecTween extends Tween<MouseCursorDecoratorSpec?> {
-  MouseCursorDecoratorSpecTween({
-    super.begin,
-    super.end,
-  });
+  MouseCursorDecoratorSpecTween({super.begin, super.end});
 
   @override
   MouseCursorDecoratorSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/opacity_widget_modifier.g.dart
@@ -13,12 +13,8 @@ mixin _$OpacityModifierSpec on WidgetModifierSpec<OpacityModifierSpec> {
   /// Creates a copy of this [OpacityModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  OpacityModifierSpec copyWith({
-    double? opacity,
-  }) {
-    return OpacityModifierSpec(
-      opacity ?? _$this.opacity,
-    );
+  OpacityModifierSpec copyWith({double? opacity}) {
+    return OpacityModifierSpec(opacity ?? _$this.opacity);
   }
 
   /// Linearly interpolates between this [OpacityModifierSpec] and another [OpacityModifierSpec] based on the given parameter [t].
@@ -49,15 +45,14 @@ mixin _$OpacityModifierSpec on WidgetModifierSpec<OpacityModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [OpacityModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.opacity,
-      ];
+  List<Object?> get props => [_$this.opacity];
 
   OpacityModifierSpec get _$this => this as OpacityModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('opacity', _$this.opacity, defaultValue: null));
+      DiagnosticsProperty('opacity', _$this.opacity, defaultValue: null),
+    );
   }
 }
 
@@ -73,9 +68,7 @@ class OpacityModifierSpecAttribute
     with Diagnosticable {
   final double? opacity;
 
-  const OpacityModifierSpecAttribute({
-    this.opacity,
-  });
+  const OpacityModifierSpecAttribute({this.opacity});
 
   /// Resolves to [OpacityModifierSpec] using the provided [MixData].
   ///
@@ -87,9 +80,7 @@ class OpacityModifierSpecAttribute
   /// ```
   @override
   OpacityModifierSpec resolve(MixData mix) {
-    return OpacityModifierSpec(
-      opacity,
-    );
+    return OpacityModifierSpec(opacity);
   }
 
   /// Merges the properties of this [OpacityModifierSpecAttribute] with the properties of [other].
@@ -104,9 +95,7 @@ class OpacityModifierSpecAttribute
   OpacityModifierSpecAttribute merge(OpacityModifierSpecAttribute? other) {
     if (other == null) return this;
 
-    return OpacityModifierSpecAttribute(
-      opacity: other.opacity ?? opacity,
-    );
+    return OpacityModifierSpecAttribute(opacity: other.opacity ?? opacity);
   }
 
   /// The list of properties that constitute the state of this [OpacityModifierSpecAttribute].
@@ -114,9 +103,7 @@ class OpacityModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [OpacityModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        opacity,
-      ];
+  List<Object?> get props => [opacity];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -130,10 +117,7 @@ class OpacityModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [OpacityModifierSpec] specifications.
 class OpacityModifierSpecTween extends Tween<OpacityModifierSpec?> {
-  OpacityModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  OpacityModifierSpecTween({super.begin, super.end});
 
   @override
   OpacityModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/padding_widget_modifier.g.dart
@@ -13,12 +13,8 @@ mixin _$PaddingModifierSpec on WidgetModifierSpec<PaddingModifierSpec> {
   /// Creates a copy of this [PaddingModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  PaddingModifierSpec copyWith({
-    EdgeInsetsGeometry? padding,
-  }) {
-    return PaddingModifierSpec(
-      padding ?? _$this.padding,
-    );
+  PaddingModifierSpec copyWith({EdgeInsetsGeometry? padding}) {
+    return PaddingModifierSpec(padding ?? _$this.padding);
   }
 
   /// Linearly interpolates between this [PaddingModifierSpec] and another [PaddingModifierSpec] based on the given parameter [t].
@@ -49,15 +45,14 @@ mixin _$PaddingModifierSpec on WidgetModifierSpec<PaddingModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [PaddingModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.padding,
-      ];
+  List<Object?> get props => [_$this.padding];
 
   PaddingModifierSpec get _$this => this as PaddingModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('padding', _$this.padding, defaultValue: null));
+      DiagnosticsProperty('padding', _$this.padding, defaultValue: null),
+    );
   }
 }
 
@@ -73,9 +68,7 @@ class PaddingModifierSpecAttribute
     with Diagnosticable {
   final EdgeInsetsGeometryDto? padding;
 
-  const PaddingModifierSpecAttribute({
-    this.padding,
-  });
+  const PaddingModifierSpecAttribute({this.padding});
 
   /// Resolves to [PaddingModifierSpec] using the provided [MixData].
   ///
@@ -87,9 +80,7 @@ class PaddingModifierSpecAttribute
   /// ```
   @override
   PaddingModifierSpec resolve(MixData mix) {
-    return PaddingModifierSpec(
-      padding?.resolve(mix),
-    );
+    return PaddingModifierSpec(padding?.resolve(mix));
   }
 
   /// Merges the properties of this [PaddingModifierSpecAttribute] with the properties of [other].
@@ -114,9 +105,7 @@ class PaddingModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [PaddingModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        padding,
-      ];
+  List<Object?> get props => [padding];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -154,12 +143,8 @@ class PaddingModifierSpecUtility<T extends StyleElement>
 
   /// Returns a new [PaddingModifierSpecAttribute] with the specified properties.
   @override
-  T only({
-    EdgeInsetsGeometryDto? padding,
-  }) {
-    return builder(PaddingModifierSpecAttribute(
-      padding: padding,
-    ));
+  T only({EdgeInsetsGeometryDto? padding}) {
+    return builder(PaddingModifierSpecAttribute(padding: padding));
   }
 }
 
@@ -168,10 +153,7 @@ class PaddingModifierSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [PaddingModifierSpec] specifications.
 class PaddingModifierSpecTween extends Tween<PaddingModifierSpec?> {
-  PaddingModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  PaddingModifierSpecTween({super.begin, super.end});
 
   @override
   PaddingModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_widget_modifier.g.dart
@@ -13,12 +13,8 @@ mixin _$RotatedBoxModifierSpec on WidgetModifierSpec<RotatedBoxModifierSpec> {
   /// Creates a copy of this [RotatedBoxModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  RotatedBoxModifierSpec copyWith({
-    int? quarterTurns,
-  }) {
-    return RotatedBoxModifierSpec(
-      quarterTurns ?? _$this.quarterTurns,
-    );
+  RotatedBoxModifierSpec copyWith({int? quarterTurns}) {
+    return RotatedBoxModifierSpec(quarterTurns ?? _$this.quarterTurns);
   }
 
   /// The list of properties that constitute the state of this [RotatedBoxModifierSpec].
@@ -26,15 +22,18 @@ mixin _$RotatedBoxModifierSpec on WidgetModifierSpec<RotatedBoxModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [RotatedBoxModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.quarterTurns,
-      ];
+  List<Object?> get props => [_$this.quarterTurns];
 
   RotatedBoxModifierSpec get _$this => this as RotatedBoxModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty('quarterTurns', _$this.quarterTurns,
-        defaultValue: null));
+    properties.add(
+      DiagnosticsProperty(
+        'quarterTurns',
+        _$this.quarterTurns,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -50,9 +49,7 @@ class RotatedBoxModifierSpecAttribute
     with Diagnosticable {
   final int? quarterTurns;
 
-  const RotatedBoxModifierSpecAttribute({
-    this.quarterTurns,
-  });
+  const RotatedBoxModifierSpecAttribute({this.quarterTurns});
 
   /// Resolves to [RotatedBoxModifierSpec] using the provided [MixData].
   ///
@@ -64,9 +61,7 @@ class RotatedBoxModifierSpecAttribute
   /// ```
   @override
   RotatedBoxModifierSpec resolve(MixData mix) {
-    return RotatedBoxModifierSpec(
-      quarterTurns,
-    );
+    return RotatedBoxModifierSpec(quarterTurns);
   }
 
   /// Merges the properties of this [RotatedBoxModifierSpecAttribute] with the properties of [other].
@@ -79,7 +74,8 @@ class RotatedBoxModifierSpecAttribute
   /// to the values from this instance.
   @override
   RotatedBoxModifierSpecAttribute merge(
-      RotatedBoxModifierSpecAttribute? other) {
+    RotatedBoxModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return RotatedBoxModifierSpecAttribute(
@@ -92,15 +88,14 @@ class RotatedBoxModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [RotatedBoxModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        quarterTurns,
-      ];
+  List<Object?> get props => [quarterTurns];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(
-        DiagnosticsProperty('quarterTurns', quarterTurns, defaultValue: null));
+      DiagnosticsProperty('quarterTurns', quarterTurns, defaultValue: null),
+    );
   }
 }
 
@@ -109,10 +104,7 @@ class RotatedBoxModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [RotatedBoxModifierSpec] specifications.
 class RotatedBoxModifierSpecTween extends Tween<RotatedBoxModifierSpec?> {
-  RotatedBoxModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  RotatedBoxModifierSpecTween({super.begin, super.end});
 
   @override
   RotatedBoxModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/scroll_view_widget_modifier.g.dart
@@ -65,27 +65,39 @@ mixin _$ScrollViewModifierSpec on WidgetModifierSpec<ScrollViewModifierSpec> {
   /// compare two [ScrollViewModifierSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.scrollDirection,
-        _$this.reverse,
-        _$this.padding,
-        _$this.physics,
-        _$this.clipBehavior,
-      ];
+    _$this.scrollDirection,
+    _$this.reverse,
+    _$this.padding,
+    _$this.physics,
+    _$this.clipBehavior,
+  ];
 
   ScrollViewModifierSpec get _$this => this as ScrollViewModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty(
-        'scrollDirection', _$this.scrollDirection,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('reverse', _$this.reverse, defaultValue: null));
+      DiagnosticsProperty(
+        'scrollDirection',
+        _$this.scrollDirection,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('padding', _$this.padding, defaultValue: null));
+      DiagnosticsProperty('reverse', _$this.reverse, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('physics', _$this.physics, defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty('padding', _$this.padding, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('physics', _$this.physics, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
   }
 }
 
@@ -142,7 +154,8 @@ class ScrollViewModifierSpecAttribute
   /// to the values from this instance.
   @override
   ScrollViewModifierSpecAttribute merge(
-      ScrollViewModifierSpecAttribute? other) {
+    ScrollViewModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
     return ScrollViewModifierSpecAttribute(
@@ -160,23 +173,29 @@ class ScrollViewModifierSpecAttribute
   /// compare two [ScrollViewModifierSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        scrollDirection,
-        reverse,
-        padding,
-        physics,
-        clipBehavior,
-      ];
+    scrollDirection,
+    reverse,
+    padding,
+    physics,
+    clipBehavior,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('scrollDirection', scrollDirection,
-        defaultValue: null));
+    properties.add(
+      DiagnosticsProperty(
+        'scrollDirection',
+        scrollDirection,
+        defaultValue: null,
+      ),
+    );
     properties.add(DiagnosticsProperty('reverse', reverse, defaultValue: null));
     properties.add(DiagnosticsProperty('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty('physics', physics, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
   }
 }
 
@@ -185,10 +204,7 @@ class ScrollViewModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [ScrollViewModifierSpec] specifications.
 class ScrollViewModifierSpecTween extends Tween<ScrollViewModifierSpec?> {
-  ScrollViewModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  ScrollViewModifierSpecTween({super.begin, super.end});
 
   @override
   ScrollViewModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_widget_modifier.g.dart
@@ -13,10 +13,7 @@ mixin _$SizedBoxModifierSpec on WidgetModifierSpec<SizedBoxModifierSpec> {
   /// Creates a copy of this [SizedBoxModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  SizedBoxModifierSpec copyWith({
-    double? width,
-    double? height,
-  }) {
+  SizedBoxModifierSpec copyWith({double? width, double? height}) {
     return SizedBoxModifierSpec(
       width: width ?? _$this.width,
       height: height ?? _$this.height,
@@ -52,18 +49,17 @@ mixin _$SizedBoxModifierSpec on WidgetModifierSpec<SizedBoxModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [SizedBoxModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.width,
-        _$this.height,
-      ];
+  List<Object?> get props => [_$this.width, _$this.height];
 
   SizedBoxModifierSpec get _$this => this as SizedBoxModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties
-        .add(DiagnosticsProperty('width', _$this.width, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('height', _$this.height, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('width', _$this.width, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('height', _$this.height, defaultValue: null),
+    );
   }
 }
 
@@ -80,10 +76,7 @@ class SizedBoxModifierSpecAttribute
   final double? width;
   final double? height;
 
-  const SizedBoxModifierSpecAttribute({
-    this.width,
-    this.height,
-  });
+  const SizedBoxModifierSpecAttribute({this.width, this.height});
 
   /// Resolves to [SizedBoxModifierSpec] using the provided [MixData].
   ///
@@ -95,10 +88,7 @@ class SizedBoxModifierSpecAttribute
   /// ```
   @override
   SizedBoxModifierSpec resolve(MixData mix) {
-    return SizedBoxModifierSpec(
-      width: width,
-      height: height,
-    );
+    return SizedBoxModifierSpec(width: width, height: height);
   }
 
   /// Merges the properties of this [SizedBoxModifierSpecAttribute] with the properties of [other].
@@ -124,10 +114,7 @@ class SizedBoxModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [SizedBoxModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        width,
-        height,
-      ];
+  List<Object?> get props => [width, height];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -142,10 +129,7 @@ class SizedBoxModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [SizedBoxModifierSpec] specifications.
 class SizedBoxModifierSpecTween extends Tween<SizedBoxModifierSpec?> {
-  SizedBoxModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  SizedBoxModifierSpecTween({super.begin, super.end});
 
   @override
   SizedBoxModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/transform_widget_modifier.g.dart
@@ -13,10 +13,7 @@ mixin _$TransformModifierSpec on WidgetModifierSpec<TransformModifierSpec> {
   /// Creates a copy of this [TransformModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  TransformModifierSpec copyWith({
-    Matrix4? transform,
-    Alignment? alignment,
-  }) {
+  TransformModifierSpec copyWith({Matrix4? transform, Alignment? alignment}) {
     return TransformModifierSpec(
       transform: transform ?? _$this.transform,
       alignment: alignment ?? _$this.alignment,
@@ -53,18 +50,17 @@ mixin _$TransformModifierSpec on WidgetModifierSpec<TransformModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [TransformModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.transform,
-        _$this.alignment,
-      ];
+  List<Object?> get props => [_$this.transform, _$this.alignment];
 
   TransformModifierSpec get _$this => this as TransformModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('transform', _$this.transform, defaultValue: null));
+      DiagnosticsProperty('transform', _$this.transform, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
   }
 }
 
@@ -81,10 +77,7 @@ class TransformModifierSpecAttribute
   final Matrix4? transform;
   final Alignment? alignment;
 
-  const TransformModifierSpecAttribute({
-    this.transform,
-    this.alignment,
-  });
+  const TransformModifierSpecAttribute({this.transform, this.alignment});
 
   /// Resolves to [TransformModifierSpec] using the provided [MixData].
   ///
@@ -96,10 +89,7 @@ class TransformModifierSpecAttribute
   /// ```
   @override
   TransformModifierSpec resolve(MixData mix) {
-    return TransformModifierSpec(
-      transform: transform,
-      alignment: alignment,
-    );
+    return TransformModifierSpec(transform: transform, alignment: alignment);
   }
 
   /// Merges the properties of this [TransformModifierSpecAttribute] with the properties of [other].
@@ -125,18 +115,17 @@ class TransformModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [TransformModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        transform,
-        alignment,
-      ];
+  List<Object?> get props => [transform, alignment];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('transform', transform, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('transform', transform, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
   }
 }
 
@@ -145,10 +134,7 @@ class TransformModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [TransformModifierSpec] specifications.
 class TransformModifierSpecTween extends Tween<TransformModifierSpec?> {
-  TransformModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  TransformModifierSpecTween({super.begin, super.end});
 
   @override
   TransformModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
+++ b/packages/mix/lib/src/modifiers/visibility_widget_modifier.g.dart
@@ -13,12 +13,8 @@ mixin _$VisibilityModifierSpec on WidgetModifierSpec<VisibilityModifierSpec> {
   /// Creates a copy of this [VisibilityModifierSpec] but with the given fields
   /// replaced with the new values.
   @override
-  VisibilityModifierSpec copyWith({
-    bool? visible,
-  }) {
-    return VisibilityModifierSpec(
-      visible ?? _$this.visible,
-    );
+  VisibilityModifierSpec copyWith({bool? visible}) {
+    return VisibilityModifierSpec(visible ?? _$this.visible);
   }
 
   /// Linearly interpolates between this [VisibilityModifierSpec] and another [VisibilityModifierSpec] based on the given parameter [t].
@@ -41,9 +37,7 @@ mixin _$VisibilityModifierSpec on WidgetModifierSpec<VisibilityModifierSpec> {
   VisibilityModifierSpec lerp(VisibilityModifierSpec? other, double t) {
     if (other == null) return _$this;
 
-    return VisibilityModifierSpec(
-      t < 0.5 ? _$this.visible : other.visible,
-    );
+    return VisibilityModifierSpec(t < 0.5 ? _$this.visible : other.visible);
   }
 
   /// The list of properties that constitute the state of this [VisibilityModifierSpec].
@@ -51,15 +45,14 @@ mixin _$VisibilityModifierSpec on WidgetModifierSpec<VisibilityModifierSpec> {
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [VisibilityModifierSpec] instances for equality.
   @override
-  List<Object?> get props => [
-        _$this.visible,
-      ];
+  List<Object?> get props => [_$this.visible];
 
   VisibilityModifierSpec get _$this => this as VisibilityModifierSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('visible', _$this.visible, defaultValue: null));
+      DiagnosticsProperty('visible', _$this.visible, defaultValue: null),
+    );
   }
 }
 
@@ -75,9 +68,7 @@ class VisibilityModifierSpecAttribute
     with Diagnosticable {
   final bool? visible;
 
-  const VisibilityModifierSpecAttribute({
-    this.visible,
-  });
+  const VisibilityModifierSpecAttribute({this.visible});
 
   /// Resolves to [VisibilityModifierSpec] using the provided [MixData].
   ///
@@ -89,9 +80,7 @@ class VisibilityModifierSpecAttribute
   /// ```
   @override
   VisibilityModifierSpec resolve(MixData mix) {
-    return VisibilityModifierSpec(
-      visible,
-    );
+    return VisibilityModifierSpec(visible);
   }
 
   /// Merges the properties of this [VisibilityModifierSpecAttribute] with the properties of [other].
@@ -104,12 +93,11 @@ class VisibilityModifierSpecAttribute
   /// to the values from this instance.
   @override
   VisibilityModifierSpecAttribute merge(
-      VisibilityModifierSpecAttribute? other) {
+    VisibilityModifierSpecAttribute? other,
+  ) {
     if (other == null) return this;
 
-    return VisibilityModifierSpecAttribute(
-      visible: other.visible ?? visible,
-    );
+    return VisibilityModifierSpecAttribute(visible: other.visible ?? visible);
   }
 
   /// The list of properties that constitute the state of this [VisibilityModifierSpecAttribute].
@@ -117,9 +105,7 @@ class VisibilityModifierSpecAttribute
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [VisibilityModifierSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        visible,
-      ];
+  List<Object?> get props => [visible];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -133,10 +119,7 @@ class VisibilityModifierSpecAttribute
 /// This class can be used in animations to smoothly transition between
 /// different [VisibilityModifierSpec] specifications.
 class VisibilityModifierSpecTween extends Tween<VisibilityModifierSpec?> {
-  VisibilityModifierSpecTween({
-    super.begin,
-    super.end,
-  });
+  VisibilityModifierSpecTween({super.begin, super.end});
 
   @override
   VisibilityModifierSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -96,14 +96,23 @@ mixin _$BoxSpec on Spec<BoxSpec> {
       alignment: AlignmentGeometry.lerp(_$this.alignment, other.alignment, t),
       padding: EdgeInsetsGeometry.lerp(_$this.padding, other.padding, t),
       margin: EdgeInsetsGeometry.lerp(_$this.margin, other.margin, t),
-      constraints:
-          BoxConstraints.lerp(_$this.constraints, other.constraints, t),
+      constraints: BoxConstraints.lerp(
+        _$this.constraints,
+        other.constraints,
+        t,
+      ),
       decoration: Decoration.lerp(_$this.decoration, other.decoration, t),
       foregroundDecoration: Decoration.lerp(
-          _$this.foregroundDecoration, other.foregroundDecoration, t),
+        _$this.foregroundDecoration,
+        other.foregroundDecoration,
+        t,
+      ),
       transform: MixHelpers.lerpMatrix4(_$this.transform, other.transform, t),
       transformAlignment: AlignmentGeometry.lerp(
-          _$this.transformAlignment, other.transformAlignment, t),
+        _$this.transformAlignment,
+        other.transformAlignment,
+        t,
+      ),
       clipBehavior: t < 0.5 ? _$this.clipBehavior : other.clipBehavior,
       width: MixHelpers.lerpDouble(_$this.width, other.width, t),
       height: MixHelpers.lerpDouble(_$this.height, other.height, t),
@@ -118,52 +127,79 @@ mixin _$BoxSpec on Spec<BoxSpec> {
   /// compare two [BoxSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.alignment,
-        _$this.padding,
-        _$this.margin,
-        _$this.constraints,
-        _$this.decoration,
-        _$this.foregroundDecoration,
-        _$this.transform,
-        _$this.transformAlignment,
-        _$this.clipBehavior,
-        _$this.width,
-        _$this.height,
-        _$this.modifiers,
-        _$this.animated,
-      ];
+    _$this.alignment,
+    _$this.padding,
+    _$this.margin,
+    _$this.constraints,
+    _$this.decoration,
+    _$this.foregroundDecoration,
+    _$this.transform,
+    _$this.transformAlignment,
+    _$this.clipBehavior,
+    _$this.width,
+    _$this.height,
+    _$this.modifiers,
+    _$this.animated,
+  ];
 
   BoxSpec get _$this => this as BoxSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('padding', _$this.padding, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('margin', _$this.margin, defaultValue: null));
-    properties.add(DiagnosticsProperty('constraints', _$this.constraints,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('decoration', _$this.decoration,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'foregroundDecoration', _$this.foregroundDecoration,
-        defaultValue: null));
+      DiagnosticsProperty('padding', _$this.padding, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('transform', _$this.transform, defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'transformAlignment', _$this.transformAlignment,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('width', _$this.width, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('height', _$this.height, defaultValue: null));
+      DiagnosticsProperty('margin', _$this.margin, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty(
+        'constraints',
+        _$this.constraints,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty('decoration', _$this.decoration, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'foregroundDecoration',
+        _$this.foregroundDecoration,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('transform', _$this.transform, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'transformAlignment',
+        _$this.transformAlignment,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('width', _$this.width, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('height', _$this.height, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
   }
 }
 
@@ -249,7 +285,9 @@ class BoxSpecAttribute extends SpecAttribute<BoxSpec> with Diagnosticable {
       constraints: constraints?.merge(other.constraints) ?? other.constraints,
       decoration: DecorationDto.tryToMerge(decoration, other.decoration),
       foregroundDecoration: DecorationDto.tryToMerge(
-          foregroundDecoration, other.foregroundDecoration),
+        foregroundDecoration,
+        other.foregroundDecoration,
+      ),
       transform: other.transform ?? transform,
       transformAlignment: other.transformAlignment ?? transformAlignment,
       clipBehavior: other.clipBehavior ?? clipBehavior,
@@ -266,47 +304,63 @@ class BoxSpecAttribute extends SpecAttribute<BoxSpec> with Diagnosticable {
   /// compare two [BoxSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        alignment,
-        padding,
-        margin,
-        constraints,
-        decoration,
-        foregroundDecoration,
-        transform,
-        transformAlignment,
-        clipBehavior,
-        width,
-        height,
-        modifiers,
-        animated,
-      ];
+    alignment,
+    padding,
+    margin,
+    constraints,
+    decoration,
+    foregroundDecoration,
+    transform,
+    transformAlignment,
+    clipBehavior,
+    width,
+    height,
+    modifiers,
+    animated,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty('margin', margin, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('constraints', constraints, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('decoration', decoration, defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'foregroundDecoration', foregroundDecoration,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('transform', transform, defaultValue: null));
-    properties.add(DiagnosticsProperty('transformAlignment', transformAlignment,
-        defaultValue: null));
+      DiagnosticsProperty('constraints', constraints, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('decoration', decoration, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'foregroundDecoration',
+        foregroundDecoration,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('transform', transform, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'transformAlignment',
+        transformAlignment,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('width', width, defaultValue: null));
     properties.add(DiagnosticsProperty('height', height, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
   }
 }
 
@@ -380,22 +434,25 @@ class BoxSpecUtility<T extends StyleElement>
   late final elevation = decoration.elevation;
 
   /// Utility for defining [BoxSpecAttribute.decoration]
-  late final shapeDecoration =
-      ShapeDecorationUtility((v) => only(decoration: v));
+  late final shapeDecoration = ShapeDecorationUtility(
+    (v) => only(decoration: v),
+  );
 
   /// Utility for defining [BoxSpecAttribute.shapeDecoration.shape]
   late final shape = shapeDecoration.shape;
 
   /// Utility for defining [BoxSpecAttribute.foregroundDecoration]
-  late final foregroundDecoration =
-      BoxDecorationUtility((v) => only(foregroundDecoration: v));
+  late final foregroundDecoration = BoxDecorationUtility(
+    (v) => only(foregroundDecoration: v),
+  );
 
   /// Utility for defining [BoxSpecAttribute.transform]
   late final transform = Matrix4Utility((v) => only(transform: v));
 
   /// Utility for defining [BoxSpecAttribute.transformAlignment]
-  late final transformAlignment =
-      AlignmentGeometryUtility((v) => only(transformAlignment: v));
+  late final transformAlignment = AlignmentGeometryUtility(
+    (v) => only(transformAlignment: v),
+  );
 
   /// Utility for defining [BoxSpecAttribute.clipBehavior]
   late final clipBehavior = ClipUtility((v) => only(clipBehavior: v));
@@ -445,21 +502,23 @@ class BoxSpecUtility<T extends StyleElement>
     WidgetModifiersConfigDto? modifiers,
     AnimatedDataDto? animated,
   }) {
-    return builder(BoxSpecAttribute(
-      alignment: alignment,
-      padding: padding,
-      margin: margin,
-      constraints: constraints,
-      decoration: decoration,
-      foregroundDecoration: foregroundDecoration,
-      transform: transform,
-      transformAlignment: transformAlignment,
-      clipBehavior: clipBehavior,
-      width: width,
-      height: height,
-      modifiers: modifiers,
-      animated: animated,
-    ));
+    return builder(
+      BoxSpecAttribute(
+        alignment: alignment,
+        padding: padding,
+        margin: margin,
+        constraints: constraints,
+        decoration: decoration,
+        foregroundDecoration: foregroundDecoration,
+        transform: transform,
+        transformAlignment: transformAlignment,
+        clipBehavior: clipBehavior,
+        width: width,
+        height: height,
+        modifiers: modifiers,
+        animated: animated,
+      ),
+    );
   }
 }
 
@@ -468,10 +527,7 @@ class BoxSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [BoxSpec] specifications.
 class BoxSpecTween extends Tween<BoxSpec?> {
-  BoxSpecTween({
-    super.begin,
-    super.end,
-  });
+  BoxSpecTween({super.begin, super.end});
 
   @override
   BoxSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/flex/flex_spec.g.dart
+++ b/packages/mix/lib/src/specs/flex/flex_spec.g.dart
@@ -108,46 +108,81 @@ mixin _$FlexSpec on Spec<FlexSpec> {
   /// compare two [FlexSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.crossAxisAlignment,
-        _$this.mainAxisAlignment,
-        _$this.mainAxisSize,
-        _$this.verticalDirection,
-        _$this.direction,
-        _$this.textDirection,
-        _$this.textBaseline,
-        _$this.clipBehavior,
-        _$this.gap,
-        _$this.animated,
-        _$this.modifiers,
-      ];
+    _$this.crossAxisAlignment,
+    _$this.mainAxisAlignment,
+    _$this.mainAxisSize,
+    _$this.verticalDirection,
+    _$this.direction,
+    _$this.textDirection,
+    _$this.textBaseline,
+    _$this.clipBehavior,
+    _$this.gap,
+    _$this.animated,
+    _$this.modifiers,
+  ];
 
   FlexSpec get _$this => this as FlexSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties.add(DiagnosticsProperty(
-        'crossAxisAlignment', _$this.crossAxisAlignment,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'mainAxisAlignment', _$this.mainAxisAlignment,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('mainAxisSize', _$this.mainAxisSize,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'verticalDirection', _$this.verticalDirection,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('direction', _$this.direction, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', _$this.textDirection,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('textBaseline', _$this.textBaseline,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
+      DiagnosticsProperty(
+        'crossAxisAlignment',
+        _$this.crossAxisAlignment,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'mainAxisAlignment',
+        _$this.mainAxisAlignment,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'mainAxisSize',
+        _$this.mainAxisSize,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'verticalDirection',
+        _$this.verticalDirection,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('direction', _$this.direction, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textDirection',
+        _$this.textDirection,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textBaseline',
+        _$this.textBaseline,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
     properties.add(DiagnosticsProperty('gap', _$this.gap, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -241,43 +276,65 @@ class FlexSpecAttribute extends SpecAttribute<FlexSpec> with Diagnosticable {
   /// compare two [FlexSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        crossAxisAlignment,
-        mainAxisAlignment,
-        mainAxisSize,
-        verticalDirection,
-        direction,
-        textDirection,
-        textBaseline,
-        clipBehavior,
-        gap,
-        animated,
-        modifiers,
-      ];
+    crossAxisAlignment,
+    mainAxisAlignment,
+    mainAxisSize,
+    verticalDirection,
+    direction,
+    textDirection,
+    textBaseline,
+    clipBehavior,
+    gap,
+    animated,
+    modifiers,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty('crossAxisAlignment', crossAxisAlignment,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('mainAxisAlignment', mainAxisAlignment,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('mainAxisSize', mainAxisSize, defaultValue: null));
-    properties.add(DiagnosticsProperty('verticalDirection', verticalDirection,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('direction', direction, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', textDirection,
-        defaultValue: null));
+      DiagnosticsProperty(
+        'crossAxisAlignment',
+        crossAxisAlignment,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('textBaseline', textBaseline, defaultValue: null));
+      DiagnosticsProperty(
+        'mainAxisAlignment',
+        mainAxisAlignment,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
+      DiagnosticsProperty('mainAxisSize', mainAxisSize, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'verticalDirection',
+        verticalDirection,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('direction', direction, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('textDirection', textDirection, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('textBaseline', textBaseline, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('gap', gap, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -288,19 +345,22 @@ class FlexSpecAttribute extends SpecAttribute<FlexSpec> with Diagnosticable {
 class FlexSpecUtility<T extends StyleElement>
     extends SpecUtility<T, FlexSpecAttribute> {
   /// Utility for defining [FlexSpecAttribute.crossAxisAlignment]
-  late final crossAxisAlignment =
-      CrossAxisAlignmentUtility((v) => only(crossAxisAlignment: v));
+  late final crossAxisAlignment = CrossAxisAlignmentUtility(
+    (v) => only(crossAxisAlignment: v),
+  );
 
   /// Utility for defining [FlexSpecAttribute.mainAxisAlignment]
-  late final mainAxisAlignment =
-      MainAxisAlignmentUtility((v) => only(mainAxisAlignment: v));
+  late final mainAxisAlignment = MainAxisAlignmentUtility(
+    (v) => only(mainAxisAlignment: v),
+  );
 
   /// Utility for defining [FlexSpecAttribute.mainAxisSize]
   late final mainAxisSize = MainAxisSizeUtility((v) => only(mainAxisSize: v));
 
   /// Utility for defining [FlexSpecAttribute.verticalDirection]
-  late final verticalDirection =
-      VerticalDirectionUtility((v) => only(verticalDirection: v));
+  late final verticalDirection = VerticalDirectionUtility(
+    (v) => only(verticalDirection: v),
+  );
 
   /// Utility for defining [FlexSpecAttribute.direction]
   late final direction = AxisUtility((v) => only(direction: v));
@@ -312,8 +372,9 @@ class FlexSpecUtility<T extends StyleElement>
   late final column = direction.vertical;
 
   /// Utility for defining [FlexSpecAttribute.textDirection]
-  late final textDirection =
-      TextDirectionUtility((v) => only(textDirection: v));
+  late final textDirection = TextDirectionUtility(
+    (v) => only(textDirection: v),
+  );
 
   /// Utility for defining [FlexSpecAttribute.textBaseline]
   late final textBaseline = TextBaselineUtility((v) => only(textBaseline: v));
@@ -362,19 +423,21 @@ class FlexSpecUtility<T extends StyleElement>
     AnimatedDataDto? animated,
     WidgetModifiersConfigDto? modifiers,
   }) {
-    return builder(FlexSpecAttribute(
-      crossAxisAlignment: crossAxisAlignment,
-      mainAxisAlignment: mainAxisAlignment,
-      mainAxisSize: mainAxisSize,
-      verticalDirection: verticalDirection,
-      direction: direction,
-      textDirection: textDirection,
-      textBaseline: textBaseline,
-      clipBehavior: clipBehavior,
-      gap: gap,
-      animated: animated,
-      modifiers: modifiers,
-    ));
+    return builder(
+      FlexSpecAttribute(
+        crossAxisAlignment: crossAxisAlignment,
+        mainAxisAlignment: mainAxisAlignment,
+        mainAxisSize: mainAxisSize,
+        verticalDirection: verticalDirection,
+        direction: direction,
+        textDirection: textDirection,
+        textBaseline: textBaseline,
+        clipBehavior: clipBehavior,
+        gap: gap,
+        animated: animated,
+        modifiers: modifiers,
+      ),
+    );
   }
 }
 
@@ -383,10 +446,7 @@ class FlexSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [FlexSpec] specifications.
 class FlexSpecTween extends Tween<FlexSpec?> {
-  FlexSpecTween({
-    super.begin,
-    super.end,
-  });
+  FlexSpecTween({super.begin, super.end});
 
   @override
   FlexSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
@@ -85,22 +85,25 @@ mixin _$FlexBoxSpec on Spec<FlexBoxSpec> {
   /// compare two [FlexBoxSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.animated,
-        _$this.modifiers,
-        _$this.box,
-        _$this.flex,
-      ];
+    _$this.animated,
+    _$this.modifiers,
+    _$this.box,
+    _$this.flex,
+  ];
 
   FlexBoxSpec get _$this => this as FlexBoxSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('box', _$this.box, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('flex', _$this.flex, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('flex', _$this.flex, defaultValue: null),
+    );
   }
 }
 
@@ -166,20 +169,17 @@ class FlexBoxSpecAttribute extends SpecAttribute<FlexBoxSpec>
   /// This property is used by the [==] operator and the [hashCode] getter to
   /// compare two [FlexBoxSpecAttribute] instances for equality.
   @override
-  List<Object?> get props => [
-        animated,
-        modifiers,
-        box,
-        flex,
-      ];
+  List<Object?> get props => [animated, modifiers, box, flex];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('box', box, defaultValue: null));
     properties.add(DiagnosticsProperty('flex', flex, defaultValue: null));
   }
@@ -315,12 +315,14 @@ class FlexBoxSpecUtility<T extends StyleElement>
     BoxSpecAttribute? box,
     FlexSpecAttribute? flex,
   }) {
-    return builder(FlexBoxSpecAttribute(
-      animated: animated,
-      modifiers: modifiers,
-      box: box,
-      flex: flex,
-    ));
+    return builder(
+      FlexBoxSpecAttribute(
+        animated: animated,
+        modifiers: modifiers,
+        box: box,
+        flex: flex,
+      ),
+    );
   }
 }
 
@@ -329,10 +331,7 @@ class FlexBoxSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [FlexBoxSpec] specifications.
 class FlexBoxSpecTween extends Tween<FlexBoxSpec?> {
-  FlexBoxSpecTween({
-    super.begin,
-    super.end,
-  });
+  FlexBoxSpecTween({super.begin, super.end});
 
   @override
   FlexBoxSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/icon/icon_spec.g.dart
+++ b/packages/mix/lib/src/specs/icon/icon_spec.g.dart
@@ -91,8 +91,11 @@ mixin _$IconSpec on Spec<IconSpec> {
       size: MixHelpers.lerpDouble(_$this.size, other.size, t),
       weight: MixHelpers.lerpDouble(_$this.weight, other.weight, t),
       grade: MixHelpers.lerpDouble(_$this.grade, other.grade, t),
-      opticalSize:
-          MixHelpers.lerpDouble(_$this.opticalSize, other.opticalSize, t),
+      opticalSize: MixHelpers.lerpDouble(
+        _$this.opticalSize,
+        other.opticalSize,
+        t,
+      ),
       shadows: MixHelpers.lerpShadowList(_$this.shadows, other.shadows, t),
       textDirection: t < 0.5 ? _$this.textDirection : other.textDirection,
       applyTextScaling:
@@ -109,45 +112,67 @@ mixin _$IconSpec on Spec<IconSpec> {
   /// compare two [IconSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.color,
-        _$this.size,
-        _$this.weight,
-        _$this.grade,
-        _$this.opticalSize,
-        _$this.shadows,
-        _$this.textDirection,
-        _$this.applyTextScaling,
-        _$this.fill,
-        _$this.animated,
-        _$this.modifiers,
-      ];
+    _$this.color,
+    _$this.size,
+    _$this.weight,
+    _$this.grade,
+    _$this.opticalSize,
+    _$this.shadows,
+    _$this.textDirection,
+    _$this.applyTextScaling,
+    _$this.fill,
+    _$this.animated,
+    _$this.modifiers,
+  ];
 
   IconSpec get _$this => this as IconSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties
-        .add(DiagnosticsProperty('color', _$this.color, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('size', _$this.size, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('weight', _$this.weight, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('grade', _$this.grade, defaultValue: null));
-    properties.add(DiagnosticsProperty('opticalSize', _$this.opticalSize,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('shadows', _$this.shadows, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', _$this.textDirection,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'applyTextScaling', _$this.applyTextScaling,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('fill', _$this.fill, defaultValue: null));
+      DiagnosticsProperty('color', _$this.color, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty('size', _$this.size, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty('weight', _$this.weight, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('grade', _$this.grade, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'opticalSize',
+        _$this.opticalSize,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('shadows', _$this.shadows, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textDirection',
+        _$this.textDirection,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'applyTextScaling',
+        _$this.applyTextScaling,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('fill', _$this.fill, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -241,18 +266,18 @@ class IconSpecAttribute extends SpecAttribute<IconSpec> with Diagnosticable {
   /// compare two [IconSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        color,
-        size,
-        weight,
-        grade,
-        opticalSize,
-        shadows,
-        textDirection,
-        applyTextScaling,
-        fill,
-        animated,
-        modifiers,
-      ];
+    color,
+    size,
+    weight,
+    grade,
+    opticalSize,
+    shadows,
+    textDirection,
+    applyTextScaling,
+    fill,
+    animated,
+    modifiers,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -262,17 +287,26 @@ class IconSpecAttribute extends SpecAttribute<IconSpec> with Diagnosticable {
     properties.add(DiagnosticsProperty('weight', weight, defaultValue: null));
     properties.add(DiagnosticsProperty('grade', grade, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('opticalSize', opticalSize, defaultValue: null));
+      DiagnosticsProperty('opticalSize', opticalSize, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('shadows', shadows, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', textDirection,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('applyTextScaling', applyTextScaling,
-        defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('textDirection', textDirection, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'applyTextScaling',
+        applyTextScaling,
+        defaultValue: null,
+      ),
+    );
     properties.add(DiagnosticsProperty('fill', fill, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -301,8 +335,9 @@ class IconSpecUtility<T extends StyleElement>
   late final shadows = ShadowListUtility((v) => only(shadows: v));
 
   /// Utility for defining [IconSpecAttribute.textDirection]
-  late final textDirection =
-      TextDirectionUtility((v) => only(textDirection: v));
+  late final textDirection = TextDirectionUtility(
+    (v) => only(textDirection: v),
+  );
 
   /// Utility for defining [IconSpecAttribute.applyTextScaling]
   late final applyTextScaling = BoolUtility((v) => only(applyTextScaling: v));
@@ -348,19 +383,21 @@ class IconSpecUtility<T extends StyleElement>
     AnimatedDataDto? animated,
     WidgetModifiersConfigDto? modifiers,
   }) {
-    return builder(IconSpecAttribute(
-      color: color,
-      size: size,
-      weight: weight,
-      grade: grade,
-      opticalSize: opticalSize,
-      shadows: shadows,
-      textDirection: textDirection,
-      applyTextScaling: applyTextScaling,
-      fill: fill,
-      animated: animated,
-      modifiers: modifiers,
-    ));
+    return builder(
+      IconSpecAttribute(
+        color: color,
+        size: size,
+        weight: weight,
+        grade: grade,
+        opticalSize: opticalSize,
+        shadows: shadows,
+        textDirection: textDirection,
+        applyTextScaling: applyTextScaling,
+        fill: fill,
+        animated: animated,
+        modifiers: modifiers,
+      ),
+    );
   }
 }
 
@@ -369,10 +406,7 @@ class IconSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [IconSpec] specifications.
 class IconSpecTween extends Tween<IconSpec?> {
-  IconSpecTween({
-    super.begin,
-    super.end,
-  });
+  IconSpecTween({super.begin, super.end});
 
   @override
   IconSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/image/image_spec.g.dart
+++ b/packages/mix/lib/src/specs/image/image_spec.g.dart
@@ -108,43 +108,65 @@ mixin _$ImageSpec on Spec<ImageSpec> {
   /// compare two [ImageSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.width,
-        _$this.height,
-        _$this.color,
-        _$this.repeat,
-        _$this.fit,
-        _$this.alignment,
-        _$this.centerSlice,
-        _$this.filterQuality,
-        _$this.colorBlendMode,
-        _$this.animated,
-        _$this.modifiers,
-      ];
+    _$this.width,
+    _$this.height,
+    _$this.color,
+    _$this.repeat,
+    _$this.fit,
+    _$this.alignment,
+    _$this.centerSlice,
+    _$this.filterQuality,
+    _$this.colorBlendMode,
+    _$this.animated,
+    _$this.modifiers,
+  ];
 
   ImageSpec get _$this => this as ImageSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    properties
-        .add(DiagnosticsProperty('width', _$this.width, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('height', _$this.height, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('color', _$this.color, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('repeat', _$this.repeat, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('width', _$this.width, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('height', _$this.height, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('color', _$this.color, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('repeat', _$this.repeat, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('fit', _$this.fit, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
-    properties.add(DiagnosticsProperty('centerSlice', _$this.centerSlice,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('filterQuality', _$this.filterQuality,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('colorBlendMode', _$this.colorBlendMode,
-        defaultValue: null));
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty(
+        'centerSlice',
+        _$this.centerSlice,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty(
+        'filterQuality',
+        _$this.filterQuality,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'colorBlendMode',
+        _$this.colorBlendMode,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -238,18 +260,18 @@ class ImageSpecAttribute extends SpecAttribute<ImageSpec> with Diagnosticable {
   /// compare two [ImageSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        width,
-        height,
-        color,
-        repeat,
-        fit,
-        alignment,
-        centerSlice,
-        filterQuality,
-        colorBlendMode,
-        animated,
-        modifiers,
-      ];
+    width,
+    height,
+    color,
+    repeat,
+    fit,
+    alignment,
+    centerSlice,
+    filterQuality,
+    colorBlendMode,
+    animated,
+    modifiers,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -259,18 +281,24 @@ class ImageSpecAttribute extends SpecAttribute<ImageSpec> with Diagnosticable {
     properties.add(DiagnosticsProperty('color', color, defaultValue: null));
     properties.add(DiagnosticsProperty('repeat', repeat, defaultValue: null));
     properties.add(DiagnosticsProperty('fit', fit, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
     properties.add(
-        DiagnosticsProperty('centerSlice', centerSlice, defaultValue: null));
-    properties.add(DiagnosticsProperty('filterQuality', filterQuality,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('colorBlendMode', colorBlendMode,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('centerSlice', centerSlice, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('filterQuality', filterQuality, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('colorBlendMode', colorBlendMode, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -302,8 +330,9 @@ class ImageSpecUtility<T extends StyleElement>
   late final centerSlice = RectUtility((v) => only(centerSlice: v));
 
   /// Utility for defining [ImageSpecAttribute.filterQuality]
-  late final filterQuality =
-      FilterQualityUtility((v) => only(filterQuality: v));
+  late final filterQuality = FilterQualityUtility(
+    (v) => only(filterQuality: v),
+  );
 
   /// Utility for defining [ImageSpecAttribute.colorBlendMode]
   late final colorBlendMode = BlendModeUtility((v) => only(colorBlendMode: v));
@@ -346,19 +375,21 @@ class ImageSpecUtility<T extends StyleElement>
     AnimatedDataDto? animated,
     WidgetModifiersConfigDto? modifiers,
   }) {
-    return builder(ImageSpecAttribute(
-      width: width,
-      height: height,
-      color: color,
-      repeat: repeat,
-      fit: fit,
-      alignment: alignment,
-      centerSlice: centerSlice,
-      filterQuality: filterQuality,
-      colorBlendMode: colorBlendMode,
-      animated: animated,
-      modifiers: modifiers,
-    ));
+    return builder(
+      ImageSpecAttribute(
+        width: width,
+        height: height,
+        color: color,
+        repeat: repeat,
+        fit: fit,
+        alignment: alignment,
+        centerSlice: centerSlice,
+        filterQuality: filterQuality,
+        colorBlendMode: colorBlendMode,
+        animated: animated,
+        modifiers: modifiers,
+      ),
+    );
   }
 }
 
@@ -367,10 +398,7 @@ class ImageSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [ImageSpec] specifications.
 class ImageSpecTween extends Tween<ImageSpec?> {
-  ImageSpecTween({
-    super.begin,
-    super.end,
-  });
+  ImageSpecTween({super.begin, super.end});
 
   @override
   ImageSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/stack/stack_spec.g.dart
+++ b/packages/mix/lib/src/specs/stack/stack_spec.g.dart
@@ -90,28 +90,41 @@ mixin _$StackSpec on Spec<StackSpec> {
   /// compare two [StackSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.alignment,
-        _$this.fit,
-        _$this.textDirection,
-        _$this.clipBehavior,
-        _$this.animated,
-        _$this.modifiers,
-      ];
+    _$this.alignment,
+    _$this.fit,
+    _$this.textDirection,
+    _$this.clipBehavior,
+    _$this.animated,
+    _$this.modifiers,
+  ];
 
   StackSpec get _$this => this as StackSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null));
+      DiagnosticsProperty('alignment', _$this.alignment, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('fit', _$this.fit, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', _$this.textDirection,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('clipBehavior', _$this.clipBehavior,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty(
+        'textDirection',
+        _$this.textDirection,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty(
+        'clipBehavior',
+        _$this.clipBehavior,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -185,28 +198,33 @@ class StackSpecAttribute extends SpecAttribute<StackSpec> with Diagnosticable {
   /// compare two [StackSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        alignment,
-        fit,
-        textDirection,
-        clipBehavior,
-        animated,
-        modifiers,
-      ];
+    alignment,
+    fit,
+    textDirection,
+    clipBehavior,
+    animated,
+    modifiers,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('alignment', alignment, defaultValue: null));
-    properties.add(DiagnosticsProperty('fit', fit, defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', textDirection,
-        defaultValue: null));
     properties.add(
-        DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+      DiagnosticsProperty('alignment', alignment, defaultValue: null),
+    );
+    properties.add(DiagnosticsProperty('fit', fit, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('textDirection', textDirection, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('clipBehavior', clipBehavior, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -223,8 +241,9 @@ class StackSpecUtility<T extends StyleElement>
   late final fit = StackFitUtility((v) => only(fit: v));
 
   /// Utility for defining [StackSpecAttribute.textDirection]
-  late final textDirection =
-      TextDirectionUtility((v) => only(textDirection: v));
+  late final textDirection = TextDirectionUtility(
+    (v) => only(textDirection: v),
+  );
 
   /// Utility for defining [StackSpecAttribute.clipBehavior]
   late final clipBehavior = ClipUtility((v) => only(clipBehavior: v));
@@ -262,14 +281,16 @@ class StackSpecUtility<T extends StyleElement>
     AnimatedDataDto? animated,
     WidgetModifiersConfigDto? modifiers,
   }) {
-    return builder(StackSpecAttribute(
-      alignment: alignment,
-      fit: fit,
-      textDirection: textDirection,
-      clipBehavior: clipBehavior,
-      animated: animated,
-      modifiers: modifiers,
-    ));
+    return builder(
+      StackSpecAttribute(
+        alignment: alignment,
+        fit: fit,
+        textDirection: textDirection,
+        clipBehavior: clipBehavior,
+        animated: animated,
+        modifiers: modifiers,
+      ),
+    );
   }
 }
 
@@ -278,10 +299,7 @@ class StackSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [StackSpec] specifications.
 class StackSpecTween extends Tween<StackSpec?> {
-  StackSpecTween({
-    super.begin,
-    super.end,
-  });
+  StackSpecTween({super.begin, super.end});
 
   @override
   StackSpec lerp(double t) {

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -96,11 +96,17 @@ mixin _$TextSpec on Spec<TextSpec> {
 
     return TextSpec(
       overflow: t < 0.5 ? _$this.overflow : other.overflow,
-      strutStyle:
-          MixHelpers.lerpStrutStyle(_$this.strutStyle, other.strutStyle, t),
+      strutStyle: MixHelpers.lerpStrutStyle(
+        _$this.strutStyle,
+        other.strutStyle,
+        t,
+      ),
       textAlign: t < 0.5 ? _$this.textAlign : other.textAlign,
       textScaleFactor: MixHelpers.lerpDouble(
-          _$this.textScaleFactor, other.textScaleFactor, t),
+        _$this.textScaleFactor,
+        other.textScaleFactor,
+        t,
+      ),
       textScaler: t < 0.5 ? _$this.textScaler : other.textScaler,
       maxLines: t < 0.5 ? _$this.maxLines : other.maxLines,
       style: MixHelpers.lerpTextStyle(_$this.style, other.style, t),
@@ -121,55 +127,83 @@ mixin _$TextSpec on Spec<TextSpec> {
   /// compare two [TextSpec] instances for equality.
   @override
   List<Object?> get props => [
-        _$this.overflow,
-        _$this.strutStyle,
-        _$this.textAlign,
-        _$this.textScaleFactor,
-        _$this.textScaler,
-        _$this.maxLines,
-        _$this.style,
-        _$this.textWidthBasis,
-        _$this.textHeightBehavior,
-        _$this.textDirection,
-        _$this.softWrap,
-        _$this.directive,
-        _$this.animated,
-        _$this.modifiers,
-      ];
+    _$this.overflow,
+    _$this.strutStyle,
+    _$this.textAlign,
+    _$this.textScaleFactor,
+    _$this.textScaler,
+    _$this.maxLines,
+    _$this.style,
+    _$this.textWidthBasis,
+    _$this.textHeightBehavior,
+    _$this.textDirection,
+    _$this.softWrap,
+    _$this.directive,
+    _$this.animated,
+    _$this.modifiers,
+  ];
 
   TextSpec get _$this => this as TextSpec;
 
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties.add(
-        DiagnosticsProperty('overflow', _$this.overflow, defaultValue: null));
-    properties.add(DiagnosticsProperty('strutStyle', _$this.strutStyle,
-        defaultValue: null));
+      DiagnosticsProperty('overflow', _$this.overflow, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('textAlign', _$this.textAlign, defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'textScaleFactor', _$this.textScaleFactor,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('textScaler', _$this.textScaler,
-        defaultValue: null));
+      DiagnosticsProperty('strutStyle', _$this.strutStyle, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('maxLines', _$this.maxLines, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('style', _$this.style, defaultValue: null));
-    properties.add(DiagnosticsProperty('textWidthBasis', _$this.textWidthBasis,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty(
-        'textHeightBehavior', _$this.textHeightBehavior,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', _$this.textDirection,
-        defaultValue: null));
+      DiagnosticsProperty('textAlign', _$this.textAlign, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('softWrap', _$this.softWrap, defaultValue: null));
+      DiagnosticsProperty(
+        'textScaleFactor',
+        _$this.textScaleFactor,
+        defaultValue: null,
+      ),
+    );
     properties.add(
-        DiagnosticsProperty('directive', _$this.directive, defaultValue: null));
+      DiagnosticsProperty('textScaler', _$this.textScaler, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+      DiagnosticsProperty('maxLines', _$this.maxLines, defaultValue: null),
+    );
     properties.add(
-        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+      DiagnosticsProperty('style', _$this.style, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textWidthBasis',
+        _$this.textWidthBasis,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textHeightBehavior',
+        _$this.textHeightBehavior,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textDirection',
+        _$this.textDirection,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('softWrap', _$this.softWrap, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('directive', _$this.directive, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', _$this.animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -260,7 +294,8 @@ class TextSpecAttribute extends SpecAttribute<TextSpec> with Diagnosticable {
       maxLines: other.maxLines ?? maxLines,
       style: style?.merge(other.style) ?? other.style,
       textWidthBasis: other.textWidthBasis ?? textWidthBasis,
-      textHeightBehavior: textHeightBehavior?.merge(other.textHeightBehavior) ??
+      textHeightBehavior:
+          textHeightBehavior?.merge(other.textHeightBehavior) ??
           other.textHeightBehavior,
       textDirection: other.textDirection ?? textDirection,
       softWrap: other.softWrap ?? softWrap,
@@ -276,52 +311,73 @@ class TextSpecAttribute extends SpecAttribute<TextSpec> with Diagnosticable {
   /// compare two [TextSpecAttribute] instances for equality.
   @override
   List<Object?> get props => [
-        overflow,
-        strutStyle,
-        textAlign,
-        textScaleFactor,
-        textScaler,
-        maxLines,
-        style,
-        textWidthBasis,
-        textHeightBehavior,
-        textDirection,
-        softWrap,
-        directive,
-        animated,
-        modifiers,
-      ];
+    overflow,
+    strutStyle,
+    textAlign,
+    textScaleFactor,
+    textScaler,
+    maxLines,
+    style,
+    textWidthBasis,
+    textHeightBehavior,
+    textDirection,
+    softWrap,
+    directive,
+    animated,
+    modifiers,
+  ];
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty('overflow', overflow, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('strutStyle', strutStyle, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('textAlign', textAlign, defaultValue: null));
-    properties.add(DiagnosticsProperty('textScaleFactor', textScaleFactor,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('textScaler', textScaler, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('maxLines', maxLines, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('overflow', overflow, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('strutStyle', strutStyle, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('textAlign', textAlign, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textScaleFactor',
+        textScaleFactor,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('textScaler', textScaler, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('maxLines', maxLines, defaultValue: null),
+    );
     properties.add(DiagnosticsProperty('style', style, defaultValue: null));
-    properties.add(DiagnosticsProperty('textWidthBasis', textWidthBasis,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('textHeightBehavior', textHeightBehavior,
-        defaultValue: null));
-    properties.add(DiagnosticsProperty('textDirection', textDirection,
-        defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('softWrap', softWrap, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('directive', directive, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+    properties.add(
+      DiagnosticsProperty('textWidthBasis', textWidthBasis, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty(
+        'textHeightBehavior',
+        textHeightBehavior,
+        defaultValue: null,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty('textDirection', textDirection, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('softWrap', softWrap, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('directive', directive, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('animated', animated, defaultValue: null),
+    );
+    properties.add(
+      DiagnosticsProperty('modifiers', modifiers, defaultValue: null),
+    );
   }
 }
 
@@ -416,16 +472,19 @@ class TextSpecUtility<T extends StyleElement>
   late final fontFamilyFallback = style.fontFamilyFallback;
 
   /// Utility for defining [TextSpecAttribute.textWidthBasis]
-  late final textWidthBasis =
-      TextWidthBasisUtility((v) => only(textWidthBasis: v));
+  late final textWidthBasis = TextWidthBasisUtility(
+    (v) => only(textWidthBasis: v),
+  );
 
   /// Utility for defining [TextSpecAttribute.textHeightBehavior]
-  late final textHeightBehavior =
-      TextHeightBehaviorUtility((v) => only(textHeightBehavior: v));
+  late final textHeightBehavior = TextHeightBehaviorUtility(
+    (v) => only(textHeightBehavior: v),
+  );
 
   /// Utility for defining [TextSpecAttribute.textDirection]
-  late final textDirection =
-      TextDirectionUtility((v) => only(textDirection: v));
+  late final textDirection = TextDirectionUtility(
+    (v) => only(textDirection: v),
+  );
 
   /// Utility for defining [TextSpecAttribute.softWrap]
   late final softWrap = BoolUtility((v) => only(softWrap: v));
@@ -489,22 +548,24 @@ class TextSpecUtility<T extends StyleElement>
     AnimatedDataDto? animated,
     WidgetModifiersConfigDto? modifiers,
   }) {
-    return builder(TextSpecAttribute(
-      overflow: overflow,
-      strutStyle: strutStyle,
-      textAlign: textAlign,
-      textScaleFactor: textScaleFactor,
-      textScaler: textScaler,
-      maxLines: maxLines,
-      style: style,
-      textWidthBasis: textWidthBasis,
-      textHeightBehavior: textHeightBehavior,
-      textDirection: textDirection,
-      softWrap: softWrap,
-      directive: directive,
-      animated: animated,
-      modifiers: modifiers,
-    ));
+    return builder(
+      TextSpecAttribute(
+        overflow: overflow,
+        strutStyle: strutStyle,
+        textAlign: textAlign,
+        textScaleFactor: textScaleFactor,
+        textScaler: textScaler,
+        maxLines: maxLines,
+        style: style,
+        textWidthBasis: textWidthBasis,
+        textHeightBehavior: textHeightBehavior,
+        textDirection: textDirection,
+        softWrap: softWrap,
+        directive: directive,
+        animated: animated,
+        modifiers: modifiers,
+      ),
+    );
   }
 }
 
@@ -513,10 +574,7 @@ class TextSpecUtility<T extends StyleElement>
 /// This class can be used in animations to smoothly transition between
 /// different [TextSpec] specifications.
 class TextSpecTween extends Tween<TextSpec?> {
-  TextSpecTween({
-    super.begin,
-    super.end,
-  });
+  TextSpecTween({super.begin, super.end});
 
   @override
   TextSpec lerp(double t) {

--- a/packages/mix/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/mix/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,0 +1,10 @@
+//
+//  Generated file. Do not edit.
+//
+
+import FlutterMacOS
+import Foundation
+
+
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+}

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://github.com/leoafarias/mix
 repository: https://github.com/btwld/mix
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
   
 dependencies:
   mix_annotations: ^0.4.0
@@ -15,9 +15,9 @@ dependencies:
   meta: ^1.15.0
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
-  dart_code_metrics_presets: ^2.14.0
-  build_runner: ^2.4.9
+  flutter_lints: ^5.0.0
+  dart_code_metrics_presets: ^2.22.0
+  build_runner: ^2.5.0
   flutter_test:
     sdk: flutter
   mix_generator: ^0.4.0

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -4,9 +4,9 @@ version: 0.4.0
 repository: https://github.com/btwld/mix
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dev_dependencies:
   test: ^1.21.0
-  dart_code_metrics_presets: ^2.14.0
-  flutter_lints: ^4.0.0
+  dart_code_metrics_presets: ^2.22.0
+  flutter_lints: ^5.0.0

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   mix_annotations: ^0.4.0
-  build: ^2.4.1
+  build: ^2.4.2
   source_gen: ^2.0.0
   analyzer: ^7.3.0
   dart_style: ^3.0.1

--- a/packages/mix_lint/pubspec.yaml
+++ b/packages/mix_lint/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.3
 repository: https://github.com/btwld/mix
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   analyzer: ^7.3.0
@@ -13,5 +13,5 @@ dependencies:
 
 dev_dependencies:
   test: ^1.24.0
-  dart_code_metrics_presets: ^2.14.0
-  flutter_lints: ^4.0.0
+  dart_code_metrics_presets: ^2.22.0
+  flutter_lints: ^5.0.0

--- a/packages/mix_lint_test/pubspec.yaml
+++ b/packages/mix_lint_test/pubspec.yaml
@@ -3,8 +3,8 @@ description: A sample command-line application.
 publish_to: "none"
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"
 
 dependencies:
   flutter:

--- a/packages/naked/pubspec.yaml
+++ b/packages/naked/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.0.1-dev.0 # Or keep 0.0.1 if that's correct
 repository: https://github.com/leofarias/naked # Restore original repo URL
 
 environment:
-  sdk: ">=3.6.0 <4.0.0" # Restore original SDK constraint
-  flutter: ">=3.27.0" # Restore original Flutter constraint
+  sdk: ">=3.7.0 <4.0.0" # Restore original SDK constraint
+  flutter: ">=3.29.0" # Restore original Flutter constraint
 
 dependencies:
   flutter:
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0 # Restore original lints version
+  flutter_lints: ^5.0.0 # Restore original lints version
 
 # The following section is specific to Flutter packages.
 flutter:

--- a/packages/remix/demo/ios/Flutter/Debug.xcconfig
+++ b/packages/remix/demo/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/remix/demo/ios/Flutter/Release.xcconfig
+++ b/packages/remix/demo/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/remix/demo/ios/Podfile
+++ b/packages/remix/demo/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '12.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/packages/remix/demo/macos/Podfile
+++ b/packages/remix/demo/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.14'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/packages/remix/demo/pubspec.yaml
+++ b/packages/remix/demo/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -24,9 +24,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
   widgetbook_generator: ^3.8.0
-  build_runner: ^2.4.9
+  build_runner: ^2.5.0
 
 flutter:
   uses-material-design: true

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://www.fluttermix.com/
 version: 0.0.4+1
 
 environment:
-  sdk: ">=3.6.0 <4.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 
 
 dependencies:
@@ -23,10 +23,10 @@ dev_dependencies:
   # custom_lint: ^0.6.4
   # mix_lint: ^0.1.1
   mix_generator: ^0.4.0
-  build_runner: ^2.4.9
+  build_runner: ^2.5.0
   #lint
-  flutter_lints: ^4.0.0
-  dart_code_metrics_presets: ^2.14.0
+  flutter_lints: ^5.0.0
+  dart_code_metrics_presets: ^2.22.0
   
 
 flutter:


### PR DESCRIPTION
## Summary
- Update Flutter SDK version from 3.27.0 to 3.29.0 across all configuration files
- Update Dart SDK constraint from >=3.6.0 to >=3.7.0 for compatibility
- Update dev dependencies: flutter_lints (4.0.0 → 5.0.0), build_runner (2.4.9 → 2.5.0), dart_code_metrics_presets (2.14.0 → 2.22.0)
- Regenerate build runner artifacts with updated formatting

## Test plan
- [ ] Verify all packages can be built with Flutter 3.29.0
- [ ] Run tests to ensure compatibility
- [ ] Check that linting passes with new flutter_lints version

🤖 Generated with [Claude Code](https://claude.ai/code)