### PR TITLE
refactor: rename MixData to MixContext in code generation

### DIFF
--- a/packages/mix_generator/lib/src/core/property/property_method_builder.dart
+++ b/packages/mix_generator/lib/src/core/property/property_method_builder.dart
@@ -88,16 +88,16 @@ class MixableTypeMethods {
     const defaultValueRef = 'defaultValue';
 
     return '''
-  /// Resolves to [$resolvedType] using the provided [MixData].
+  /// Resolves to [$resolvedType] using the provided [MixContext].
   /// 
-  /// If a property is null in the [MixData], it falls back to the
+  /// If a property is null in the [MixContext], it falls back to the
   /// default value defined in the `$defaultValueRef` for that property.
   ///
   /// ```dart
   /// final ${resolvedType.lowerCaseFirst} = $className(...).resolve(mix);
   /// ```
   @override
-  $resolvedType resolve(MixData mix) {
+  $resolvedType resolve(MixContext mix) {
   $constIgnoreRule
     return $resolvedType$constructorRef(
       $params

--- a/packages/mix_generator/lib/src/core/spec/spec_mixin_builder.dart
+++ b/packages/mix_generator/lib/src/core/spec/spec_mixin_builder.dart
@@ -18,9 +18,9 @@ class SpecMixinBuilder implements CodeBuilder {
     final className = metadata.name;
     final specAttributeName = '${className}Attribute';
 
-    // Static from method to create from MixData
+    // Static from method to create from MixContext
     final fromMethod = '''
-static $className from(MixData mix) {
+static $className from(MixContext mix) {
   return mix.attributeOf<$specAttributeName>()?.resolve(mix) ?? ${metadata.isConst ? 'const' : ''} $className${metadata.constructorRef}();
 }''';
 

--- a/packages/mix_generator/test/src/core/spec/spec_attribute_builder_test.dart
+++ b/packages/mix_generator/test/src/core/spec/spec_attribute_builder_test.dart
@@ -56,7 +56,7 @@ void main() {}
 //       expect(generatedCode,
 //           contains('const TestSpecAttribute({this.name, this.age'));
 //       expect(generatedCode,
-//           contains('@override\n  TestSpec resolve(MixData mix)'));
+//           contains('@override\n  TestSpec resolve(MixContext mix)'));
 //       expect(generatedCode, contains('return TestSpec('));
 //       expect(
 //           generatedCode,
@@ -137,7 +137,7 @@ void main() {}
 //       expect(
 //           generatedCode, contains('const TestWidgetModifierSpecAttribute({'));
 //       expect(generatedCode,
-//           contains('@override\n  TestWidgetModifierSpec resolve(MixData mix)'));
+//           contains('@override\n  TestWidgetModifierSpec resolve(MixContext mix)'));
 //       expect(generatedCode, contains('return TestWidgetModifierSpec('));
 //       expect(
 //           generatedCode,

--- a/packages/mix_generator/test/src/core/spec/spec_mixin_builder_test.dart
+++ b/packages/mix_generator/test/src/core/spec/spec_mixin_builder_test.dart
@@ -52,7 +52,7 @@ void main() {}
 //       const expectedCode = '''
 // /// A mixin that provides spec functionality for [TestSpec].
 // mixin _\$TestSpec on Spec<TestSpec> {
-//   static TestSpec from(MixData mix) {
+//   static TestSpec from(MixContext mix) {
 //   return mix.attributeOf<TestSpecAttribute>()?.resolve(mix) ?? const TestSpec();
 // }
 
@@ -253,7 +253,7 @@ void main() {}
 //       const expectedCode = '''
 // /// A mixin that provides spec functionality for [DiagnosticableSpec].
 // mixin _\$DiagnosticableSpec on Spec<DiagnosticableSpec> {
-//   static DiagnosticableSpec from(MixData mix) {
+//   static DiagnosticableSpec from(MixContext mix) {
 //   return mix.attributeOf<DiagnosticableSpecAttribute>()?.resolve(mix) ?? const DiagnosticableSpec();
 // }
 
@@ -382,7 +382,7 @@ void main() {}
 //       const expectedCode = '''
 // /// A mixin that provides spec functionality for [ExistingMethodsSpec].
 // mixin _\$ExistingMethodsSpec on Spec<ExistingMethodsSpec> {
-//   static ExistingMethodsSpec from(MixData mix) {
+//   static ExistingMethodsSpec from(MixContext mix) {
 //   return mix.attributeOf<ExistingMethodsSpecAttribute>()?.resolve(mix) ?? const ExistingMethodsSpec();
 // }
 

--- a/packages/mix_generator/test/src/helpers/test_helpers.dart
+++ b/packages/mix_generator/test/src/helpers/test_helpers.dart
@@ -197,8 +197,8 @@ class SpecUtility {
 }
 
 /// Mix data container
-class MixData {
-  const MixData();
+class MixContext {
+  const MixContext();
 }
 
 /// Base class for all style elements


### PR DESCRIPTION
## Summary
• Renamed `MixData` to `MixContext` in code generation templates and test files
• Updated documentation comments to reflect the new naming convention
• Maintained backward compatibility in generated code structure

## Test plan
- [x] All existing tests pass
- [x] Generated code compiles without errors
- [x] Documentation comments are updated consistently

🤖 Generated with [Claude Code](https://claude.ai/code)