### PR TITLE
refactor: RxSelect to support custom item and trigger widgets

### DIFF
--- a/packages/naked/lib/src/naked_select.dart
+++ b/packages/naked/lib/src/naked_select.dart
@@ -367,9 +367,13 @@ class NakedSelectInherited<T> extends InheritedWidget {
   });
 
   /// Gets the nearest NakedSelectInherited ancestor of the given context.
+  static NakedSelectInherited<T>? maybeOf<T>(BuildContext context) {
+    return context
+        .dependOnInheritedWidgetOfExactType<NakedSelectInherited<T>>();
+  }
+
   static NakedSelectInherited<T> of<T>(BuildContext context) {
-    final inherited =
-        context.dependOnInheritedWidgetOfExactType<NakedSelectInherited<T>>();
+    final inherited = maybeOf<T>(context);
     if (inherited == null) {
       throw StateError(
         'NakedSelectInherited<$T> not found in context.\n'
@@ -517,7 +521,7 @@ class _NakedSelectTriggerState extends State<NakedSelectTrigger> {
 /// providing callbacks for hover, press, focus and selection states to enable complete styling control.
 ///
 /// Key features:
-/// - Customizable cursor and interaction states 
+/// - Customizable cursor and interaction states
 /// - Keyboard selection support
 /// - Optional haptic feedback
 /// - Accessibility support with ARIA attributes

--- a/packages/remix/demo/lib/api/form/select.dart
+++ b/packages/remix/demo/lib/api/form/select.dart
@@ -28,22 +28,43 @@ class _MyAppState extends State<MyApp> {
       home: Scaffold(
         backgroundColor: Colors.white,
         body: Center(
-          child: RxSelect(
-            selectedValue: _value,
-            onSelectedValueChanged: (value) {
-              setState(() {
-                _value = value;
-              });
-            },
-            items: Options.values
-                .map((e) => RxSelectItem(value: e, label: e.name.capitalize()))
-                .toList(),
-            style: RxSelectStyle()
-              ..trigger.container.width(200)
-              ..trigger.container.flex.mainAxisAlignment.spaceBetween(),
-            child: RxSelectTrigger(
-              label: _value?.name.capitalize() ?? 'Select an item',
-            ),
+          child: Row(
+            children: [
+              RxSelect<Options>(
+                items: const [
+                  RxSelectItem<Options>.raw(
+                    value: Options.apple,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.favorite, color: Colors.red),
+                        SizedBox(width: 8),
+                        Text('Custom Apple'),
+                      ],
+                    ),
+                  ),
+                ],
+                child: RxSelectTrigger(label: 'Select an item'),
+              ),
+              RxSelect(
+                selectedValue: _value,
+                onSelectedValueChanged: (value) {
+                  setState(() {
+                    _value = value;
+                  });
+                },
+                items: Options.values
+                    .map((e) =>
+                        RxSelectItem(value: e, label: e.name.capitalize()))
+                    .toList(),
+                style: RxSelectStyle()
+                  ..trigger.container.width(200)
+                  ..trigger.container.flex.mainAxisAlignment.spaceBetween(),
+                child: RxSelectTrigger(
+                  label: _value?.name.capitalize() ?? 'Select an item',
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/packages/remix/lib/src/components/form/select/select.dart
+++ b/packages/remix/lib/src/components/form/select/select.dart
@@ -59,28 +59,66 @@ class SelectSpec extends Spec<SelectSpec> with _$SelectSpec, Diagnosticable {
 @MixableSpec()
 base class SelectMenuItemSpec extends Spec<SelectMenuItemSpec>
     with _$SelectMenuItemSpec, Diagnosticable {
-  final IconSpec icon;
-  final TextSpec text;
   final FlexBoxSpec container;
+  final TextStyle textStyle;
+
+  @MixableField(
+    dto: MixableFieldType(type: 'IconThemeDataDto'),
+    utilities: [MixableFieldUtility(type: 'IconThemeDataUtility')],
+  )
+  final IconThemeData icon;
 
   static const of = _$SelectMenuItemSpec.of;
 
   static const from = _$SelectMenuItemSpec.from;
 
   const SelectMenuItemSpec({
-    IconSpec? icon,
-    TextSpec? text,
+    IconThemeData? icon,
+    TextStyle? textStyle,
     FlexBoxSpec? container,
     super.modifiers,
     super.animated,
-  })  : icon = icon ?? const IconSpec(),
-        text = text ?? const TextSpec(),
+  })  : icon = icon ?? const IconThemeData(),
+        textStyle = textStyle ?? const TextStyle(),
         container = container ?? const FlexBoxSpec();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     _debugFillProperties(properties);
+  }
+
+  /// Linearly interpolates between this [SelectMenuItemSpec] and another [SelectMenuItemSpec] based on the given parameter [t].
+  ///
+  /// The parameter [t] represents the interpolation factor, typically ranging from 0.0 to 1.0.
+  /// When [t] is 0.0, the current [SelectMenuItemSpec] is returned. When [t] is 1.0, the [other] [SelectMenuItemSpec] is returned.
+  /// For values of [t] between 0.0 and 1.0, an interpolated [SelectMenuItemSpec] is returned.
+  ///
+  /// If [other] is null, this method returns the current [SelectMenuItemSpec] instance.
+  ///
+  /// The interpolation is performed on each property of the [SelectMenuItemSpec] using the appropriate
+  /// interpolation method:
+  /// - [IconThemeData.lerp] for [icon].
+  /// - [MixHelpers.lerpTextStyle] for [textStyle].
+  /// - [FlexBoxSpec.lerp] for [container].
+  /// For [modifiers] and [animated], the interpolation is performed using a step function.
+  /// If [t] is less than 0.5, the value from the current [SelectMenuItemSpec] is used. Otherwise, the value
+  /// from the [other] [SelectMenuItemSpec] is used.
+  ///
+  /// This method is typically used in animations to smoothly transition between
+  /// different [SelectMenuItemSpec] configurations.
+  @override
+  SelectMenuItemSpec lerp(SelectMenuItemSpec? other, double t) {
+    if (other == null) return _$this;
+
+    return SelectMenuItemSpec(
+      icon: IconThemeData.lerp(_$this.icon, other.icon, t),
+      textStyle:
+          MixHelpers.lerpTextStyle(_$this.textStyle, other.textStyle, t)!,
+      container: _$this.container.lerp(other.container, t),
+      modifiers: other.modifiers,
+      animated: _$this.animated ?? other.animated,
+    );
   }
 }
 

--- a/packages/remix/lib/src/components/form/select/select.g.dart
+++ b/packages/remix/lib/src/components/form/select/select.g.dart
@@ -331,50 +331,18 @@ mixin _$SelectMenuItemSpec on Spec<SelectMenuItemSpec> {
   /// replaced with the new values.
   @override
   SelectMenuItemSpec copyWith({
-    IconSpec? icon,
-    TextSpec? text,
+    IconThemeData? icon,
+    TextStyle? textStyle,
     FlexBoxSpec? container,
     WidgetModifiersConfig? modifiers,
     AnimatedData? animated,
   }) {
     return SelectMenuItemSpec(
       icon: icon ?? _$this.icon,
-      text: text ?? _$this.text,
+      textStyle: textStyle ?? _$this.textStyle,
       container: container ?? _$this.container,
       modifiers: modifiers ?? _$this.modifiers,
       animated: animated ?? _$this.animated,
-    );
-  }
-
-  /// Linearly interpolates between this [SelectMenuItemSpec] and another [SelectMenuItemSpec] based on the given parameter [t].
-  ///
-  /// The parameter [t] represents the interpolation factor, typically ranging from 0.0 to 1.0.
-  /// When [t] is 0.0, the current [SelectMenuItemSpec] is returned. When [t] is 1.0, the [other] [SelectMenuItemSpec] is returned.
-  /// For values of [t] between 0.0 and 1.0, an interpolated [SelectMenuItemSpec] is returned.
-  ///
-  /// If [other] is null, this method returns the current [SelectMenuItemSpec] instance.
-  ///
-  /// The interpolation is performed on each property of the [SelectMenuItemSpec] using the appropriate
-  /// interpolation method:
-  /// - [IconSpec.lerp] for [icon].
-  /// - [TextSpec.lerp] for [text].
-  /// - [FlexBoxSpec.lerp] for [container].
-  /// For [modifiers] and [animated], the interpolation is performed using a step function.
-  /// If [t] is less than 0.5, the value from the current [SelectMenuItemSpec] is used. Otherwise, the value
-  /// from the [other] [SelectMenuItemSpec] is used.
-  ///
-  /// This method is typically used in animations to smoothly transition between
-  /// different [SelectMenuItemSpec] configurations.
-  @override
-  SelectMenuItemSpec lerp(SelectMenuItemSpec? other, double t) {
-    if (other == null) return _$this;
-
-    return SelectMenuItemSpec(
-      icon: _$this.icon.lerp(other.icon, t),
-      text: _$this.text.lerp(other.text, t),
-      container: _$this.container.lerp(other.container, t),
-      modifiers: other.modifiers,
-      animated: _$this.animated ?? other.animated,
     );
   }
 
@@ -385,7 +353,7 @@ mixin _$SelectMenuItemSpec on Spec<SelectMenuItemSpec> {
   @override
   List<Object?> get props => [
         _$this.icon,
-        _$this.text,
+        _$this.textStyle,
         _$this.container,
         _$this.modifiers,
         _$this.animated,
@@ -396,8 +364,8 @@ mixin _$SelectMenuItemSpec on Spec<SelectMenuItemSpec> {
   void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties
         .add(DiagnosticsProperty('icon', _$this.icon, defaultValue: null));
-    properties
-        .add(DiagnosticsProperty('text', _$this.text, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty('textStyle', _$this.textStyle, defaultValue: null));
     properties.add(
         DiagnosticsProperty('container', _$this.container, defaultValue: null));
     properties.add(
@@ -416,13 +384,13 @@ mixin _$SelectMenuItemSpec on Spec<SelectMenuItemSpec> {
 /// the [SelectMenuItemSpec] constructor.
 class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
     with Diagnosticable {
-  final IconSpecAttribute? icon;
-  final TextSpecAttribute? text;
+  final IconThemeDataDto? icon;
+  final TextStyleDto? textStyle;
   final FlexBoxSpecAttribute? container;
 
   const SelectMenuItemSpecAttribute({
     this.icon,
-    this.text,
+    this.textStyle,
     this.container,
     super.modifiers,
     super.animated,
@@ -440,7 +408,7 @@ class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
   SelectMenuItemSpec resolve(MixContext mix) {
     return SelectMenuItemSpec(
       icon: icon?.resolve(mix),
-      text: text?.resolve(mix),
+      textStyle: textStyle?.resolve(mix),
       container: container?.resolve(mix),
       modifiers: modifiers?.resolve(mix),
       animated: animated?.resolve(mix) ?? mix.animation,
@@ -461,7 +429,7 @@ class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
 
     return SelectMenuItemSpecAttribute(
       icon: icon?.merge(other.icon) ?? other.icon,
-      text: text?.merge(other.text) ?? other.text,
+      textStyle: textStyle?.merge(other.textStyle) ?? other.textStyle,
       container: container?.merge(other.container) ?? other.container,
       modifiers: modifiers?.merge(other.modifiers) ?? other.modifiers,
       animated: animated?.merge(other.animated) ?? other.animated,
@@ -475,7 +443,7 @@ class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
   @override
   List<Object?> get props => [
         icon,
-        text,
+        textStyle,
         container,
         modifiers,
         animated,
@@ -485,7 +453,8 @@ class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty('icon', icon, defaultValue: null));
-    properties.add(DiagnosticsProperty('text', text, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('textStyle', textStyle, defaultValue: null));
     properties
         .add(DiagnosticsProperty('container', container, defaultValue: null));
     properties
@@ -502,10 +471,10 @@ class SelectMenuItemSpecAttribute extends SpecAttribute<SelectMenuItemSpec>
 class SelectMenuItemSpecUtility<T extends SpecAttribute>
     extends SpecUtility<T, SelectMenuItemSpecAttribute> {
   /// Utility for defining [SelectMenuItemSpecAttribute.icon]
-  late final icon = IconSpecUtility((v) => only(icon: v));
+  late final icon = IconThemeDataUtility((v) => only(icon: v));
 
-  /// Utility for defining [SelectMenuItemSpecAttribute.text]
-  late final text = TextSpecUtility((v) => only(text: v));
+  /// Utility for defining [SelectMenuItemSpecAttribute.textStyle]
+  late final textStyle = TextStyleUtility((v) => only(textStyle: v));
 
   /// Utility for defining [SelectMenuItemSpecAttribute.container]
   late final container = FlexBoxSpecUtility((v) => only(container: v));
@@ -537,15 +506,15 @@ class SelectMenuItemSpecUtility<T extends SpecAttribute>
   /// Returns a new [SelectMenuItemSpecAttribute] with the specified properties.
   @override
   T only({
-    IconSpecAttribute? icon,
-    TextSpecAttribute? text,
+    IconThemeDataDto? icon,
+    TextStyleDto? textStyle,
     FlexBoxSpecAttribute? container,
     WidgetModifiersConfigDto? modifiers,
     AnimatedDataDto? animated,
   }) {
     return builder(SelectMenuItemSpecAttribute(
       icon: icon,
-      text: text,
+      textStyle: textStyle,
       container: container,
       modifiers: modifiers,
       animated: animated,

--- a/packages/remix/lib/src/components/form/select/select_style.dart
+++ b/packages/remix/lib/src/components/form/select/select_style.dart
@@ -20,12 +20,14 @@ class RxSelectStyle extends SelectSpecUtility<SelectSpecAttribute> {
       ..menuContainer.border.color.grey.shade300()
       ..item.container.flex.mainAxisAlignment.spaceBetween()
       ..item.icon.size(16)
-      ..item.container.padding(4)
+      ..item.textStyle.color.grey.shade700()
+      ..item.container.padding.horizontal(8)
+      ..item.container.padding.vertical(8)
       ..item.container.borderRadius(4)
-      ..item.icon.wrap.opacity(0)
+      ..item.icon.color.grey.withOpacity(0)
       ..on.selected(
         RxSelectStyle()
-          ..item.icon.wrap.opacity(1)
+          ..item.icon.color.grey.withOpacity(1)
           ..item.container.color.grey.shade100(),
       );
   }

--- a/packages/remix/test/components/select_test.dart
+++ b/packages/remix/test/components/select_test.dart
@@ -1,0 +1,425 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../utils/interaction_tests.dart';
+
+enum Options {
+  banana,
+  apple,
+  orange,
+}
+
+void main() {
+  group('RxSelect', () {
+    group('Constructor', () {
+      const label = 'Select an item';
+      const selectedValue = Options.apple;
+      final items = Options.values
+          .map((e) => RxSelectItem(value: e, label: e.name))
+          .toList();
+      final style = RxSelectStyle();
+      void onSelectedValueChanged(Options? value) {}
+
+      testWidgets('should initialize with correct properties',
+          (WidgetTester tester) async {
+        final widget = RxSelect<Options>(
+          selectedValue: selectedValue,
+          onSelectedValueChanged: onSelectedValueChanged,
+          items: items,
+          style: style,
+          child: const RxSelectTrigger(label: label),
+        );
+
+        await tester.pumpRxWidget(widget);
+
+        expect(widget.selectedValue, selectedValue);
+        expect(widget.items, items);
+        expect(widget.style, style);
+        expect(widget.onSelectedValueChanged, onSelectedValueChanged);
+
+        expect(find.text(label), findsOneWidget);
+      });
+    });
+
+    testWidgets('should display items when trigger is tapped',
+        (WidgetTester tester) async {
+      final items = Options.values
+          .map((e) => RxSelectItem(value: e, label: e.name))
+          .toList();
+
+      await tester.pumpRxWidget(
+        RxSelect<Options>(
+          selectedValue: Options.banana,
+          onSelectedValueChanged: (_) {},
+          items: items,
+          child: const RxSelectTrigger(label: 'Select an item'),
+        ),
+      );
+
+      await tester.tap(find.text('Select an item'));
+      await tester.pumpAndSettle();
+
+      for (var option in Options.values) {
+        expect(find.text(option.name), findsOneWidget);
+      }
+    });
+
+    testWidgets(
+        'should close or keep menu open based on closeOnSelect property when item is selected',
+        (WidgetTester tester) async {
+      for (final closeOnSelect in [true, false]) {
+        final items = Options.values
+            .map((e) => RxSelectItem(value: e, label: e.name))
+            .toList();
+
+        await tester.pumpRxWidget(
+          RxSelect<Options>(
+            selectedValue: Options.banana,
+            closeOnSelect: closeOnSelect,
+            onSelectedValueChanged: (_) {},
+            items: items,
+            child: const RxSelectTrigger(label: 'Select an item'),
+          ),
+        );
+
+        // Open dropdown
+        await tester.tap(find.text('Select an item'));
+        await tester.pumpAndSettle();
+
+        // Verify dropdown is open
+        expect(find.text(Options.apple.name), findsOneWidget);
+        expect(find.text(Options.orange.name), findsOneWidget);
+
+        // Select an item
+        await tester.tap(find.text(Options.apple.name));
+        await tester.pumpAndSettle();
+
+        // Verify dropdown behavior based on closeOnSelect
+        if (closeOnSelect) {
+          // Verify dropdown is closed
+          expect(find.text(Options.apple.name), findsNothing);
+          expect(find.text(Options.orange.name), findsNothing);
+        } else {
+          // Verify dropdown remains open
+          expect(find.text(Options.apple.name), findsOneWidget);
+          expect(find.text(Options.orange.name), findsOneWidget);
+        }
+      }
+    });
+
+    testWidgets('should call onSelectedValueChanged when item is selected',
+        (WidgetTester tester) async {
+      Options? selectedValue;
+      final items = Options.values
+          .map((e) => RxSelectItem(value: e, label: e.name))
+          .toList();
+
+      await tester.pumpRxWidget(
+        RxSelect<Options>(
+          selectedValue: selectedValue,
+          onSelectedValueChanged: (value) {
+            selectedValue = value;
+          },
+          items: items,
+          child: const RxSelectTrigger(label: 'Select an item'),
+        ),
+      );
+
+      // Open dropdown
+      await tester.tap(find.text('Select an item'));
+      await tester.pumpAndSettle();
+
+      // Select an item
+      await tester.tap(find.text(Options.apple.name));
+      await tester.pumpAndSettle();
+
+      // Verify onSelectedValueChanged was called with correct value
+      expect(selectedValue, equals(Options.apple));
+    });
+
+    group('interactions', () {
+      testHoverWidget('should handle hover state', () {
+        return RxSelect<Options>(
+          selectedValue: Options.apple,
+          onSelectedValueChanged: (_) {},
+          items: Options.values
+              .map((e) => RxSelectItem(value: e, label: e.name))
+              .toList(),
+          child: const RxSelectTrigger(label: 'Select an item'),
+        );
+      }, shouldExpectHover: true);
+
+      testHoverWidget('should not handle hover state when disabled', () {
+        return RxSelect<Options>(
+          enabled: false,
+          selectedValue: Options.apple,
+          onSelectedValueChanged: (_) {},
+          items: Options.values
+              .map((e) => RxSelectItem(value: e, label: e.name))
+              .toList(),
+          child: const RxSelectTrigger(label: 'Select an item'),
+        );
+      }, shouldExpectHover: false);
+
+      testFocusWidget('should handle focus state when enabled', (focusNode) {
+        return RxSelect<Options>(
+          selectedValue: Options.apple,
+          onSelectedValueChanged: (_) {},
+          items: Options.values
+              .map((e) => RxSelectItem(value: e, label: e.name))
+              .toList(),
+          style: RxSelectStyle(),
+          child: RxSelectTrigger(label: 'Select an item', focusNode: focusNode),
+        );
+      }, shouldExpectFocus: true);
+
+      testFocusWidget('should not handle focus state when disabled',
+          (focusNode) {
+        return RxSelect<Options>(
+          enabled: false,
+          selectedValue: Options.apple,
+          onSelectedValueChanged: (_) {},
+          items: Options.values
+              .map((e) => RxSelectItem(value: e, label: e.name))
+              .toList(),
+          child: RxSelectTrigger(label: 'Select an item', focusNode: focusNode),
+        );
+      }, shouldExpectFocus: false);
+    });
+  });
+
+  group('RxSelectTrigger', () {
+    group('Constructor', () {
+      const label = 'Select an item';
+      const semanticLabel = 'Choose an option';
+      const cursor = SystemMouseCursors.precise;
+      const enableHapticFeedback = false;
+      const trailingIcon = Icons.arrow_drop_down;
+
+      testWidgets('should initialize with correct properties',
+          (WidgetTester tester) async {
+        final focusNode = FocusNode();
+        final widget = RxSelectTrigger(
+          label: label,
+          semanticLabel: semanticLabel,
+          cursor: cursor,
+          enableHapticFeedback: enableHapticFeedback,
+          focusNode: focusNode,
+          trailingIcon: trailingIcon,
+        );
+
+        expect(widget.label, label);
+        expect(widget.semanticLabel, semanticLabel);
+        expect(widget.cursor, cursor);
+        expect(widget.enableHapticFeedback, enableHapticFeedback);
+        expect(widget.focusNode, focusNode);
+        expect(widget.trailingIcon, trailingIcon);
+      });
+
+      testWidgets('should throw exception when used outside RxSelect',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelectTrigger(label: 'Select an item'),
+        );
+
+        expect(tester.takeException(), isException);
+      });
+
+      testWidgets(
+          'should initialize with correct properties for raw constructor',
+          (WidgetTester tester) async {
+        final focusNode = FocusNode();
+
+        final child =
+            Container(color: Colors.red, child: const Text('Custom Child'));
+
+        final widget = RxSelect(
+          items: const [],
+          child: RxSelectTrigger.raw(
+            semanticLabel: semanticLabel,
+            cursor: cursor,
+            enableHapticFeedback: enableHapticFeedback,
+            focusNode: focusNode,
+            child: child,
+          ),
+        );
+
+        await tester.pumpRxWidget(widget);
+
+        expect(find.byWidget(child), findsOneWidget);
+      });
+    });
+
+    group('Layout', () {
+      testWidgets('should display label and icon in horizontal layout',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelect(
+            items: [],
+            child: RxSelectTrigger(label: 'Select an item'),
+          ),
+        );
+
+        final triggerFinder = find.byType(RxSelectTrigger);
+        expect(triggerFinder, findsOneWidget);
+
+        // Verify the label is displayed
+        expect(find.text('Select an item'), findsOneWidget);
+
+        // Verify the default icon is displayed
+        expect(find.byIcon(Icons.keyboard_arrow_down), findsOneWidget);
+      });
+
+      testWidgets('should display custom icon when provided',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelect(
+            items: [],
+            child: RxSelectTrigger(
+              label: 'Select an item',
+              trailingIcon: Icons.abc,
+            ),
+          ),
+        );
+
+        expect(find.byIcon(Icons.abc), findsOneWidget);
+        expect(find.byIcon(Icons.keyboard_arrow_down), findsNothing);
+      });
+    });
+  });
+
+  group('RxSelectItem', () {
+    group('Constructor', () {
+      const value = Options.apple;
+      const label = 'Apple';
+      const trailingIcon = Icons.star;
+      const semanticLabel = 'Select apple';
+      const cursor = SystemMouseCursors.precise;
+      const enableHapticFeedback = false;
+
+      testWidgets('should initialize with correct properties',
+          (WidgetTester tester) async {
+        final focusNode = FocusNode();
+
+        final widget = RxSelectItem<Options>(
+          value: value,
+          label: label,
+          trailingIcon: trailingIcon,
+          enabled: false,
+          semanticLabel: semanticLabel,
+          cursor: cursor,
+          enableHapticFeedback: enableHapticFeedback,
+          focusNode: focusNode,
+        );
+
+        expect(widget.value, value);
+        expect(widget.label, label);
+        expect(widget.trailingIcon, trailingIcon);
+        expect(widget.enabled, false);
+        expect(widget.semanticLabel, semanticLabel);
+        expect(widget.cursor, cursor);
+        expect(widget.enableHapticFeedback, enableHapticFeedback);
+        expect(widget.focusNode, focusNode);
+      });
+
+      testWidgets('should throw exception when not wrapped by RxSelect',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelectItem<Options>(
+            value: Options.apple,
+            label: 'Apple',
+          ),
+        );
+
+        expect(tester.takeException(), isException);
+      });
+    });
+
+    group('Layout', () {
+      testWidgets('should display label and icon', (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelect<Options>(
+            items: [
+              RxSelectItem<Options>(
+                value: Options.apple,
+                label: 'Apple',
+                trailingIcon: Icons.star,
+              ),
+            ],
+            child: RxSelectTrigger(label: 'Select an item'),
+          ),
+        );
+
+        await tester.tap(find.text('Select an item'));
+        await tester.pumpAndSettle();
+
+        final itemFinder = find.byType(RxSelectItem<Options>);
+        expect(itemFinder, findsOneWidget);
+
+        // Verify the label is displayed
+        expect(find.text('Apple'), findsOneWidget);
+
+        // Verify the default icon is displayed
+        expect(find.byIcon(Icons.star), findsOneWidget);
+      });
+
+      testWidgets('should display custom widget with raw constructor',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelect<Options>(
+            items: [
+              RxSelectItem<Options>.raw(
+                value: Options.apple,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.favorite, color: Colors.red),
+                    SizedBox(width: 8),
+                    Text('heart'),
+                  ],
+                ),
+              ),
+            ],
+            child: RxSelectTrigger(label: 'Select an item'),
+          ),
+        );
+
+        await tester.tap(find.text('Select an item'));
+        await tester.pumpAndSettle();
+
+        final itemFinder = find.byType(RxSelectItem<Options>);
+        expect(itemFinder, findsOneWidget);
+
+        // Verify the custom widget is displayed
+        expect(find.text('heart'), findsOneWidget);
+        expect(find.byIcon(Icons.favorite), findsOneWidget);
+
+        // Verify default label and icon are not displayed
+        expect(find.byIcon(Icons.check), findsNothing);
+      });
+
+      testWidgets('should display custom icon when provided',
+          (WidgetTester tester) async {
+        await tester.pumpRxWidget(
+          const RxSelect<Options>(
+            items: [
+              RxSelectItem<Options>(
+                value: Options.apple,
+                label: 'Apple',
+                trailingIcon: Icons.star,
+              ),
+            ],
+            child: RxSelectTrigger(label: 'Select an item'),
+          ),
+        );
+
+        await tester.tap(find.text('Select an item'));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.star), findsOneWidget);
+        expect(find.byIcon(Icons.check), findsNothing);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Refactored RxSelect component to support custom item and trigger widgets with `.raw()` constructors
- Updated SelectMenuItemSpec to use IconThemeData and TextStyle instead of IconSpec and TextSpec
- Added comprehensive test suite for RxSelect component
- Improved styling system with proper icon and text theme support
- Enhanced demo with examples of custom widgets

## Key Changes
- Added RxSelectTrigger.raw() and RxSelectItem.raw() constructors for custom widgets
- Replaced IconSpec and TextSpec with IconThemeData and TextStyle in SelectMenuItemSpec
- Updated styling to use IconTheme and DefaultTextStyle for better theming
- Added NakedSelectInherited.maybeOf() method for better error handling
- Comprehensive test coverage including interaction tests

## Test plan
- [x] Basic select functionality works
- [x] Custom trigger and item widgets work correctly
- [x] Styling applies properly to both default and custom widgets
- [x] All existing tests pass
- [x] New comprehensive test suite validates component behavior

🤖 Generated with [Claude Code](https://claude.ai/code)