### PR TITLE
feat: enhance RxSlider with focus support and drag callbacks

### DIFF
--- a/packages/naked/lib/src/naked_radio.dart
+++ b/packages/naked/lib/src/naked_radio.dart
@@ -43,10 +43,10 @@ class NakedRadioGroup<T> extends StatefulWidget {
   });
 
   @override
-  State<NakedRadioGroup<T>> createState() => _NakedRadioGroupState<T>();
+  State<NakedRadioGroup<T>> createState() => NakedRadioGroupState<T>();
 }
 
-class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
+class NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
   // Set of registered radio buttons
   final Set<_NakedRadioState<T>> _radios = {};
 
@@ -122,7 +122,7 @@ class _NakedRadioGroupState<T> extends State<NakedRadioGroup<T>> {
 
 /// Internal InheritedWidget that provides radio group state to child radio buttons.
 class NakedRadioGroupScope<T> extends InheritedWidget {
-  final _NakedRadioGroupState<T> state;
+  final NakedRadioGroupState<T> state;
   final T? groupValue;
 
   /// Creates a radio group scope.
@@ -311,7 +311,7 @@ class _NakedRadioState<T> extends State<NakedRadio<T>> {
   };
 
   bool _getInterative(
-    _NakedRadioGroupState<T> group,
+    NakedRadioGroupState<T> group,
   ) =>
       widget.enabled && group.widget.enabled && group.widget.onChanged != null;
 

--- a/packages/remix/lib/src/components/form/radio/radio_widget.dart
+++ b/packages/remix/lib/src/components/form/radio/radio_widget.dart
@@ -42,6 +42,7 @@ class RxRadioGroup<T> extends StatefulWidget {
     required this.child,
     this.enabled = true,
     this.style,
+    this.variants = const [],
   });
 
   final T? value;
@@ -57,6 +58,9 @@ class RxRadioGroup<T> extends StatefulWidget {
 
   /// {@macro remix.component.style}
   final RxRadioStyle? style;
+
+  /// {@macro remix.component.variants}
+  final List<Variant> variants;
 
   @override
   State<RxRadioGroup<T>> createState() => _RxRadioGroupState<T>();
@@ -86,6 +90,7 @@ class _RxRadioGroupState<T> extends State<RxRadioGroup<T>> {
   Widget build(BuildContext context) {
     return StyleScope<RxRadioStyle>(
       style: _style,
+      variants: widget.variants,
       child: NakedRadioGroup<T>(
         groupValue: _value,
         onChanged: (value) {
@@ -141,7 +146,7 @@ class _RxRadioState<T> extends State<RxRadio<T>>
 
   @override
   Widget build(BuildContext context) {
-    final style = StyleScope.of<RxRadioStyle>(context)!;
+    final styleScope = StyleScope.of<RxRadioStyle>(context)!;
 
     return NakedRadio<T>(
       value: widget.value,
@@ -174,7 +179,7 @@ class _RxRadioState<T> extends State<RxRadio<T>>
             ],
           );
         },
-        style: Style(style),
+        style: Style(styleScope.style).applyVariants(styleScope.variants),
         controller: mixController,
       ),
     );

--- a/packages/remix/lib/src/components/form/select/select_widget.dart
+++ b/packages/remix/lib/src/components/form/select/select_widget.dart
@@ -136,6 +136,7 @@ class _RxSelectState<T> extends State<RxSelect<T>>
   Widget build(BuildContext context) {
     return StyleScope<RxSelectStyle>(
       style: _style,
+      variants: widget.variants,
       child: MixBuilder(
         style: Style(_style),
         builder: (context) {
@@ -302,7 +303,7 @@ class RxSelectTrigger extends StatefulWidget implements Disableable {
 
 class _RxSelectTriggerState extends State<RxSelectTrigger>
     with MixControllerMixin, DisableableMixin {
-  RxSelectStyle get style {
+  StyleScope<RxSelectStyle> get styleScope {
     final style = StyleScope.of<RxSelectStyle>(context);
     if (style == null) {
       throw Exception(
@@ -348,7 +349,7 @@ class _RxSelectTriggerState extends State<RxSelectTrigger>
                 spec.trigger.container.box(child: widget.child ?? defaultChild),
           );
         },
-        style: Style(style),
+        style: Style(styleScope.style).applyVariants(styleScope.variants),
         controller: mixController,
       ),
     );
@@ -435,7 +436,8 @@ class _RxSelectItemState<T> extends State<RxSelectItem<T>>
     mixController.selected = inherited.isSelected(context, widget.value);
   }
 
-  RxSelectStyle get _style => StyleScope.of<RxSelectStyle>(context)!;
+  StyleScope<RxSelectStyle> get _styleScope =>
+      StyleScope.of<RxSelectStyle>(context)!;
 
   @override
   Widget build(BuildContext context) {
@@ -477,7 +479,7 @@ class _RxSelectItemState<T> extends State<RxSelectItem<T>>
             ),
           );
         },
-        style: Style(_style),
+        style: Style(_styleScope.style).applyVariants(_styleScope.variants),
         controller: mixController,
       ),
     );

--- a/packages/remix/lib/src/components/form/slider/slider_widget.dart
+++ b/packages/remix/lib/src/components/form/slider/slider_widget.dart
@@ -29,6 +29,7 @@ class RxSlider extends StatefulWidget implements Disableable {
     this.style,
     this.variants = const [],
     this.enabled = true,
+    this.focusNode,
   }) : assert(
           value >= min && value <= max,
           'Slider value must be between min and max values',
@@ -67,6 +68,9 @@ class RxSlider extends StatefulWidget implements Disableable {
   /// Called when the user is done selecting a new value.
   final ValueChanged<double>? onChangeEnd;
 
+  /// The focus node for the slider.
+  final FocusNode? focusNode;
+
   @override
   State<RxSlider> createState() => _RxSliderState();
 }
@@ -91,6 +95,10 @@ class _RxSliderState extends State<RxSlider>
       min: widget.min,
       max: widget.max,
       onChanged: widget.onChanged,
+      onDragStart: () {
+        widget.onChangeStart?.call(widget.value);
+      },
+      onDragEnd: widget.onChangeEnd,
       onHoverState: (state) {
         mixController.hovered = state;
       },
@@ -101,6 +109,7 @@ class _RxSliderState extends State<RxSlider>
         mixController.focused = state;
       },
       enabled: widget.enabled,
+      focusNode: widget.focusNode,
       direction: Axis.horizontal,
       divisions: _divisions,
       child: RemixBuilder(

--- a/packages/remix/lib/src/core/style_scope.dart
+++ b/packages/remix/lib/src/core/style_scope.dart
@@ -4,13 +4,19 @@ import 'package:mix/mix.dart';
 
 @internal
 class StyleScope<U extends SpecUtility> extends InheritedWidget {
-  const StyleScope({super.key, required super.child, required this.style});
+  const StyleScope({
+    super.key,
+    required super.child,
+    required this.style,
+    this.variants = const [],
+  });
 
-  static U? of<U extends SpecUtility>(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<StyleScope<U>>()?.style;
+  static StyleScope<U>? of<U extends SpecUtility>(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<StyleScope<U>>();
   }
 
-  final U? style;
+  final U style;
+  final List<Variant> variants;
 
   @override
   bool updateShouldNotify(StyleScope<U> oldWidget) {

--- a/packages/remix/test/components/slider_test.dart
+++ b/packages/remix/test/components/slider_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/src/components/form/slider/slider.dart';
+import '../utils/interaction_tests.dart';
+
+void main() {
+  group('RxSlider', () {
+    group('Constructor', () {
+      const min = 0.0;
+      const max = 100.0;
+      const value = 50.0;
+      const enabled = true;
+      final style = RxSliderStyle();
+      void onChanged(double value) {}
+      const variants = [Variant('primary')];
+
+      testWidgets('should initialize with correct properties', (tester) async {
+        final slider = RxSlider(
+          min: min,
+          max: max,
+          value: value,
+          enabled: enabled,
+          style: style,
+          onChanged: onChanged,
+          variants: variants,
+        );
+
+        await tester.pumpRxWidget(slider);
+
+        expect(slider.min, min);
+        expect(slider.max, max);
+        expect(slider.value, value);
+        expect(slider.enabled, enabled);
+        expect(slider.style, style);
+        expect(slider.onChanged, onChanged);
+        expect(slider.variants, variants);
+      });
+
+      testWidgets('should render correct UI output', (tester) async {
+        final slider = RxSlider(
+          min: min,
+          max: max,
+          value: value,
+          onChanged: onChanged,
+        );
+
+        await tester.pumpRxWidget(slider);
+
+        final sliderFinder = find.byType(RxSlider);
+        expect(sliderFinder, findsOneWidget);
+      });
+    });
+
+    testWidgets('should call onChangeStart when drag begins', (tester) async {
+      double? startValue;
+      double value = 50.0;
+      final slider = StatefulBuilder(builder: (context, setState) {
+        return RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: value,
+          onChangeStart: (newValue) => startValue = newValue,
+          onChanged: (newValue) {
+            setState(() {
+              value = newValue;
+            });
+          },
+        );
+      });
+
+      await tester.pumpRxWidget(slider);
+
+      final center = tester.getCenter(find.byType(RxSlider));
+      final gesture = await tester.startGesture(center);
+      await gesture.moveTo(Offset(center.dx + 50, center.dy));
+      await tester.pumpAndSettle();
+
+      expect(startValue, equals(50.0));
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('should call onChangeEnd when drag ends', (tester) async {
+      double? endValue;
+      double value = 50.0;
+      final slider = StatefulBuilder(builder: (context, setState) {
+        return RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: value,
+          onChangeEnd: (newValue) {
+            endValue = newValue;
+          },
+          onChanged: (newValue) {
+            setState(() {
+              value = newValue;
+            });
+          },
+        );
+      });
+
+      await tester.pumpRxWidget(slider);
+
+      final center = tester.getCenter(find.byType(RxSlider));
+      final gesture = await tester.startGesture(center);
+      await gesture.moveTo(Offset(center.dx + 50, center.dy));
+
+      await tester.pumpAndSettle();
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(endValue, isNotNull);
+      expect(endValue!, greaterThan(50.0));
+    });
+
+    group('interactions', () {
+      Future<void> testSliderDrag(
+        WidgetTester tester, {
+        required bool enabled,
+        required bool shouldCallOnChanged,
+      }) async {
+        double? changedValue;
+        final slider = RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: 50.0,
+          enabled: enabled,
+          onChanged: (value) => changedValue = value,
+        );
+
+        await tester.pumpRxWidget(slider);
+
+        final center = tester.getCenter(find.byType(RxSlider));
+        final gesture = await tester.startGesture(center);
+        await gesture.moveTo(Offset(center.dx + 50, center.dy));
+        await tester.pumpAndSettle();
+
+        if (shouldCallOnChanged) {
+          expect(changedValue, isNotNull);
+          expect(changedValue!, greaterThan(50.0));
+        } else {
+          expect(changedValue, isNull);
+        }
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('should call onChanged when dragged', (tester) async {
+        await testSliderDrag(tester, enabled: true, shouldCallOnChanged: true);
+      });
+
+      testWidgets('should not call onChanged when disabled and dragged',
+          (tester) async {
+        await testSliderDrag(tester,
+            enabled: false, shouldCallOnChanged: false);
+      });
+
+      testHoverWidget('should handle hover state correctly', () {
+        return RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: 50.0,
+          onChanged: (value) {},
+        );
+      }, shouldExpectHover: true);
+
+      testFocusWidget('should handle focus state correctly', (focusNode) {
+        return RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: 50.0,
+          focusNode: focusNode,
+          onChanged: (value) {},
+        );
+      }, shouldExpectFocus: true);
+
+      testFocusWidget('should not handle focus state when disabled',
+          (focusNode) {
+        return RxSlider(
+          min: 0.0,
+          max: 100.0,
+          value: 50.0,
+          focusNode: focusNode,
+          enabled: false,
+          onChanged: (value) {},
+        );
+      }, shouldExpectFocus: false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add focusNode and drag callback support to RxSlider component
- Add comprehensive test suite for RxSlider interactions and state management
- Add variants support to radio and select components for better theming
- Refactor StyleScope to properly handle variants across components
- Expose NakedRadioGroupState for better component composition

## Test plan
- [x] All existing tests pass
- [x] New RxSlider tests cover focus, hover, drag interactions
- [x] Drag callbacks (onChangeStart/onChangeEnd) work correctly
- [x] FocusNode integration functions properly
- [x] Variants support works across radio and select components
- [x] Disabled state prevents interactions as expected

🤖 Generated with [Claude Code](https://claude.ai/code)