### PR TITLE
feat: Add icon position support

### DIFF
--- a/packages/remix/demo/lib/blocks/auth.dart
+++ b/packages/remix/demo/lib/blocks/auth.dart
@@ -79,20 +79,20 @@ class _AuthBlockState extends State<AuthBlock> {
                   children: [
                     RxTextField(
                       controller: usernameController,
-                      placeholderText: 'Username',
+                      hintText: 'Username',
                       style: TextFieldStyle(),
                     ),
                     RxTextField(
                       controller: passwordController,
                       obscureText: !showPassword,
-                      placeholderText: 'Password',
+                      hintText: 'Password',
                       suffix: RxButton(
                         onPressed: () {
                           setState(() {
                             showPassword = !showPassword;
                           });
                         },
-                        label: 'Show',
+                        label: showPassword ? 'Hide' : 'Show',
                         style: LinkButtonStyle()..textStyle.fontSize(14),
                       ),
                       style: TextFieldStyle(),
@@ -126,20 +126,23 @@ class _AuthBlockState extends State<AuthBlock> {
             Column(
               spacing: 8,
               children: [
-                SocialMediaButton(
+                RxButton(
                   label: 'Continue with Apple',
                   onPressed: () {},
                   icon: Icons.apple,
+                  style: SocialMediaButtonStyle(),
                 ),
-                SocialMediaButton(
+                RxButton(
                   label: 'Continue with Facebook',
                   onPressed: () {},
                   icon: Icons.facebook,
+                  style: SocialMediaButtonStyle(),
                 ),
-                SocialMediaButton(
+                RxButton(
                   label: 'Show more options',
                   onPressed: () {},
                   icon: Icons.add,
+                  style: SocialMediaButtonStyle(),
                 ),
               ],
             ),
@@ -181,38 +184,18 @@ class TextFieldStyle extends RxTextFieldStyle {
   }
 }
 
-class SocialMediaButton extends StatelessWidget {
-  const SocialMediaButton({
-    super.key,
-    required this.label,
-    required this.onPressed,
-    required this.icon,
-  });
-
-  final String label;
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return RxButton.raw(
-      onPressed: onPressed,
-      style: RxButtonStyle()
-        ..icon.size(24)
-        ..container.height(56)
-        ..container.color.white()
-        ..container.border.all.color.grey.shade300()
-        ..textStyle.color.black()
-        ..textStyle.fontWeight.w500()
-        ..icon.color.black(),
-      child: Row(
-        spacing: 12,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(icon),
-          Text(label),
-        ],
-      ),
-    );
+class SocialMediaButtonStyle extends RxButtonStyle {
+  SocialMediaButtonStyle() : super() {
+    container
+      ..alignment.center()
+      ..height(56)
+      ..color.white()
+      ..border.all.color.grey.shade300();
+    textStyle
+      ..color.black()
+      ..fontWeight.w500();
+    icon
+      ..color.black()
+      ..size(24);
   }
 }

--- a/packages/remix/lib/src/components/action/button/button_widget.dart
+++ b/packages/remix/lib/src/components/action/button/button_widget.dart
@@ -25,7 +25,8 @@ class RxButton extends StatefulWidget implements Disableable {
   RxButton({
     super.key,
     required String label,
-    IconData? leadingIcon,
+    IconData? icon,
+    IconPosition iconPosition = IconPosition.start,
     this.enabled = true,
     this.loading = false,
     this.spinnerWidget,
@@ -34,7 +35,7 @@ class RxButton extends StatefulWidget implements Disableable {
     this.focusNode,
     this.variants = const [],
     this.style,
-  }) : child = RxLabel(label, icon: leadingIcon);
+  }) : child = RxLabel(label, icon: icon, iconPosition: iconPosition);
 
   /// Creates a Remix button with only an icon.
   ///

--- a/packages/remix/lib/src/components/content_presentation/label/label.dart
+++ b/packages/remix/lib/src/components/content_presentation/label/label.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 

--- a/packages/remix/lib/src/components/content_presentation/label/label_widget.dart
+++ b/packages/remix/lib/src/components/content_presentation/label/label_widget.dart
@@ -1,5 +1,10 @@
 part of 'label.dart';
 
+enum IconPosition {
+  start,
+  end,
+}
+
 /// A customizable label component that supports icons and styling.
 ///
 /// The [RxLabel] widget is designed to display text with optional icons.
@@ -26,6 +31,7 @@ class RxLabel extends StatelessWidget {
     this.icon,
     this.variants = const [],
     this.style,
+    this.iconPosition = IconPosition.start,
   });
 
   /// The text to display in the label.
@@ -36,6 +42,8 @@ class RxLabel extends StatelessWidget {
 
   /// {@macro remix.component.variants}
   final List<Variant> variants;
+
+  final IconPosition iconPosition;
 
   /// {@macro remix.component.style}
   final RxLabelStyle? style;
@@ -52,7 +60,13 @@ class RxLabel extends StatelessWidget {
         return Row(
           mainAxisSize: MainAxisSize.min,
           spacing: spec.spacing,
-          children: [if (icon != null) spec.icon(icon), spec.label(label)],
+          children: [
+            if (icon != null && iconPosition == IconPosition.start)
+              spec.icon(icon),
+            spec.label(label),
+            if (icon != null && iconPosition == IconPosition.end)
+              spec.icon(icon),
+          ],
         );
       },
     );


### PR DESCRIPTION
## Summary

This PR adds icon position support to RxButton and RxLabel components, allowing icons to be positioned at either the start or end of the label text.

### Changes Made

- **RxLabel**: Added `IconPosition` enum with `start` and `end` options
- **RxLabel**: Added `iconPosition` parameter to control icon placement (defaults to `IconPosition.start`)
- **RxButton**: Updated constructor to use generic `icon` parameter instead of `leadingIcon`
- **RxButton**: Added `iconPosition` parameter support (defaults to `IconPosition.start`)
- **Demo**: Refactored auth block to use RxButton with SocialMediaButtonStyle instead of custom SocialMediaButton widget
- **Demo**: Updated text field properties from `placeholderText` to `hintText`
- **Demo**: Improved show/hide password button text logic

### Example

```dart
// Before
RxButton(
  label: 'Button',
  leadingIcon: Icons.add,
)

// After  
RxButton(
  label: 'Button',
  icon: Icons.add,
  iconPosition: IconPosition.start, // optional, defaults to start
)
```