### PR TITLE
refactor: Rename MixWidgetState to MixWidgetStateModel

### DIFF
--- a/packages/mix/lib/src/core/styled_widget.dart
+++ b/packages/mix/lib/src/core/styled_widget.dart
@@ -100,7 +100,7 @@ class SpecBuilder extends StatefulWidget {
   /// Order in which modifiers should be applied.
   ///
   /// Defaults to an empty list, which uses the default modifier order.
-  final List<Type> orderOfModifiers;
+  final List<Type>? orderOfModifiers;
 
   @override
   State<SpecBuilder> createState() => _SpecBuilderState();
@@ -151,10 +151,11 @@ class _SpecBuilderState extends State<SpecBuilder> {
       style: _convertToStyle(widget.style),
       builder: widget.builder,
       inherit: widget.inherit,
-      orderOfModifiers: widget.orderOfModifiers,
+      orderOfModifiers: widget.orderOfModifiers ?? [],
     );
 
-    if (_shouldWrapWithInteractable && MixWidgetState.of(context) == null) {
+    if (_shouldWrapWithInteractable &&
+        MixWidgetStateModel.of(context) == null) {
       return Interactable(controller: widget.controller, child: builder);
     }
 

--- a/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
+++ b/packages/mix/lib/src/core/widget_state/internal/mix_widget_state_builder.dart
@@ -18,7 +18,7 @@ class MixWidgetStateBuilder extends StatelessWidget {
     return ListenableBuilder(
       listenable: controller,
       builder: (context, _) {
-        return MixWidgetState.fromSet(
+        return MixWidgetStateModel.fromSet(
           states: controller.value,
           child: Builder(builder: builder),
         );

--- a/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
+++ b/packages/mix/lib/src/core/widget_state/widget_state_controller.dart
@@ -80,8 +80,8 @@ extension on Set<WidgetState> {
   bool get hasError => contains(WidgetState.error);
 }
 
-class MixWidgetState extends InheritedModel<WidgetState> {
-  MixWidgetState.fromSet({
+class MixWidgetStateModel extends InheritedModel<WidgetState> {
+  MixWidgetStateModel.fromSet({
     super.key,
     required Set<WidgetState> states,
     required super.child,
@@ -93,7 +93,7 @@ class MixWidgetState extends InheritedModel<WidgetState> {
         selected = states.hasSelected,
         error = states.hasError;
 
-  const MixWidgetState({
+  const MixWidgetStateModel({
     super.key,
     required this.disabled,
     required this.hovered,
@@ -105,8 +105,8 @@ class MixWidgetState extends InheritedModel<WidgetState> {
     required super.child,
   });
 
-  static MixWidgetState? of(BuildContext context, [WidgetState? state]) {
-    return InheritedModel.inheritFrom<MixWidgetState>(
+  static MixWidgetStateModel? of(BuildContext context, [WidgetState? state]) {
+    return InheritedModel.inheritFrom<MixWidgetStateModel>(
       context,
       aspect: state,
     );
@@ -139,7 +139,7 @@ class MixWidgetState extends InheritedModel<WidgetState> {
   final bool error;
 
   @override
-  bool updateShouldNotify(MixWidgetState oldWidget) {
+  bool updateShouldNotify(MixWidgetStateModel oldWidget) {
     return oldWidget.disabled != disabled ||
         oldWidget.hovered != hovered ||
         oldWidget.focused != focused ||
@@ -151,7 +151,7 @@ class MixWidgetState extends InheritedModel<WidgetState> {
 
   @override
   bool updateShouldNotifyDependent(
-    MixWidgetState oldWidget,
+    MixWidgetStateModel oldWidget,
     Set<WidgetState> dependencies,
   ) {
     return oldWidget.disabled != disabled && dependencies.hasDisabled ||

--- a/packages/mix/lib/src/variants/widget_state_variant.dart
+++ b/packages/mix/lib/src/variants/widget_state_variant.dart
@@ -33,7 +33,8 @@ abstract class _ToggleMixStateVariant extends MixWidgetStateVariant<bool> {
   bool builder(BuildContext context) => when(context);
 
   @override
-  bool when(BuildContext context) => MixWidgetState.hasStateOf(context, _state);
+  bool when(BuildContext context) =>
+      MixWidgetStateModel.hasStateOf(context, _state);
 }
 
 /// Applies styles when widget is hovered over.
@@ -54,7 +55,7 @@ class OnHoverVariant extends MixWidgetStateVariant<PointerPosition?> {
   }
 
   @override
-  bool when(BuildContext context) => MixWidgetState.hasStateOf(
+  bool when(BuildContext context) => MixWidgetStateModel.hasStateOf(
         context,
         WidgetState.hovered,
       );
@@ -74,6 +75,13 @@ class OnLongPressVariant extends ContextVariant {
     'The longPress variant has been removed. Please implement your own context variant for it',
   )
   const OnLongPressVariant();
+
+  ContextVariantBuilder event(Style Function(bool) fn) {
+    return ContextVariantBuilder(
+      (BuildContext context) => fn(when(context)),
+      this,
+    );
+  }
 
   @override
   bool when(BuildContext context) {

--- a/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
+++ b/packages/mix/test/src/core/mix_state/internal/gesture_mix_state_test.dart
@@ -56,7 +56,7 @@ void main() {
       final context = tester.element(find.byKey(key));
 
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.pressed),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should be pressed immediately after tap',
       );
@@ -97,7 +97,7 @@ void main() {
       await tester.pump();
       final context = tester.element(find.byKey(key));
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.pressed),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should be pressed immediately after tap',
       );
@@ -106,7 +106,7 @@ void main() {
         const Duration(milliseconds: 50),
       );
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.pressed),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.pressed),
         isTrue,
         reason: 'GesturableState should still be pressed 50ms after tap',
       );
@@ -115,7 +115,7 @@ void main() {
         const Duration(milliseconds: 100),
       );
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.pressed),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.pressed),
         isFalse,
         reason:
             'GesturableState should be unpressed after unpressDelay has passed',
@@ -132,7 +132,8 @@ void main() {
 
       await tester.tap(find.byType(GestureMixStateWidget));
       final context = tester.element(find.byKey(key));
-      expect(MixWidgetState.hasStateOf(context, WidgetState.pressed), isFalse);
+      expect(MixWidgetStateModel.hasStateOf(context, WidgetState.pressed),
+          isFalse);
     });
 
     testWidgets('GesturableWidget pan functions test', (

--- a/packages/mix/test/src/core/mix_state/internal/interactive_mix_state_test.dart
+++ b/packages/mix/test/src/core/mix_state/internal/interactive_mix_state_test.dart
@@ -17,7 +17,7 @@ void main() {
       var context = tester.element(find.byType(Container));
 
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.disabled),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.disabled),
         isTrue,
       );
 
@@ -27,7 +27,8 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(MixWidgetState.hasStateOf(context, WidgetState.disabled), isFalse);
+      expect(MixWidgetStateModel.hasStateOf(context, WidgetState.disabled),
+          isFalse);
     });
 
     testWidgets('should update focused state', (WidgetTester tester) async {
@@ -40,7 +41,7 @@ void main() {
 
       var context = tester.element(find.byType(Container));
       expect(
-        MixWidgetState.hasStateOf(context, WidgetState.focused),
+        MixWidgetStateModel.hasStateOf(context, WidgetState.focused),
         isTrue,
       );
 
@@ -50,7 +51,8 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(MixWidgetState.hasStateOf(context, WidgetState.focused), isFalse);
+      expect(MixWidgetStateModel.hasStateOf(context, WidgetState.focused),
+          isFalse);
     });
 
     testWidgets('should update hovered state', (WidgetTester tester) async {
@@ -64,7 +66,8 @@ void main() {
       );
 
       var context = tester.element(find.byType(Container));
-      expect(MixWidgetState.hasStateOf(context, WidgetState.hovered), isTrue);
+      expect(
+          MixWidgetStateModel.hasStateOf(context, WidgetState.hovered), isTrue);
 
       controller.hovered = false;
 
@@ -72,7 +75,8 @@ void main() {
 
       context = tester.element(find.byType(Container));
 
-      expect(MixWidgetState.hasStateOf(context, WidgetState.hovered), isFalse);
+      expect(MixWidgetStateModel.hasStateOf(context, WidgetState.hovered),
+          isFalse);
     });
   });
 }

--- a/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
+++ b/packages/mix/test/src/widgets/pressable/pressable_widget_test.dart
@@ -43,9 +43,9 @@ void main() {
       final secondContext = tester.element(find.byKey(secondKey));
       final thirdContext = tester.element(find.byKey(thirdKey));
 
-      final firstNotifier = MixWidgetState.of(firstContext);
-      final secondNotifier = MixWidgetState.of(secondContext);
-      final thirdNotifier = MixWidgetState.of(thirdContext);
+      final firstNotifier = MixWidgetStateModel.of(firstContext);
+      final secondNotifier = MixWidgetStateModel.of(secondContext);
+      final thirdNotifier = MixWidgetStateModel.of(thirdContext);
 
       expect(onEnabledAttr.variant.when(firstContext), false,
           reason: 'First Pressable should be disabled');

--- a/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
+++ b/packages/mix/test/src/widgets/widget_state/widget_state_controller_test.dart
@@ -148,14 +148,14 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: MixWidgetState.fromSet(
+          home: MixWidgetStateModel.fromSet(
             states: controller.value,
             child: Container(),
           ),
         ),
       );
       final foundModel =
-          MixWidgetState.of(tester.element(find.byType(Container)));
+          MixWidgetStateModel.of(tester.element(find.byType(Container)));
       expect(foundModel, isNotNull);
       expect(foundModel!.disabled, isTrue);
       expect(foundModel.hovered, isTrue);
@@ -169,7 +169,7 @@ void main() {
     testWidgets('hasStateOf returns if state is set', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: MixWidgetState(
+          home: MixWidgetStateModel(
             disabled: true,
             hovered: false,
             focused: false,
@@ -180,14 +180,14 @@ void main() {
             child: Builder(
               builder: (context) {
                 expect(
-                  MixWidgetState.hasStateOf(
+                  MixWidgetStateModel.hasStateOf(
                     context,
                     WidgetState.disabled,
                   ),
                   isTrue,
                 );
                 expect(
-                  MixWidgetState.hasStateOf(
+                  MixWidgetStateModel.hasStateOf(
                     context,
                     WidgetState.hovered,
                   ),
@@ -202,7 +202,7 @@ void main() {
     });
 
     test('updateShouldNotify returns true if value changed', () {
-      final oldModel = MixWidgetState(
+      final oldModel = MixWidgetStateModel(
         disabled: false,
         hovered: false,
         focused: false,
@@ -212,7 +212,7 @@ void main() {
         error: false,
         child: Container(),
       );
-      final newModel = MixWidgetState(
+      final newModel = MixWidgetStateModel(
         disabled: true,
         hovered: false,
         focused: false,
@@ -227,7 +227,7 @@ void main() {
     });
 
     test('updateShouldNotifyDependent returns if a dependency changed', () {
-      final oldModel = MixWidgetState(
+      final oldModel = MixWidgetStateModel(
         disabled: false,
         hovered: false,
         focused: false,
@@ -237,7 +237,7 @@ void main() {
         error: false,
         child: Container(),
       );
-      final newModel = MixWidgetState(
+      final newModel = MixWidgetStateModel(
         disabled: true,
         hovered: false,
         focused: false,
@@ -462,7 +462,7 @@ class PressableStateTestWidget extends StatefulWidget {
 class _PressableStateTestWidgetState extends State<PressableStateTestWidget> {
   bool Function(BuildContext) _widgetStateOf(WidgetState state) {
     return (BuildContext context) {
-      return MixWidgetState.hasStateOf(context, state);
+      return MixWidgetStateModel.hasStateOf(context, state);
     };
   }
 

--- a/packages/remix/lib/src/helpers/remix_builder.dart
+++ b/packages/remix/lib/src/helpers/remix_builder.dart
@@ -21,7 +21,7 @@ class RemixBuilder extends StatelessWidget {
     return ListenableBuilder(
       listenable: controller,
       builder: (_, __) {
-        return MixWidgetState.fromSet(
+        return MixWidgetStateModel.fromSet(
           states: controller.value,
           child: MixBuilder(style: Style(style), builder: builder),
         );

--- a/packages/remix/test/components/radio_test.dart
+++ b/packages/remix/test/components/radio_test.dart
@@ -1,9 +1,10 @@
 import 'dart:ui';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';
 import 'package:remix/remix.dart';
+
 import '../utils/interaction_tests.dart';
 
 void main() {
@@ -217,15 +218,15 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        final state =
-            tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+        final state = tester
+            .widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
         expect(state.pressed, expectedPressedDuringTap);
 
         await gesture.up();
         await tester.pumpAndSettle();
 
-        final stateAfter =
-            tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+        final stateAfter = tester
+            .widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
         expect(stateAfter.pressed, false);
       }
 
@@ -287,24 +288,26 @@ void main() {
         await tester.pumpAndSettle();
 
         final state1 = tester
-            .widgetList<MixWidgetState>(find.byType(MixWidgetState))
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
             .first;
         expect(state1.hovered, expectedHovered);
 
-        final state2 =
-            tester.widgetList<MixWidgetState>(find.byType(MixWidgetState)).last;
+        final state2 = tester
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
+            .last;
         expect(state2.hovered, false);
 
         await gesture.removePointer();
         await tester.pumpAndSettle();
 
         final stateAfter1 = tester
-            .widgetList<MixWidgetState>(find.byType(MixWidgetState))
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
             .first;
         expect(stateAfter1.hovered, false);
 
-        final stateAfter2 =
-            tester.widgetList<MixWidgetState>(find.byType(MixWidgetState)).last;
+        final stateAfter2 = tester
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
+            .last;
         expect(stateAfter2.hovered, false);
       }
 
@@ -364,24 +367,26 @@ void main() {
         await tester.pumpAndSettle();
 
         final state1 = tester
-            .widgetList<MixWidgetState>(find.byType(MixWidgetState))
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
             .first;
         expect(state1.focused, expectedFocused);
 
-        final state2 =
-            tester.widgetList<MixWidgetState>(find.byType(MixWidgetState)).last;
+        final state2 = tester
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
+            .last;
         expect(state2.focused, false);
 
         focusNode1.unfocus();
         await tester.pumpAndSettle();
 
         final stateAfter1 = tester
-            .widgetList<MixWidgetState>(find.byType(MixWidgetState))
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
             .first;
         expect(stateAfter1.focused, false);
 
-        final stateAfter2 =
-            tester.widgetList<MixWidgetState>(find.byType(MixWidgetState)).last;
+        final stateAfter2 = tester
+            .widgetList<MixWidgetStateModel>(find.byType(MixWidgetStateModel))
+            .last;
         expect(stateAfter2.focused, false);
       }
 

--- a/packages/remix/test/utils/interaction_tests.dart
+++ b/packages/remix/test/utils/interaction_tests.dart
@@ -96,7 +96,8 @@ void testHoverWidget(
     await gesture.moveTo(tester.getCenter(find.byWidget(widget)));
 
     await tester.pumpAndSettle();
-    final state = tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+    final state =
+        tester.widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
 
     expect(state.hovered, shouldExpectHover);
 
@@ -104,7 +105,7 @@ void testHoverWidget(
     await tester.pumpAndSettle();
 
     final stateAfter =
-        tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+        tester.widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
     expect(stateAfter.hovered, false);
   });
 }
@@ -126,7 +127,8 @@ void testFocusWidget(
     focusNode.requestFocus();
     await tester.pumpAndSettle();
 
-    final state = tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+    final state =
+        tester.widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
 
     expect(state.focused, shouldExpectFocus);
 
@@ -134,7 +136,7 @@ void testFocusWidget(
     await tester.pumpAndSettle();
 
     final stateAfter =
-        tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+        tester.widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
 
     expect(stateAfter.focused, false);
   });
@@ -165,7 +167,8 @@ void testSelectStateWidget(
     await tester.tap(find.byWidget(widget));
     await tester.pumpAndSettle();
 
-    final state = tester.widget<MixWidgetState>(find.byType(MixWidgetState));
+    final state =
+        tester.widget<MixWidgetStateModel>(find.byType(MixWidgetStateModel));
 
     expect(state.selected, shouldExpectSelect);
     expect(holder.value, shouldExpectSelect);


### PR DESCRIPTION
Refactors the MixWidgetState class and related references to MixWidgetStateModel across core, variants, and test files. This improves clarity and consistency in naming for widget state management.