### PR TITLE
feat: Add variants support to radio and select components

### DIFF
--- a/packages/naked/lib/src/naked_radio.dart
+++ b/packages/naked/lib/src/naked_radio.dart
@@ -43,10 +43,10 @@ class NakedRadioGroup<T> extends StatefulWidget {
   });
 
   @override
-  State<NakedRadioGroup<T>> createState() => _NakedRadioGroupState<T>();
+  State<NakedRadioGroup<T>> createState() => NakedRadioGroupState<T>();
 }
 
-class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
+class NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
   // Set of registered radio buttons
   final Set<_NakedRadioState<T>> _radios = {};
 
@@ -122,7 +122,7 @@ class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
 
 /// Internal InheritedWidget that provides radio group state to child radio buttons.
 class NakedRadioGroupScope<T> extends InheritedWidget {
-  final _NakedRadioGroupState<T> state;
+  final NakedRadioGroupState<T> state;
   final T? groupValue;
 
   /// Creates a radio group scope.
@@ -311,7 +311,7 @@ class _NakedRadioState<T> extends State<NakedRadio<T>> {
   };
 
   bool _getInterative(
-    _NakedRadioGroupState<T> group,
+    NakedRadioGroupState<T> group,
   ) =>
       widget.enabled && group.widget.enabled && group.widget.onChanged != null;
 

--- a/packages/remix/lib/src/components/form/radio/radio_widget.dart
+++ b/packages/remix/lib/src/components/form/radio/radio_widget.dart
@@ -42,6 +42,7 @@ class RxRadioGroup<T> extends StatefulWidget {
     required this.child,
     this.enabled = true,
     this.style,
+    this.variants = const [],
   });
 
   final T? value;
@@ -57,6 +58,9 @@ class RxRadioGroup<T> extends StatefulWidget {
 
   /// {@macro remix.component.style}
   final RxRadioStyle? style;
+
+  /// {@macro remix.component.variants}
+  final List<Variant> variants;
 
   @override
   State<RxRadioGroup<T>> createState() => _RxRadioGroupState<T>();
@@ -86,6 +90,7 @@ class _RxRadioGroupState<T> extends State<RxRadioGroup<T>> {
   Widget build(BuildContext context) {
     return StyleScope<RxRadioStyle>(
       style: _style,
+      variants: widget.variants,
       child: NakedRadioGroup<T>(
         groupValue: _value,
         onChanged: (value) {
@@ -141,7 +146,7 @@ class _RxRadioState<T> extends State<RxRadio<T>>
 
   @override
   Widget build(BuildContext context) {
-    final style = StyleScope.of<RxRadioStyle>(context)!;
+    final styleScope = StyleScope.of<RxRadioStyle>(context)!;
 
     return NakedRadio<T>(
       value: widget.value,
@@ -174,7 +179,7 @@ class _RxRadioState<T> extends State<RxRadio<T>>
             ],
           );
         },
-        style: Style(style),
+        style: Style(styleScope.style).applyVariants(styleScope.variants),
         controller: mixController,
       ),
     );

--- a/packages/remix/lib/src/components/form/select/select_widget.dart
+++ b/packages/remix/lib/src/components/form/select/select_widget.dart
@@ -136,6 +136,7 @@ class _RxSelectState<T> extends State<RxSelect<T>>
   Widget build(BuildContext context) {
     return StyleScope<RxSelectStyle>(
       style: _style,
+      variants: widget.variants,
       child: MixBuilder(
         style: Style(_style),
         builder: (context) {
@@ -302,7 +303,7 @@ class RxSelectTrigger extends StatefulWidget implements Disableable {
 
 class _RxSelectTriggerState extends State<RxSelectTrigger>
     with MixControllerMixin, DisableableMixin {
-  RxSelectStyle get style {
+  StyleScope<RxSelectStyle> get styleScope {
     final style = StyleScope.of<RxSelectStyle>(context);
     if (style == null) {
       throw Exception(
@@ -348,7 +349,7 @@ class _RxSelectTriggerState extends State<RxSelectTrigger>
                 spec.trigger.container.box(child: widget.child ?? defaultChild),
           );
         },
-        style: Style(style),
+        style: Style(styleScope.style).applyVariants(styleScope.variants),
         controller: mixController,
       ),
     );
@@ -435,7 +436,8 @@ class _RxSelectItemState<T> extends State<RxSelectItem<T>>
     mixController.selected = inherited.isSelected(context, widget.value);
   }
 
-  RxSelectStyle get _style => StyleScope.of<RxSelectStyle>(context)!;
+  StyleScope<RxSelectStyle> get _styleScope =>
+      StyleScope.of<RxSelectStyle>(context)!;
 
   @override
   Widget build(BuildContext context) {
@@ -477,7 +479,7 @@ class _RxSelectItemState<T> extends State<RxSelectItem<T>>
             ),
           );
         },
-        style: Style(_style),
+        style: Style(_styleScope.style).applyVariants(_styleScope.variants),
         controller: mixController,
       ),
     );

--- a/packages/remix/lib/src/core/style_scope.dart
+++ b/packages/remix/lib/src/core/style_scope.dart
@@ -4,13 +4,19 @@ import 'package:mix/mix.dart';
 
 @internal
 class StyleScope<U extends SpecUtility> extends InheritedWidget {
-  const StyleScope({super.key, required super.child, required this.style});
+  const StyleScope({
+    super.key,
+    required super.child,
+    required this.style,
+    this.variants = const [],
+  });
 
-  static U? of<U extends SpecUtility>(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<StyleScope<U>>()?.style;
+  static StyleScope<U>? of<U extends SpecUtility>(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<StyleScope<U>>();
   }
 
-  final U? style;
+  final U style;
+  final List<Variant> variants;
 
   @override
   bool updateShouldNotify(StyleScope<U> oldWidget) {


### PR DESCRIPTION
## Summary
- Add variants support to RxRadioGroup and RxSelect components
- Refactor StyleScope to include variants parameter
- Update select menu item spec to use IconThemeData and TextStyle instead of IconSpec and TextSpec
- Add comprehensive test suite for RxSelect component
- Improve error handling in radio and select components with better null safety

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Test radio group with variants
- [x] Test select component with variants
- [x] Verify style scope changes work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)