### PR TITLE
fix: Add variant condition check to ContextVariantBuilder

### DIFF
--- a/packages/mix/lib/src/core/factory/mix_data.dart
+++ b/packages/mix/lib/src/core/factory/mix_data.dart
@@ -212,7 +212,8 @@ Style _applyVariants(
   Style style,
   VariantAttribute variantAttribute,
 ) {
-  if (variantAttribute is ContextVariantBuilder) {
+  if (variantAttribute is ContextVariantBuilder &&
+      variantAttribute.variant.when(context)) {
     return style.merge(variantAttribute.build(context));
   }
 

--- a/packages/mix/test/src/factory/mix_provider_data_test.dart
+++ b/packages/mix/test/src/factory/mix_provider_data_test.dart
@@ -174,6 +174,27 @@ void main() {
       });
 
       test(
+          'ContextVariantBuilder should apply Style based on when() return value',
+          () {
+        for (var whenReturnValue in [true, false]) {
+          final variant = _MockContextVariant(whenReturnValue: whenReturnValue);
+          final style = Style(const MockIntScalarAttribute(1));
+          final builder = ContextVariantBuilder((_) => style, variant);
+
+          final attributesList = applyContextToVisualAttributes(
+            MockBuildContext(),
+            Style(builder),
+          );
+
+          if (whenReturnValue) {
+            expect(attributesList, equals([const MockIntScalarAttribute(1)]));
+          } else {
+            expect(attributesList, isEmpty);
+          }
+        }
+      });
+
+      test(
           'must return the same Style that was inputted when is only Variants in the Style',
           () {
         _testApplyContextToVisualAttributes(
@@ -579,4 +600,12 @@ void _testApplyContextToVisualAttributes({
   ]);
 
   expect(attributeList, expectedStyle.styles.values);
+}
+
+class _MockContextVariant extends ContextVariant {
+  final bool whenReturnValue;
+  const _MockContextVariant({this.whenReturnValue = true});
+
+  @override
+  bool when(BuildContext context) => whenReturnValue;
 }


### PR DESCRIPTION
## Summary
- Adds variant condition check to ContextVariantBuilder in _applyVariants function
- Ensures that styles are only applied when the variant condition is met
- Prevents incorrect style application when variant conditions are false

## Changes
- Modified `lib/src/core/factory/mix_data.dart:215-216` to include variant condition check

## Test plan
- [ ] Verify that ContextVariantBuilder only applies styles when variant condition is true
- [ ] Test that styles are not applied when variant condition is false
- [ ] Run existing tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)