### PR TITLE
refactor: Remove SpecConfiguration and SpecStyle from environment

### DIFF
--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -6,10 +6,8 @@ import '../attributes/animated/animated_data_dto.dart';
 import '../attributes/modifiers/widget_modifiers_config.dart';
 import '../attributes/modifiers/widget_modifiers_config_dto.dart';
 import '../internal/compare_mixin.dart';
-import '../variants/context_variant_util/on_util.dart';
 import 'element.dart';
 import 'factory/mix_data.dart';
-import 'factory/style_mix.dart';
 
 @immutable
 abstract class Spec<T extends Spec<T>> with EqualityMixin {
@@ -89,22 +87,4 @@ abstract class SpecUtility<T extends StyleElement, V> extends StyleElement {
 
   @override
   get props => [attributeValue];
-}
-
-class SpecConfiguration<U extends SpecUtility> {
-  final BuildContext context;
-
-  final U _utility;
-
-  const SpecConfiguration(this.context, this._utility);
-
-  OnContextVariantUtility get on => OnContextVariantUtility.self;
-
-  U get utilities => _utility;
-}
-
-abstract class SpecStyle<U extends SpecUtility> {
-  const SpecStyle();
-
-  Style makeStyle(SpecConfiguration<U> spec);
 }

--- a/packages/remix/lib/src/components/action/icon_button/icon_button.dart
+++ b/packages/remix/lib/src/components/action/icon_button/icon_button.dart
@@ -5,6 +5,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 import '../../feedback/spinner/spinner.dart';
 
 part 'icon_button.g.dart';

--- a/packages/remix/lib/src/components/content_presentation/accordion/accordion.dart
+++ b/packages/remix/lib/src/components/content_presentation/accordion/accordion.dart
@@ -5,6 +5,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'accordion.g.dart';
 part 'accordion_style.dart';

--- a/packages/remix/lib/src/components/content_presentation/avatar/avatar.dart
+++ b/packages/remix/lib/src/components/content_presentation/avatar/avatar.dart
@@ -4,6 +4,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 import '../../../helpers/utility_extension.dart';
 
 part 'avatar.g.dart';

--- a/packages/remix/lib/src/components/content_presentation/card/card.dart
+++ b/packages/remix/lib/src/components/content_presentation/card/card.dart
@@ -5,6 +5,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'card.g.dart';
 part 'card_style.dart';

--- a/packages/remix/lib/src/components/content_presentation/chip/chip.dart
+++ b/packages/remix/lib/src/components/content_presentation/chip/chip.dart
@@ -5,6 +5,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'chip.g.dart';
 part 'chip_style.dart';

--- a/packages/remix/lib/src/components/content_presentation/label/label.dart
+++ b/packages/remix/lib/src/components/content_presentation/label/label.dart
@@ -4,6 +4,8 @@ import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
+import '../../../helpers/spec_style.dart';
+
 part 'label.g.dart';
 part 'label_style.dart';
 part 'label_widget.dart';

--- a/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.dart
+++ b/packages/remix/lib/src/components/content_presentation/menu_item/menu_item.dart
@@ -5,6 +5,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'menu_item.g.dart';
 part 'menu_item_style.dart';

--- a/packages/remix/lib/src/components/feedback/callout/callout.dart
+++ b/packages/remix/lib/src/components/feedback/callout/callout.dart
@@ -3,6 +3,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'callout.g.dart';
 part 'callout_style.dart';

--- a/packages/remix/lib/src/components/feedback/dialog/dialog.dart
+++ b/packages/remix/lib/src/components/feedback/dialog/dialog.dart
@@ -6,6 +6,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'dialog.g.dart';
 part 'dialog_style.dart';

--- a/packages/remix/lib/src/components/feedback/progress/progress.dart
+++ b/packages/remix/lib/src/components/feedback/progress/progress.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'progress.g.dart';
 part 'progress_style.dart';

--- a/packages/remix/lib/src/components/feedback/spinner/spinner.dart
+++ b/packages/remix/lib/src/components/feedback/spinner/spinner.dart
@@ -6,6 +6,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'spinner.g.dart';
 part 'spinner_painter.dart';

--- a/packages/remix/lib/src/components/feedback/toast/toast.dart
+++ b/packages/remix/lib/src/components/feedback/toast/toast.dart
@@ -6,6 +6,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'toast.g.dart';
 part 'toast_layer.dart';

--- a/packages/remix/lib/src/components/form/checkbox/checkbox.dart
+++ b/packages/remix/lib/src/components/form/checkbox/checkbox.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'checkbox.g.dart';
 part 'checkbox_style.dart';

--- a/packages/remix/lib/src/components/form/radio/radio.dart
+++ b/packages/remix/lib/src/components/form/radio/radio.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 import '../../../helpers/utility_extension.dart';
 
 part 'radio.g.dart';

--- a/packages/remix/lib/src/components/form/select/select.dart
+++ b/packages/remix/lib/src/components/form/select/select.dart
@@ -7,6 +7,7 @@ import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/object_ext.dart';
 import '../../../helpers/overlay.dart';
 import '../../../helpers/spec/composited_transform_follower_spec.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'item/select_menu.dart';
 part 'item/select_menu_widget.dart';

--- a/packages/remix/lib/src/components/form/slider/slider.dart
+++ b/packages/remix/lib/src/components/form/slider/slider.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'slider.g.dart';
 part 'slider_style.dart';

--- a/packages/remix/lib/src/components/form/slider/slider_style.dart
+++ b/packages/remix/lib/src/components/form/slider/slider_style.dart
@@ -60,7 +60,8 @@ class SliderDarkStyle extends SliderStyle {
       ..color.black()
       ..shape.circle.side.color.white();
 
-    return Style.create([super.makeStyle(spec), activeTrack, track, thumb]).animate(
+    return Style.create([super.makeStyle(spec), activeTrack, track, thumb])
+        .animate(
       duration: const Duration(milliseconds: 150),
       curve: Curves.easeInOut,
     );

--- a/packages/remix/lib/src/components/form/switch/switch.dart
+++ b/packages/remix/lib/src/components/form/switch/switch.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'switch.g.dart';
 part 'switch_style.dart';

--- a/packages/remix/lib/src/components/form/textfield/textfield.dart
+++ b/packages/remix/lib/src/components/form/textfield/textfield.dart
@@ -15,6 +15,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/component_builder.dart';
+import '../../../helpers/spec_style.dart';
 import 'attributes/attributes.dart';
 
 part 'textfield.g.dart';

--- a/packages/remix/lib/src/components/layout/divider/divider.dart
+++ b/packages/remix/lib/src/components/layout/divider/divider.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'divider.g.dart';
 part 'divider_style.dart';

--- a/packages/remix/lib/src/components/layout/header/header.dart
+++ b/packages/remix/lib/src/components/layout/header/header.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'header.g.dart';
 part 'header_style.dart';

--- a/packages/remix/lib/src/components/layout/scaffold/scaffold.dart
+++ b/packages/remix/lib/src/components/layout/scaffold/scaffold.dart
@@ -5,6 +5,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 import '../../feedback/toast/toast.dart';
 
 part 'scaffold.g.dart';

--- a/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.dart
+++ b/packages/remix/lib/src/components/navigation/segmented_control/segmented_control.dart
@@ -4,6 +4,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'button/segmented_control_button.dart';
 part 'button/segmented_control_button_widget.dart';

--- a/packages/remix/lib/src/components/utility/badge/badge.dart
+++ b/packages/remix/lib/src/components/utility/badge/badge.dart
@@ -3,6 +3,7 @@ import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 
 import '../../../core/theme/remix_theme.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'badge.g.dart';
 part 'badge_style.dart';

--- a/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.dart
+++ b/packages/remix/lib/src/components/utility/dropdown_menu/dropdown_menu.dart
@@ -6,6 +6,7 @@ import 'package:mix_annotations/mix_annotations.dart';
 import '../../../core/theme/remix_theme.dart';
 import '../../../helpers/object_ext.dart';
 import '../../../helpers/overlay.dart';
+import '../../../helpers/spec_style.dart';
 
 part 'dropdown_menu.g.dart';
 part 'dropdown_menu_style.dart';

--- a/packages/remix/lib/src/helpers/spec_style.dart
+++ b/packages/remix/lib/src/helpers/spec_style.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+import 'package:mix/mix.dart';
+
+class SpecConfiguration<U extends SpecUtility> {
+  final BuildContext context;
+
+  final U _utility;
+
+  const SpecConfiguration(this.context, this._utility);
+
+  OnContextVariantUtility get on => OnContextVariantUtility.self;
+
+  U get utilities => _utility;
+}
+
+abstract class SpecStyle<U extends SpecUtility> {
+  const SpecStyle();
+
+  Style makeStyle(SpecConfiguration<U> spec);
+}

--- a/packages/remix/lib/src/themes/fortaleza/components/accordion_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/accordion_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
 
 import '../../../components/content_presentation/accordion/accordion.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaAccordionStyle extends AccordionStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/avatar_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/avatar_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/content_presentation/avatar/avatar.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaAvatarStyle extends AvatarStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/badge_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/badge_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/utility/badge/badge.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaBadgeStyle extends BadgeStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/button_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/button_theme.dart
@@ -2,7 +2,7 @@
 // import 'package:mix/mix.dart';
 
 // import '../../../components/action/button/button.dart';
-// import '../tokens.dart';
+// import '../../../helpers/spec_style.dart';
 
 // class FortalezaButtonStyle extends ButtonStyle {
 //   static const soft = Variant('for.button.soft');

--- a/packages/remix/lib/src/themes/fortaleza/components/callout_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/callout_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/feedback/callout/callout.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaCalloutStyle extends CalloutStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/card_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/card_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/content_presentation/card/card.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaCardStyle extends CardStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/checkbox_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/checkbox_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
 
 import '../../../components/form/checkbox/checkbox.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaCheckboxStyle extends CheckboxStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/chip_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/chip_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/content_presentation/chip/chip.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaChipStyle extends ChipStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/dialog_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/dialog_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/feedback/dialog/dialog.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaDialogStyle extends DialogStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/divider_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/divider_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/layout/divider/divider.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaDividerStyle extends DividerStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/dropdown_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/dropdown_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/utility/dropdown_menu/dropdown_menu.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaDropdownMenuStyle extends DropdownMenuStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/header_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/header_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/layout/header/header.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaHeaderStyle extends HeaderStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/icon_button_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/icon_button_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/action/icon_button/icon_button.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaIconButtonStyle extends IconButtonStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/menu_item_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/menu_item_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/content_presentation/menu_item/menu_item.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaMenuItemStyle extends MenuItemStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/progress_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/progress_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/feedback/progress/progress.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaProgressStyle extends ProgressStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/radio_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/radio_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/animation.dart';
 import 'package:mix/mix.dart';
 
 import '../../../components/form/radio/radio.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaRadioStyle extends RadioStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/scaffold_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/scaffold_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/layout/scaffold/scaffold.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaScaffoldStyle extends ScaffoldStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/segmented_control_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/segmented_control_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/navigation/segmented_control/segmented_control.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaSegmentedControlStyle extends SegmentedControlStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/select_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/select_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/form/select/select.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaSelectStyle extends SelectStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/slider_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/slider_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/animation.dart';
 import 'package:mix/mix.dart';
 
 import '../../../components/form/slider/slider.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaSliderStyle extends SliderStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/spinner_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/spinner_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/feedback/spinner/spinner.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaSpinnerStyle extends SpinnerStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/switch_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/switch_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/form/switch/switch.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaSwitchStyle extends SwitchStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/textfield_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/textfield_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/form/textfield/textfield.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaTextFieldStyle extends TextFieldStyle {

--- a/packages/remix/lib/src/themes/fortaleza/components/toast_theme.dart
+++ b/packages/remix/lib/src/themes/fortaleza/components/toast_theme.dart
@@ -1,6 +1,7 @@
 import 'package:mix/mix.dart';
 
 import '../../../components/feedback/toast/toast.dart';
+import '../../../helpers/spec_style.dart';
 import '../tokens.dart';
 
 class FortalezaToastStyle extends ToastStyle {


### PR DESCRIPTION
## Summary
- Removes SpecConfiguration and SpecStyle classes from the core spec system
- Updates all component implementations to work without spec widgets
- Adds spec_style.dart helper to maintain styling functionality
- This change is one step towards completely removing SpecStyle from the environment

## Changes
- Removed SpecConfiguration class and its context/utility management from `lib/src/core/spec.dart`
- Removed SpecStyle abstract class and makeStyle method
- Updated 49 component files to work without the removed spec widget system
- Added `spec_style.dart` helper for style generation

## Test plan
- [ ] Verify all components still render correctly
- [ ] Run existing tests to ensure no regressions
- [ ] Check that themes still apply properly to components

🤖 Generated with [Claude Code](https://claude.ai/code)