### PR TITLE
test: Create a test suite for RxButton and RxLabel

### DIFF
--- a/packages/remix/lib/src/components/action/button/button_widget.dart
+++ b/packages/remix/lib/src/components/action/button/button_widget.dart
@@ -29,7 +29,7 @@ class RxButton extends StatefulWidget implements Disableable {
     IconPosition iconPosition = IconPosition.start,
     this.enabled = true,
     this.loading = false,
-    this.spinnerWidget,
+    this.spinnerBuilder,
     this.enableHapticFeedback = true,
     required this.onPressed,
     this.focusNode,
@@ -56,7 +56,7 @@ class RxButton extends StatefulWidget implements Disableable {
     super.key,
     this.enabled = true,
     this.loading = false,
-    this.spinnerWidget,
+    this.spinnerBuilder,
     this.enableHapticFeedback = true,
     required this.onPressed,
     this.focusNode,
@@ -83,7 +83,7 @@ class RxButton extends StatefulWidget implements Disableable {
     required this.child,
     this.enabled = true,
     this.loading = false,
-    this.spinnerWidget,
+    this.spinnerBuilder,
     this.enableHapticFeedback = true,
     required this.onPressed,
     this.focusNode,
@@ -101,7 +101,7 @@ class RxButton extends StatefulWidget implements Disableable {
   /// Whether the button is in a loading state.
   ///
   /// When true, the button will display a spinner and become non-interactive.
-  /// The spinner can be customized via [spinnerWidget].
+  /// The spinner can be customized via [spinnerBuilder].
   final bool loading;
 
   /// Callback function called when the button is pressed.
@@ -121,11 +121,11 @@ class RxButton extends StatefulWidget implements Disableable {
   /// RxButton(
   ///   label: 'Submit',
   ///   loading: true,
-  ///   spinnerWidget: CircularProgressIndicator(),
+  ///   spinnerBuilder: (context) => CircularProgressIndicator(),
   ///   onPressed: () {},
   /// )
   /// ```
-  final Widget? spinnerWidget;
+  final WidgetBuilder? spinnerBuilder;
 
   /// The style configuration for the button.
   ///
@@ -149,8 +149,13 @@ class RxButton extends StatefulWidget implements Disableable {
 
 class _RxButtonState extends State<RxButton> with MixControllerMixin {
   /// Builds the loading overlay that shows a spinner while preserving layout.
-  Widget _buildLoadingOverlay(ButtonSpec spec, Widget child) {
-    final Widget spinner = widget.spinnerWidget ?? spec.spinner();
+  Widget _buildLoadingOverlay(
+    ButtonSpec spec,
+    Widget child,
+    BuildContext context,
+  ) {
+    final Widget spinner =
+        widget.spinnerBuilder?.call(context) ?? spec.spinner();
 
     return widget.loading
         ? Stack(
@@ -194,7 +199,13 @@ class _RxButtonState extends State<RxButton> with MixControllerMixin {
               child: IconTheme(
                 data: spec.icon,
                 child: widget.loading
-                    ? _buildLoadingOverlay(spec, widget.child)
+                    ? Builder(builder: (context) {
+                        return _buildLoadingOverlay(
+                          spec,
+                          widget.child,
+                          context,
+                        );
+                      })
                     : widget.child,
               ),
             ),

--- a/packages/remix/lib/src/components/content_presentation/chip/chip_widget.dart
+++ b/packages/remix/lib/src/components/content_presentation/chip/chip_widget.dart
@@ -31,6 +31,7 @@ class RxChip extends StatefulWidget implements Disableable, Selectable {
     this.iconLeft,
     this.iconRight,
     this.variants = const [],
+    this.focusNode,
     required this.onChanged,
     this.style,
   }) : child = _ChipBody(
@@ -60,6 +61,7 @@ class RxChip extends StatefulWidget implements Disableable, Selectable {
     this.iconLeft,
     this.iconRight,
     this.variants = const [],
+    this.focusNode,
     required this.child,
     required this.onChanged,
     this.style,
@@ -94,6 +96,9 @@ class RxChip extends StatefulWidget implements Disableable, Selectable {
   /// {@macro remix.component.style}
   final RxChipStyle? style;
 
+  /// {@macro remix.component.focusNode}
+  final FocusNode? focusNode;
+
   @override
   State<RxChip> createState() => _RxChipState();
 }
@@ -118,13 +123,10 @@ class _RxChipState extends State<RxChip>
         mixController.focused = state;
       },
       enabled: widget.enabled,
+      focusNode: widget.focusNode,
       child: RemixBuilder(
         builder: (context) {
-          return _ChipBody(
-            iconLeft: widget.iconLeft,
-            iconRight: widget.iconRight,
-            label: widget.label,
-          );
+          return widget.child;
         },
         style: Style(_style).applyVariants(widget.variants),
         controller: mixController,

--- a/packages/remix/lib/src/components/form/checkbox/checkbox_widget.dart
+++ b/packages/remix/lib/src/components/form/checkbox/checkbox_widget.dart
@@ -33,6 +33,7 @@ class RxCheckbox extends StatefulWidget implements Disableable, Selectable {
     this.style,
     this.variants = const [],
     this.label,
+    this.focusNode,
   });
 
   /// {@macro remix.component.enabled}
@@ -61,6 +62,9 @@ class RxCheckbox extends StatefulWidget implements Disableable, Selectable {
   /// An optional label that will be displayed next to the checkbox.
   final String? label;
 
+  /// {@macro remix.component.focusNode}
+  final FocusNode? focusNode;
+
   @override
   State<RxCheckbox> createState() => _RxCheckboxState();
 }
@@ -75,6 +79,9 @@ class _RxCheckboxState extends State<RxCheckbox>
     return NakedCheckbox(
       value: widget.selected,
       onChanged: (value) => widget.onChanged?.call(value ?? false),
+      onHoverState: (state) {
+        mixController.hovered = state;
+      },
       onPressedState: (state) {
         mixController.pressed = state;
       },
@@ -82,6 +89,7 @@ class _RxCheckboxState extends State<RxCheckbox>
         mixController.focused = state;
       },
       enabled: widget.enabled,
+      focusNode: widget.focusNode,
       child: RemixBuilder(
         builder: (context) {
           final spec = CheckboxSpec.of(context);

--- a/packages/remix/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/remix/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,0 +1,10 @@
+//
+//  Generated file. Do not edit.
+//
+
+import FlutterMacOS
+import Foundation
+
+
+func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+}

--- a/packages/remix/test/components/button_test.dart
+++ b/packages/remix/test/components/button_test.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/remix.dart';
+
+import '../utils/interaction_tests.dart';
+
+void main() {
+  group('RxButton', () {
+    group('Constructor', () {
+      const child = Text('Raw Button');
+      const label = 'Raw Button';
+      const icon = Icons.star;
+      const variants = [Variant('warning')];
+      final focusNode = FocusNode();
+      Widget spinnerBuilder(context) => const SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          );
+
+      testWidgets(
+          'ensures RxButton.raw initializes with correct properties and displays child widget',
+          (WidgetTester tester) async {
+        final widget = RxButton.raw(
+          enabled: true,
+          loading: false,
+          enableHapticFeedback: true,
+          onPressed: () {},
+          variants: variants,
+          style: RxButtonStyle(),
+          focusNode: focusNode,
+          spinnerBuilder: spinnerBuilder,
+          child: child,
+        );
+
+        await pumpRxWidget(tester, widget);
+
+        expect(widget.enabled, isTrue);
+        expect(widget.loading, isFalse);
+        expect(widget.enableHapticFeedback, isTrue);
+        expect(widget.variants, variants);
+        expect(widget.style, RxButtonStyle());
+        expect(widget.child, child);
+        expect(widget.focusNode, focusNode);
+        expect(widget.spinnerBuilder, spinnerBuilder);
+
+        expect(find.text('Raw Button'), findsOneWidget);
+      });
+
+      testWidgets(
+          'ensures RxButton initializes with correct properties and displays child widget',
+          (WidgetTester tester) async {
+        final widget = RxButton(
+          label: label,
+          icon: icon,
+          enabled: true,
+          loading: false,
+          enableHapticFeedback: true,
+          onPressed: () {},
+          variants: variants,
+          style: RxButtonStyle(),
+          focusNode: focusNode,
+          spinnerBuilder: spinnerBuilder,
+        );
+
+        await pumpRxWidget(tester, widget);
+
+        expect(widget.enabled, isTrue);
+        expect(widget.loading, isFalse);
+        expect(widget.enableHapticFeedback, isTrue);
+        expect(widget.variants, variants);
+        expect(widget.style, RxButtonStyle());
+        expect(widget.focusNode, focusNode);
+        expect(widget.spinnerBuilder, spinnerBuilder);
+
+        expect(find.text(label), findsOneWidget);
+        expect(find.byIcon(icon), findsOneWidget);
+      });
+
+      testWidgets(
+          'ensures RxButton.icon initializes with correct properties and displays icon',
+          (WidgetTester tester) async {
+        final widget = RxButton.icon(
+          icon,
+          enabled: true,
+          loading: false,
+          enableHapticFeedback: true,
+          onPressed: () {},
+          variants: variants,
+          style: RxButtonStyle(),
+          focusNode: focusNode,
+          spinnerBuilder: spinnerBuilder,
+        );
+
+        await pumpRxWidget(tester, widget);
+
+        expect(widget.enabled, isTrue);
+        expect(widget.loading, isFalse);
+        expect(widget.enableHapticFeedback, isTrue);
+        expect(widget.variants, variants);
+        expect(widget.style, RxButtonStyle());
+        expect(widget.focusNode, focusNode);
+        expect(widget.spinnerBuilder, spinnerBuilder);
+
+        expect(find.byIcon(icon), findsOneWidget);
+        expect(find.byType(Text), findsNothing);
+      });
+    });
+
+    testWidgets('creates button with icon in different positions',
+        (WidgetTester tester) async {
+      for (var position in [IconPosition.start, IconPosition.end]) {
+        await pumpRxWidget(
+          tester,
+          RxButton(
+            label: 'Test Button',
+            icon: Icons.arrow_forward,
+            iconPosition: position,
+            onPressed: () {},
+          ),
+        );
+
+        expect(find.text('Test Button'), findsOneWidget);
+        expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+
+        final findPosition = position == IconPosition.start
+            ? FindPosition.first
+            : FindPosition.last;
+
+        final iconWidget = findWidgetInFlex<Icon>(
+          tester,
+          parentType: RxButton,
+          widgetType: Icon,
+          findPosition: findPosition,
+        );
+
+        expect(iconWidget.icon, Icons.arrow_forward);
+      }
+    });
+
+    testWidgets('creates button with custom spinner',
+        (WidgetTester tester) async {
+      for (var loadingState in [true, false]) {
+        await pumpRxWidget(
+          tester,
+          RxButton(
+            label: 'Custom Spinner',
+            loading: loadingState,
+            spinnerBuilder: (context) => const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            onPressed: () {},
+          ),
+        );
+
+        expect(find.text('Custom Spinner'), findsOneWidget);
+        if (loadingState) {
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        } else {
+          expect(find.byType(CircularProgressIndicator), findsNothing);
+        }
+      }
+    });
+
+    testWidgets('applies custom style correctly', (WidgetTester tester) async {
+      await pumpRxWidget(
+        tester,
+        RxButton(
+          label: 'Styled Button',
+          style: RxButtonStyle()
+            ..container.color.red()
+            ..textStyle.color.purple()
+            ..container.borderRadius.circular(8),
+          onPressed: () {},
+        ),
+      );
+
+      final buttonFinder = find.byType(RxButton);
+      final textFinder = find.byType(RichText);
+
+      expect(buttonFinder, findsOneWidget);
+      expect(textFinder, findsOneWidget);
+
+      // Find the Container widget inside the RxButton
+      final containerFinder = find.descendant(
+        of: buttonFinder,
+        matching: find.byType(Container),
+      );
+      final buttonContainer = tester.widget<Container>(containerFinder);
+
+      // Verify Container color and borderRadius
+      final decoration = buttonContainer.decoration as BoxDecoration;
+      expect(decoration.color, equals(Colors.red));
+      expect(decoration.borderRadius, equals(BorderRadius.circular(8)));
+
+      // Verify the Text widget color
+      final textWidget = tester.widget<RichText>(textFinder);
+      expect(textWidget.text.style?.color, equals(Colors.purple));
+    });
+
+    group('Interaction', () {
+      testTapWidget(
+          'should be clickable when enabled is true and onPressed is not null',
+          (holder) {
+        return RxButton(
+          label: 'Test Button',
+          onPressed: () => holder.value = true,
+        );
+      }, shouldExpectPress: true);
+
+      testTapWidget('should be unclickable when enabled is false', (value) {
+        return RxButton(
+          label: 'Test Button',
+          onPressed: () => value.value = true,
+          enabled: false,
+        );
+      }, shouldExpectPress: false);
+
+      testTapWidget('should be unclickable when onPressed is null', (value) {
+        return RxButton(
+          label: 'Test Button',
+          onPressed: null,
+        );
+      }, shouldExpectPress: false);
+
+      testHoverWidget('should be hoverable when enabled', () {
+        return RxButton(
+          label: 'Test Button',
+          onPressed: () {},
+        );
+      }, shouldExpectHover: true);
+
+      testHoverWidget('should not react to hover when disabled', () {
+        return RxButton(
+          label: 'Test Button',
+          onPressed: () {},
+          enabled: false,
+        );
+      }, shouldExpectHover: false);
+
+      testFocusWidget('should be focusable when enabled', (focusNode) {
+        return RxButton(
+          label: 'Test Button',
+          focusNode: focusNode,
+          onPressed: () {},
+        );
+      }, shouldExpectFocus: true);
+
+      testFocusWidget('should not be focusable when disabled', (focusNode) {
+        return RxButton(
+          label: 'Test Button',
+          focusNode: focusNode,
+          onPressed: () {},
+          enabled: false,
+        );
+      }, shouldExpectFocus: false);
+    });
+  });
+}

--- a/packages/remix/test/components/button_test.dart
+++ b/packages/remix/test/components/button_test.dart
@@ -8,7 +8,11 @@ import '../utils/interaction_tests.dart';
 void main() {
   group('RxButton', () {
     group('Constructor', () {
-      const child = Text('Raw Button');
+      const child = SizedBox(
+        width: 100,
+        height: 100,
+        child: Icon(Icons.star),
+      );
       const label = 'Raw Button';
       const icon = Icons.star;
       const variants = [Variant('warning')];
@@ -20,7 +24,7 @@ void main() {
           );
 
       testWidgets(
-          'ensures RxButton.raw initializes with correct properties and displays child widget',
+          'Should initialize RxButton.raw with correct properties and display child widget',
           (WidgetTester tester) async {
         final widget = RxButton.raw(
           enabled: true,
@@ -34,7 +38,7 @@ void main() {
           child: child,
         );
 
-        await pumpRxWidget(tester, widget);
+        await tester.pumpRxWidget(widget);
 
         expect(widget.enabled, isTrue);
         expect(widget.loading, isFalse);
@@ -45,11 +49,11 @@ void main() {
         expect(widget.focusNode, focusNode);
         expect(widget.spinnerBuilder, spinnerBuilder);
 
-        expect(find.text('Raw Button'), findsOneWidget);
+        expect(find.byWidget(child), findsOneWidget);
       });
 
       testWidgets(
-          'ensures RxButton initializes with correct properties and displays child widget',
+          'Should initialize RxButton with correct properties and display child widget',
           (WidgetTester tester) async {
         final widget = RxButton(
           label: label,
@@ -64,7 +68,7 @@ void main() {
           spinnerBuilder: spinnerBuilder,
         );
 
-        await pumpRxWidget(tester, widget);
+        await tester.pumpRxWidget(widget);
 
         expect(widget.enabled, isTrue);
         expect(widget.loading, isFalse);
@@ -79,7 +83,7 @@ void main() {
       });
 
       testWidgets(
-          'ensures RxButton.icon initializes with correct properties and displays icon',
+          'Should initialize RxButton.icon with correct properties and display icon',
           (WidgetTester tester) async {
         final widget = RxButton.icon(
           icon,
@@ -93,7 +97,7 @@ void main() {
           spinnerBuilder: spinnerBuilder,
         );
 
-        await pumpRxWidget(tester, widget);
+        await tester.pumpRxWidget(widget);
 
         expect(widget.enabled, isTrue);
         expect(widget.loading, isFalse);
@@ -108,11 +112,10 @@ void main() {
       });
     });
 
-    testWidgets('creates button with icon in different positions',
+    testWidgets('Should create button with icon in different positions',
         (WidgetTester tester) async {
       for (var position in [IconPosition.start, IconPosition.end]) {
-        await pumpRxWidget(
-          tester,
+        await tester.pumpRxWidget(
           RxButton(
             label: 'Test Button',
             icon: Icons.arrow_forward,
@@ -139,11 +142,10 @@ void main() {
       }
     });
 
-    testWidgets('creates button with custom spinner',
+    testWidgets('Should create button with custom spinner',
         (WidgetTester tester) async {
       for (var loadingState in [true, false]) {
-        await pumpRxWidget(
-          tester,
+        await tester.pumpRxWidget(
           RxButton(
             label: 'Custom Spinner',
             loading: loadingState,
@@ -165,9 +167,9 @@ void main() {
       }
     });
 
-    testWidgets('applies custom style correctly', (WidgetTester tester) async {
-      await pumpRxWidget(
-        tester,
+    testWidgets('Should apply custom style correctly',
+        (WidgetTester tester) async {
+      await tester.pumpRxWidget(
         RxButton(
           label: 'Styled Button',
           style: RxButtonStyle()
@@ -203,7 +205,7 @@ void main() {
 
     group('Interaction', () {
       testTapWidget(
-          'should be clickable when enabled is true and onPressed is not null',
+          'Should be clickable when enabled is true and onPressed is not null',
           (holder) {
         return RxButton(
           label: 'Test Button',
@@ -211,7 +213,7 @@ void main() {
         );
       }, shouldExpectPress: true);
 
-      testTapWidget('should be unclickable when enabled is false', (value) {
+      testTapWidget('Should be unclickable when enabled is false', (value) {
         return RxButton(
           label: 'Test Button',
           onPressed: () => value.value = true,
@@ -219,21 +221,21 @@ void main() {
         );
       }, shouldExpectPress: false);
 
-      testTapWidget('should be unclickable when onPressed is null', (value) {
+      testTapWidget('Should be unclickable when onPressed is null', (value) {
         return RxButton(
           label: 'Test Button',
           onPressed: null,
         );
       }, shouldExpectPress: false);
 
-      testHoverWidget('should be hoverable when enabled', () {
+      testHoverWidget('Should be hoverable when enabled', () {
         return RxButton(
           label: 'Test Button',
           onPressed: () {},
         );
       }, shouldExpectHover: true);
 
-      testHoverWidget('should not react to hover when disabled', () {
+      testHoverWidget('Should not react to hover when disabled', () {
         return RxButton(
           label: 'Test Button',
           onPressed: () {},
@@ -241,7 +243,7 @@ void main() {
         );
       }, shouldExpectHover: false);
 
-      testFocusWidget('should be focusable when enabled', (focusNode) {
+      testFocusWidget('Should be focusable when enabled', (focusNode) {
         return RxButton(
           label: 'Test Button',
           focusNode: focusNode,
@@ -249,7 +251,7 @@ void main() {
         );
       }, shouldExpectFocus: true);
 
-      testFocusWidget('should not be focusable when disabled', (focusNode) {
+      testFocusWidget('Should not be focusable when disabled', (focusNode) {
         return RxButton(
           label: 'Test Button',
           focusNode: focusNode,

--- a/packages/remix/test/components/checkbox_test.dart
+++ b/packages/remix/test/components/checkbox_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/src/components/form/checkbox/checkbox.dart';
+
+import '../utils/interaction_tests.dart';
+
+void main() {
+  group('RxCheckbox', () {
+    group('Constructor', () {
+      const iconChecked = Icons.check_rounded;
+      const iconUnchecked = Icons.close_rounded;
+      const label = 'Accept Terms';
+      const enabled = true;
+      const selected = true;
+      final style = RxCheckboxStyle();
+      void onChanged(bool value) {}
+      const variants = [Variant('name')];
+
+      testWidgets('should initialize with correct properties', (tester) async {
+        final checkbox = RxCheckbox(
+          selected: selected,
+          iconChecked: iconChecked,
+          iconUnchecked: iconUnchecked,
+          label: label,
+          enabled: enabled,
+          style: style,
+          onChanged: onChanged,
+          variants: variants,
+        );
+
+        await tester.pumpRxWidget(checkbox);
+
+        expect(checkbox.selected, selected);
+        expect(checkbox.iconChecked, iconChecked);
+        expect(checkbox.iconUnchecked, iconUnchecked);
+        expect(checkbox.label, label);
+        expect(checkbox.enabled, enabled);
+        expect(checkbox.style, style);
+        expect(checkbox.onChanged, onChanged);
+        expect(checkbox.variants, variants);
+      });
+
+      testWidgets('should render correct UI output', (tester) async {
+        const checkbox = RxCheckbox(
+          selected: true,
+          iconChecked: Icons.check_rounded,
+          label: 'Accept Terms',
+        );
+
+        await tester.pumpRxWidget(checkbox);
+
+        final iconFinder = find.byIcon(Icons.check_rounded);
+        expect(iconFinder, findsOneWidget);
+
+        final labelFinder = find.text('Accept Terms');
+        expect(labelFinder, findsOneWidget);
+      });
+    });
+
+    testWidgets('should apply style correctly', (tester) async {
+      final style = RxCheckboxStyle()..indicator.color.blue();
+
+      final checkbox = RxCheckbox(
+        selected: true,
+        iconChecked: Icons.check_rounded,
+        style: style,
+      );
+
+      await tester.pumpRxWidget(checkbox);
+
+      final iconFinder = find.byIcon(Icons.check_rounded);
+      final iconWidget = tester.widget<Icon>(iconFinder);
+      expect(iconWidget.color, Colors.blue);
+    });
+
+    group('interactions', () {
+      testTapWidget('should call onChanged when tapped', (holder) {
+        return RxCheckbox(
+          selected: holder.value,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectPress: true);
+
+      testTapWidget('should not call onChanged when disabled', (holder) {
+        return RxCheckbox(
+          selected: holder.value,
+          enabled: false,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectPress: false);
+
+      testHoverWidget('should handle hover state when enabled', () {
+        return RxCheckbox(
+          selected: true,
+          onChanged: (newValue) {},
+        );
+      }, shouldExpectHover: true);
+
+      testHoverWidget('should handle hover state when disabled', () {
+        return RxCheckbox(
+          selected: true,
+          enabled: false,
+          onChanged: (newValue) {},
+        );
+      }, shouldExpectHover: false);
+
+      testFocusWidget('should handle focus state when enabled', (focusNode) {
+        return RxCheckbox(
+          selected: true,
+          onChanged: (newValue) {},
+          focusNode: focusNode,
+        );
+      }, shouldExpectFocus: true);
+
+      testFocusWidget('should not focus when disabled', (focusNode) {
+        return RxCheckbox(
+          selected: true,
+          enabled: false,
+          focusNode: focusNode,
+        );
+      }, shouldExpectFocus: false);
+
+      testSelectStateWidget('should handle select state', (holder) {
+        return RxCheckbox(
+          selected: holder.value,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectSelect: true);
+    });
+  });
+}

--- a/packages/remix/test/components/chip_test.dart
+++ b/packages/remix/test/components/chip_test.dart
@@ -188,6 +188,7 @@ void main() {
         return RxChip(
           label: 'Test',
           selected: false,
+          focusNode: focusNode,
           onChanged: (newValue) {},
         );
       }, shouldExpectFocus: true);

--- a/packages/remix/test/components/chip_test.dart
+++ b/packages/remix/test/components/chip_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/remix.dart';
+
+import '../utils/interaction_tests.dart';
+
+void main() {
+  group('RxChip', () {
+    group('Constructor', () {
+      const label = 'Test Label';
+      const iconLeft = Icons.check;
+      const iconRight = Icons.close;
+      const isSelected = true;
+      const isEnabled = true;
+      const variants = [Variant('primary')];
+      final style = RxChipStyle()..container.color.red();
+      void onChanged(bool value) {}
+
+      testWidgets('should initialize with correct properties',
+          (WidgetTester tester) async {
+        final widget = RxChip(
+          label: label,
+          iconLeft: iconLeft,
+          iconRight: iconRight,
+          selected: isSelected,
+          enabled: isEnabled,
+          variants: variants,
+          style: style,
+          onChanged: onChanged,
+        );
+
+        await tester.pumpRxWidget(widget);
+
+        expect(widget.label, label);
+        expect(widget.iconLeft, iconLeft);
+        expect(widget.iconRight, iconRight);
+        expect(widget.selected, isSelected);
+        expect(widget.enabled, isEnabled);
+        expect(widget.variants, variants);
+        expect(widget.style, style);
+        expect(widget.onChanged, onChanged);
+
+        expect(find.text(label), findsOneWidget);
+        expect(find.byIcon(iconLeft), findsOneWidget);
+        expect(find.byIcon(iconRight), findsOneWidget);
+      });
+
+      testWidgets('Raw should initialize with correct properties',
+          (WidgetTester tester) async {
+        const child = SizedBox(
+          width: 100,
+          height: 100,
+          child: Icon(iconLeft),
+        );
+
+        final widget = RxChip.raw(
+          label: label,
+          iconLeft: iconLeft,
+          iconRight: iconRight,
+          selected: isSelected,
+          enabled: isEnabled,
+          variants: variants,
+          style: style,
+          onChanged: onChanged,
+          child: child,
+        );
+
+        await tester.pumpRxWidget(widget);
+
+        expect(widget.label, label);
+        expect(widget.iconLeft, iconLeft);
+        expect(widget.iconRight, iconRight);
+        expect(widget.selected, isSelected);
+        expect(widget.enabled, isEnabled);
+        expect(widget.variants, variants);
+        expect(widget.style, style);
+        expect(widget.onChanged, onChanged);
+
+        expect(find.byWidget(child), findsOneWidget);
+      });
+    });
+
+    testWidgets('should display icons in correct positions',
+        (WidgetTester tester) async {
+      const iconLeft = Icons.check;
+      const iconRight = Icons.close;
+
+      await tester.pumpRxWidget(
+        RxChip(
+          label: 'Test',
+          iconLeft: iconLeft,
+          iconRight: iconRight,
+          onChanged: (_) {},
+        ),
+      );
+
+      final iconLeftFinder = find.byIcon(iconLeft);
+      final iconRightFinder = find.byIcon(iconRight);
+
+      expect(
+          tester.getTopLeft(iconLeftFinder).dx <
+              tester.getTopLeft(iconRightFinder).dx,
+          isTrue);
+    });
+
+    testWidgets('should change selection state on tap',
+        (WidgetTester tester) async {
+      bool isSelected = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RxChip(
+              label: 'Test',
+              selected: isSelected,
+              onChanged: (bool newValue) {
+                isSelected = newValue;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(RxChip));
+      await tester.pumpAndSettle();
+
+      expect(isSelected, isTrue);
+    });
+
+    testWidgets('should not change selection state when disabled',
+        (WidgetTester tester) async {
+      bool isSelected = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RxChip(
+              label: 'Test',
+              selected: isSelected,
+              enabled: false,
+              onChanged: (bool newValue) {
+                isSelected = newValue;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(RxChip));
+      await tester.pumpAndSettle();
+
+      expect(isSelected, isFalse);
+    });
+
+    group('interactions', () {
+      testTapWidget('should call onChanged when tapped', (holder) {
+        return RxChip(
+          label: 'Test',
+          selected: holder.value,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectPress: true);
+
+      testTapWidget('should not call onChanged when tapped and disabled',
+          (holder) {
+        return RxChip(
+          label: 'Test',
+          selected: holder.value,
+          enabled: false,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectPress: false);
+
+      testHoverWidget('should handle hover state correctly', () {
+        return RxChip(
+          label: 'Test',
+          selected: false,
+          onChanged: (newValue) {},
+        );
+      }, shouldExpectHover: true);
+
+      testFocusWidget('should handle focus state correctly', (focusNode) {
+        return RxChip(
+          label: 'Test',
+          selected: false,
+          onChanged: (newValue) {},
+        );
+      }, shouldExpectFocus: true);
+
+      testFocusWidget('should handle focus state correctly when disabled',
+          (focusNode) {
+        return RxChip(
+          label: 'Test',
+          selected: false,
+          enabled: false,
+          focusNode: focusNode,
+          onChanged: (newValue) {},
+        );
+      }, shouldExpectFocus: false);
+
+      testSelectStateWidget('should handle select state correctly', (holder) {
+        return RxChip(
+          label: 'Test',
+          selected: holder.value,
+          onChanged: (newValue) {
+            holder.value = newValue;
+          },
+        );
+      }, shouldExpectSelect: true);
+    });
+  });
+}

--- a/packages/remix/test/components/label_test.dart
+++ b/packages/remix/test/components/label_test.dart
@@ -18,7 +18,7 @@ void main() {
         icon: icon,
       );
 
-      await pumpRxWidget(tester, widget);
+      await tester.pumpRxWidget(widget);
 
       expect(find.text(label), findsOneWidget);
       expect(find.byIcon(icon), findsOneWidget);
@@ -33,7 +33,7 @@ void main() {
         style: RxLabelStyle(),
       );
 
-      await pumpRxWidget(tester, widget);
+      await tester.pumpRxWidget(widget);
 
       expect(find.text(label), findsOneWidget);
       expect(find.byIcon(icon), findsNothing);
@@ -42,8 +42,7 @@ void main() {
     testWidgets('should create label with icon in different positions',
         (WidgetTester tester) async {
       for (var position in [IconPosition.start, IconPosition.end]) {
-        await pumpRxWidget(
-          tester,
+        await tester.pumpRxWidget(
           RxLabel(
             label,
             icon: icon,

--- a/packages/remix/test/components/label_test.dart
+++ b/packages/remix/test/components/label_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/remix.dart';
+
+import '../utils/interaction_tests.dart';
+
+void main() {
+  group('RxLabel', () {
+    const label = 'Test Label';
+    const icon = Icons.star;
+    const variants = [Variant('primary')];
+
+    testWidgets('should initialize with correct properties and display label',
+        (WidgetTester tester) async {
+      const widget = RxLabel(
+        label,
+        icon: icon,
+      );
+
+      await pumpRxWidget(tester, widget);
+
+      expect(find.text(label), findsOneWidget);
+      expect(find.byIcon(icon), findsOneWidget);
+    });
+
+    testWidgets('should display label without icon when icon is null',
+        (WidgetTester tester) async {
+      final widget = RxLabel(
+        label,
+        icon: null,
+        variants: variants,
+        style: RxLabelStyle(),
+      );
+
+      await pumpRxWidget(tester, widget);
+
+      expect(find.text(label), findsOneWidget);
+      expect(find.byIcon(icon), findsNothing);
+    });
+
+    testWidgets('should create label with icon in different positions',
+        (WidgetTester tester) async {
+      for (var position in [IconPosition.start, IconPosition.end]) {
+        await pumpRxWidget(
+          tester,
+          RxLabel(
+            label,
+            icon: icon,
+            iconPosition: position,
+            variants: variants,
+            style: RxLabelStyle(),
+          ),
+        );
+
+        expect(find.text(label), findsOneWidget);
+        expect(find.byIcon(icon), findsOneWidget);
+
+        final findPosition = position == IconPosition.start
+            ? FindPosition.first
+            : FindPosition.last;
+
+        final iconWidget = findWidgetInFlex<Icon>(
+          tester,
+          parentType: RxLabel,
+          widgetType: Icon,
+          findPosition: findPosition,
+        );
+
+        expect(iconWidget.icon, icon);
+      }
+    });
+  });
+}

--- a/packages/remix/test/utils/interaction_tests.dart
+++ b/packages/remix/test/utils/interaction_tests.dart
@@ -1,0 +1,129 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/src/helpers/mix_controller_mixin.dart';
+
+Future<void> pumpRxWidget(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: child,
+      ),
+    ),
+  );
+}
+
+enum FindPosition {
+  first,
+  last,
+}
+
+T findWidgetInFlex<T extends Widget>(
+  WidgetTester tester, {
+  required Type parentType,
+  required Type widgetType,
+  required FindPosition findPosition,
+}) {
+  final flexFinder = find.descendant(
+    of: find.byType(parentType),
+    matching: find.byWidgetPredicate((widget) => widget is Flex),
+  );
+  final flexWidget = tester.widget<Flex>(flexFinder);
+  final targetChild = findPosition == FindPosition.last
+      ? flexWidget.children.last
+      : flexWidget.children.first;
+
+  final widgetFinder = find.descendant(
+    of: find.byWidget(targetChild),
+    matching: find.byWidgetPredicate((widget) => widget is T),
+  );
+
+  return tester.widget<T>(widgetFinder);
+}
+
+class ValueHolder<T> {
+  T value;
+
+  ValueHolder({required this.value});
+}
+
+@isTest
+void testTapWidget(
+  String description,
+  Widget Function(ValueHolder<bool> value) child, {
+  required bool shouldExpectPress,
+}) {
+  testWidgets(description, (WidgetTester tester) async {
+    final valueHolder = ValueHolder<bool>(value: false);
+    final widget = child(valueHolder);
+    await pumpRxWidget(tester, widget);
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byWidget(widget)),
+    );
+
+    final state = tester.state(find.byWidget(widget)) as MixControllerMixin;
+
+    expect(state.mixController.has(WidgetState.pressed), shouldExpectPress);
+    await gesture.up();
+    expect(valueHolder.value, shouldExpectPress);
+  });
+}
+
+@isTest
+void testHoverWidget(
+  String description,
+  Widget Function() child, {
+  required bool shouldExpectHover,
+}) {
+  testWidgets(description, (WidgetTester tester) async {
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+
+    final widget = child();
+    await pumpRxWidget(tester, widget);
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(find.byWidget(widget)));
+
+    final state = tester.state(find.byWidget(widget)) as MixControllerMixin;
+
+    expect(state.mixController.has(WidgetState.hovered), shouldExpectHover);
+
+    await gesture.removePointer();
+
+    expect(state.mixController.has(WidgetState.hovered), false);
+  });
+}
+
+@isTest
+void testFocusWidget(
+  String description,
+  Widget Function(FocusNode focusNode) childBuilder, {
+  required bool shouldExpectFocus,
+}) {
+  testWidgets(description, (WidgetTester tester) async {
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+    final focusNode = FocusNode();
+
+    final widget = childBuilder(focusNode);
+    await pumpRxWidget(tester, widget);
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    final state = tester.state(find.byWidget(widget)) as MixControllerMixin;
+
+    expect(state.mixController.has(WidgetState.focused), shouldExpectFocus);
+
+    focusNode.unfocus();
+    await tester.pump();
+
+    expect(state.mixController.has(WidgetState.focused), false);
+  });
+}


### PR DESCRIPTION
### Description

This PR adds a comprehensive test suite for the RxButton and RxLabel widgets and updates the button API to use a spinner builder callback.

- Introduces `interaction_tests.dart` with reusable interaction helpers.
- Adds `label_test.dart` covering RxLabel rendering and icon positioning.
- Adds `button_test.dart` covering RxButton constructors, styling, spinner behavior, and interactive states.
- Renames `spinnerWidget` to `spinnerBuilder` in `RxButton` and updates its loading overlay logic.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
