### PR TITLE
fix: Address multiple deprecation warnings across the codebase

### DIFF
--- a/packages/mix/lib/src/core/spec.dart
+++ b/packages/mix/lib/src/core/spec.dart
@@ -40,7 +40,7 @@ abstract class Spec<T extends Spec<T>> with EqualityMixin {
 abstract class SpecAttribute<Value> extends StyleElement
     implements Mixable<Value> {
   final AnimatedDataDto? animated;
-  final WidgetModifiersDataDto? modifiers;
+  final WidgetModifiersConfigDto? modifiers;
 
   const SpecAttribute({this.animated, this.modifiers});
 

--- a/packages/mix/lib/src/modifiers/default_text_style_widget_modifier.dart
+++ b/packages/mix/lib/src/modifiers/default_text_style_widget_modifier.dart
@@ -57,7 +57,7 @@ final class DefaultTextStyleModifierSpec
   }
 }
 
-final class DefaultTextStyleModifierSpecUtility<T extends Attribute>
+final class DefaultTextStyleModifierSpecUtility<T extends StyleElement>
     extends MixUtility<T, DefaultTextStyleModifierSpecAttribute> {
   const DefaultTextStyleModifierSpecUtility(super.builder);
   T call({

--- a/packages/mix/test/src/specs/flex/flex_spec_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_spec_test.dart
@@ -215,8 +215,8 @@ void main() {
 
     test('Immutable behavior when having multiple flexes', () {
       final flexUtil = FlexSpecUtility.self;
-      final flex1 = flexUtil.chain..gap(10);
-      final flex2 = flexUtil.chain..gap(20);
+      final flex1 = flexUtil..gap(10);
+      final flex2 = flexUtil..gap(20);
 
       final attr1 = flex1.attributeValue!;
       final attr2 = flex2.attributeValue!;

--- a/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
@@ -348,10 +348,10 @@ void main() {
 
     test('Immutable behavior when having multiple flexboxes', () {
       final flexBoxUtil = FlexBoxSpecUtility.self;
-      final flexBox1 = flexBoxUtil.chain
+      final flexBox1 = flexBoxUtil
         ..box.padding(10)
         ..flex.mainAxisAlignment.start();
-      final flexBox2 = flexBoxUtil.chain
+      final flexBox2 = flexBoxUtil
         ..box.padding(20)
         ..flex.mainAxisAlignment.end();
 

--- a/packages/mix/test/src/specs/icon/icon_spec_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_spec_test.dart
@@ -166,8 +166,8 @@ void main() {
 
     test('Immutable behavior when having multiple icons', () {
       final iconUtil = IconSpecUtility.self;
-      final icon1 = iconUtil.chain..size(24);
-      final icon2 = iconUtil.chain..size(48);
+      final icon1 = iconUtil..size(24);
+      final icon2 = iconUtil..size(48);
 
       final attr1 = icon1.attributeValue!;
       final attr2 = icon2.attributeValue!;

--- a/packages/mix/test/src/specs/image/image_spec_test.dart
+++ b/packages/mix/test/src/specs/image/image_spec_test.dart
@@ -158,8 +158,8 @@ void main() {
 
     test('Immutable behavior when having multiple images', () {
       final imageUtil = ImageSpecUtility.self;
-      final image1 = imageUtil.chain..width(100);
-      final image2 = imageUtil.chain..width(200);
+      final image1 = imageUtil..width(100);
+      final image2 = imageUtil..width(200);
 
       final attr1 = image1.attributeValue!;
       final attr2 = image2.attributeValue!;

--- a/packages/mix/test/src/specs/stack/stack_spec_test.dart
+++ b/packages/mix/test/src/specs/stack/stack_spec_test.dart
@@ -111,8 +111,8 @@ void main() {
 
     test('Immutable behavior when having multiple stacks', () {
       final stackUtil = StackSpecUtility.self;
-      final stack1 = stackUtil.chain..alignment.topLeft();
-      final stack2 = stackUtil.chain..alignment.bottomRight();
+      final stack1 = stackUtil..alignment.topLeft();
+      final stack2 = stackUtil..alignment.bottomRight();
 
       final attr1 = stack1.attributeValue!;
       final attr2 = stack2.attributeValue!;

--- a/packages/mix/test/src/specs/text/text_spec_test.dart
+++ b/packages/mix/test/src/specs/text/text_spec_test.dart
@@ -340,8 +340,8 @@ void main() {
 
     test('Immutable behavior when having multiple texts', () {
       final textUtil = TextSpecUtility.self;
-      final text1 = textUtil.chain..maxLines(3);
-      final text2 = textUtil.chain..maxLines(5);
+      final text1 = textUtil..maxLines(3);
+      final text2 = textUtil..maxLines(5);
 
       final attr1 = text1.attributeValue!;
       final attr2 = text2.attributeValue!;

--- a/packages/naked/example/lib/api/naked_select.1.dart
+++ b/packages/naked/example/lib/api/naked_select.1.dart
@@ -123,7 +123,7 @@ class _AnimatedSelectExampleState extends State<AnimatedSelectExample>
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 8,
                       offset: const Offset(0, 4),
                     ),

--- a/packages/naked/example/lib/api/naked_select.2.dart
+++ b/packages/naked/example/lib/api/naked_select.2.dart
@@ -129,7 +129,7 @@ class _AnimatedMultiSelectExampleState extends State<AnimatedMultiSelectExample>
                   borderRadius: BorderRadius.circular(12),
                   boxShadow: [
                     BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
+                      color: Colors.black.withValues(alpha: 0.1),
                       blurRadius: 8,
                       offset: const Offset(0, 4),
                     ),

--- a/packages/remix/demo/lib/components/card_use_case.dart
+++ b/packages/remix/demo/lib/components/card_use_case.dart
@@ -25,7 +25,7 @@ Widget buildCard(BuildContext context) {
                 StyledText(
                   'Leo Farias',
                   style: Style(
-                    $text.chain
+                    $text
                       ..style.fontSize(14)
                       ..style.fontWeight.bold()
                       ..style.color.black87(),
@@ -37,7 +37,7 @@ Widget buildCard(BuildContext context) {
                 StyledText(
                   'Flutter Engineer',
                   style: Style(
-                    $text.chain
+                    $text
                       ..style.fontSize(12)
                       ..style.color.black54(),
                     $on.dark(

--- a/packages/remix/demo/lib/components/header_use_case.dart
+++ b/packages/remix/demo/lib/components/header_use_case.dart
@@ -12,7 +12,7 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 Widget buildCard(BuildContext context) {
   final leading = Box(
     style: Style(
-      $box.chain
+      $box
         ..padding(10)
         ..color.white10()
         ..borderRadius(8)


### PR DESCRIPTION
## Summary
• Fixed deprecated `WidgetModifiersDataDto` to use `WidgetModifiersConfigDto`
• Updated deprecated generic type constraint from `Attribute` to `StyleElement`
• Replaced deprecated `.chain` utility syntax with direct utility calls
• Updated deprecated `withOpacity()` to use `withValues(alpha:)` for colors

## Test plan
- [x] All existing tests pass
- [x] No new deprecation warnings in build output
- [x] Code maintains existing functionality