### PR TITLE
feat: Add RxTooltip component with styles and tests

### DIFF
--- a/packages/remix/demo/lib/api/overlay/tooltip.dart
+++ b/packages/remix/demo/lib/api/overlay/tooltip.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Row(
+            children: [
+              RxTooltip(
+                tooltipChild: Text(
+                  'This is a tooltip',
+                  style: TextStyle(color: Colors.white),
+                ),
+                child: Text('Hello'),
+              ),
+              Tooltip(
+                message: 'This is a tooltip',
+                child: Text('Hello Mate'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/remix/lib/remix.dart
+++ b/packages/remix/lib/remix.dart
@@ -40,6 +40,7 @@ export 'src/components/form/switch/switch.dart';
 export 'src/components/form/textfield/textfield.dart';
 export 'src/components/layout/divider/divider.dart';
 export 'src/components/navigation/segmented_control/segmented_control.dart';
+export 'src/components/overlay/tooltip.dart';
 export 'src/components/utility/badge/badge.dart';
 export 'src/components/utility/dropdown_menu/dropdown_menu.dart';
 

--- a/packages/remix/lib/src/components/overlay/tooltip.dart
+++ b/packages/remix/lib/src/components/overlay/tooltip.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mix/experimental.dart';
+import 'package:mix/mix.dart';
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:naked/naked.dart';
+
+part 'tooltip.g.dart';
+part 'tooltip_style.dart';
+part 'tooltip_widget.dart';
+
+@MixableSpec()
+base class TooltipSpec extends Spec<TooltipSpec>
+    with _$TooltipSpec, Diagnosticable {
+  final BoxSpec container;
+
+  /// {@macro tooltip_spec_of}
+  static const of = _$TooltipSpec.of;
+
+  static const from = _$TooltipSpec.from;
+
+  const TooltipSpec({BoxSpec? container, super.modifiers, super.animated})
+      : container = container ?? const BoxSpec();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    _debugFillProperties(properties);
+  }
+}

--- a/packages/remix/lib/src/components/overlay/tooltip.g.dart
+++ b/packages/remix/lib/src/components/overlay/tooltip.g.dart
@@ -1,0 +1,246 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'tooltip.dart';
+
+// **************************************************************************
+// MixGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+/// A mixin that provides spec functionality for [TooltipSpec].
+mixin _$TooltipSpec on Spec<TooltipSpec> {
+  static TooltipSpec from(MixContext mix) {
+    return mix.attributeOf<TooltipSpecAttribute>()?.resolve(mix) ??
+        const TooltipSpec();
+  }
+
+  /// {@template tooltip_spec_of}
+  /// Retrieves the [TooltipSpec] from the nearest [ComputedStyle] ancestor in the widget tree.
+  ///
+  /// This method uses [ComputedStyle.specOf] for surgical rebuilds - only widgets
+  /// that call this method will rebuild when [TooltipSpec] changes, not when other specs change.
+  /// If no ancestor [ComputedStyle] is found, this method returns an empty [TooltipSpec].
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// final tooltipSpec = TooltipSpec.of(context);
+  /// ```
+  /// {@endtemplate}
+  static TooltipSpec of(BuildContext context) {
+    return ComputedStyle.specOf<TooltipSpec>(context) ?? const TooltipSpec();
+  }
+
+  /// Creates a copy of this [TooltipSpec] but with the given fields
+  /// replaced with the new values.
+  @override
+  TooltipSpec copyWith({
+    BoxSpec? container,
+    WidgetModifiersConfig? modifiers,
+    AnimatedData? animated,
+  }) {
+    return TooltipSpec(
+      container: container ?? _$this.container,
+      modifiers: modifiers ?? _$this.modifiers,
+      animated: animated ?? _$this.animated,
+    );
+  }
+
+  /// Linearly interpolates between this [TooltipSpec] and another [TooltipSpec] based on the given parameter [t].
+  ///
+  /// The parameter [t] represents the interpolation factor, typically ranging from 0.0 to 1.0.
+  /// When [t] is 0.0, the current [TooltipSpec] is returned. When [t] is 1.0, the [other] [TooltipSpec] is returned.
+  /// For values of [t] between 0.0 and 1.0, an interpolated [TooltipSpec] is returned.
+  ///
+  /// If [other] is null, this method returns the current [TooltipSpec] instance.
+  ///
+  /// The interpolation is performed on each property of the [TooltipSpec] using the appropriate
+  /// interpolation method:
+  /// - [BoxSpec.lerp] for [container].
+  /// For [modifiers] and [animated], the interpolation is performed using a step function.
+  /// If [t] is less than 0.5, the value from the current [TooltipSpec] is used. Otherwise, the value
+  /// from the [other] [TooltipSpec] is used.
+  ///
+  /// This method is typically used in animations to smoothly transition between
+  /// different [TooltipSpec] configurations.
+  @override
+  TooltipSpec lerp(TooltipSpec? other, double t) {
+    if (other == null) return _$this;
+
+    return TooltipSpec(
+      container: _$this.container.lerp(other.container, t),
+      modifiers: other.modifiers,
+      animated: _$this.animated ?? other.animated,
+    );
+  }
+
+  /// The list of properties that constitute the state of this [TooltipSpec].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [TooltipSpec] instances for equality.
+  @override
+  List<Object?> get props => [
+        _$this.container,
+        _$this.modifiers,
+        _$this.animated,
+      ];
+
+  TooltipSpec get _$this => this as TooltipSpec;
+
+  void _debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    properties.add(
+        DiagnosticsProperty('container', _$this.container, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty('modifiers', _$this.modifiers, defaultValue: null));
+    properties.add(
+        DiagnosticsProperty('animated', _$this.animated, defaultValue: null));
+  }
+}
+
+/// Represents the attributes of a [TooltipSpec].
+///
+/// This class encapsulates properties defining the layout and
+/// appearance of a [TooltipSpec].
+///
+/// Use this class to configure the attributes of a [TooltipSpec] and pass it to
+/// the [TooltipSpec] constructor.
+class TooltipSpecAttribute extends SpecAttribute<TooltipSpec>
+    with Diagnosticable {
+  final BoxSpecAttribute? container;
+
+  const TooltipSpecAttribute({
+    this.container,
+    super.modifiers,
+    super.animated,
+  });
+
+  /// Resolves to [TooltipSpec] using the provided [MixContext].
+  ///
+  /// If a property is null in the [MixContext], it falls back to the
+  /// default value defined in the `defaultValue` for that property.
+  ///
+  /// ```dart
+  /// final tooltipSpec = TooltipSpecAttribute(...).resolve(mix);
+  /// ```
+  @override
+  TooltipSpec resolve(MixContext mix) {
+    return TooltipSpec(
+      container: container?.resolve(mix),
+      modifiers: modifiers?.resolve(mix),
+      animated: animated?.resolve(mix) ?? mix.animation,
+    );
+  }
+
+  /// Merges the properties of this [TooltipSpecAttribute] with the properties of [other].
+  ///
+  /// If [other] is null, returns this instance unchanged. Otherwise, returns a new
+  /// [TooltipSpecAttribute] with the properties of [other] taking precedence over
+  /// the corresponding properties of this instance.
+  ///
+  /// Properties from [other] that are null will fall back
+  /// to the values from this instance.
+  @override
+  TooltipSpecAttribute merge(TooltipSpecAttribute? other) {
+    if (other == null) return this;
+
+    return TooltipSpecAttribute(
+      container: container?.merge(other.container) ?? other.container,
+      modifiers: modifiers?.merge(other.modifiers) ?? other.modifiers,
+      animated: animated?.merge(other.animated) ?? other.animated,
+    );
+  }
+
+  /// The list of properties that constitute the state of this [TooltipSpecAttribute].
+  ///
+  /// This property is used by the [==] operator and the [hashCode] getter to
+  /// compare two [TooltipSpecAttribute] instances for equality.
+  @override
+  List<Object?> get props => [
+        container,
+        modifiers,
+        animated,
+      ];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+        .add(DiagnosticsProperty('container', container, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('modifiers', modifiers, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty('animated', animated, defaultValue: null));
+  }
+}
+
+/// Utility class for configuring [TooltipSpec] properties.
+///
+/// This class provides methods to set individual properties of a [TooltipSpec].
+/// Use the methods of this class to configure specific properties of a [TooltipSpec].
+class TooltipSpecUtility<T extends SpecAttribute>
+    extends SpecUtility<T, TooltipSpecAttribute> {
+  /// Utility for defining [TooltipSpecAttribute.container]
+  late final container = BoxSpecUtility((v) => only(container: v));
+
+  /// Utility for defining [TooltipSpecAttribute.modifiers]
+  late final wrap = SpecModifierUtility((v) => only(modifiers: v));
+
+  /// Utility for defining [TooltipSpecAttribute.animated]
+  late final animated = AnimatedUtility((v) => only(animated: v));
+
+  TooltipSpecUtility(
+    super.builder, {
+    @Deprecated(
+      'mutable parameter is no longer used. All SpecUtilities are now mutable by default.',
+    )
+    super.mutable,
+  });
+
+  @Deprecated(
+    'Use "this" instead of "chain" for method chaining. '
+    'The chain getter will be removed in a future version.',
+  )
+  TooltipSpecUtility<T> get chain => TooltipSpecUtility(attributeBuilder);
+
+  static TooltipSpecUtility<TooltipSpecAttribute> get self =>
+      TooltipSpecUtility((v) => v);
+
+  /// Returns a new [TooltipSpecAttribute] with the specified properties.
+  @override
+  T only({
+    BoxSpecAttribute? container,
+    WidgetModifiersConfigDto? modifiers,
+    AnimatedDataDto? animated,
+  }) {
+    return builder(TooltipSpecAttribute(
+      container: container,
+      modifiers: modifiers,
+      animated: animated,
+    ));
+  }
+}
+
+/// A tween that interpolates between two [TooltipSpec] instances.
+///
+/// This class can be used in animations to smoothly transition between
+/// different [TooltipSpec] specifications.
+class TooltipSpecTween extends Tween<TooltipSpec?> {
+  TooltipSpecTween({
+    super.begin,
+    super.end,
+  });
+
+  @override
+  TooltipSpec lerp(double t) {
+    if (begin == null && end == null) {
+      return const TooltipSpec();
+    }
+
+    if (begin == null) {
+      return end!;
+    }
+
+    return begin!.lerp(end!, t);
+  }
+}

--- a/packages/remix/lib/src/components/overlay/tooltip_style.dart
+++ b/packages/remix/lib/src/components/overlay/tooltip_style.dart
@@ -1,0 +1,19 @@
+part of 'tooltip.dart';
+
+class RxTooltipStyle extends TooltipSpecUtility<TooltipSpecAttribute> {
+  RxTooltipStyle() : super((v) => v);
+
+  factory RxTooltipStyle._default() {
+    return RxTooltipStyle()
+      ..container.color.black.withOpacity(0.8)
+      ..container.padding(10)
+      ..container.borderRadius(8)
+      ..animated.duration(100.ms)
+      ..on.hover(RxTooltipStyle()..container.color.red());
+  }
+
+  @override
+  RxTooltipStyle merge(RxTooltipStyle other) {
+    return super.merge(other) as RxTooltipStyle;
+  }
+}

--- a/packages/remix/lib/src/components/overlay/tooltip_widget.dart
+++ b/packages/remix/lib/src/components/overlay/tooltip_widget.dart
@@ -1,0 +1,120 @@
+part of 'tooltip.dart';
+
+/// A customizable tooltip component that wraps NakedTooltip.
+/// The tooltip integrates with the Mix styling system and follows Remix design patterns.
+///
+/// ## Example
+///
+/// ```dart
+/// RxTooltip(
+///   tooltipChild: Text(
+///     'This is a tooltip',
+///     style: TextStyle(color: Colors.white),
+///   ),
+///   child: Text('Hello'),
+/// )
+/// ```
+///
+class RxTooltip extends StatefulWidget {
+  /// Creates a Remix tooltip.
+  ///
+  /// The [tooltipChild] and [child] parameters are required.
+  /// The [tooltipChild] parameter should be the widget to display in the tooltip.
+  const RxTooltip({
+    super.key,
+    required this.tooltipChild,
+    required this.child,
+    this.showDuration = const Duration(seconds: 1),
+    this.waitDuration = Duration.zero,
+    this.tooltipSemantics,
+    this.style,
+    this.variants = const [],
+  });
+
+  /// The widget to display in the tooltip.
+  ///
+  /// This widget will be shown as the tooltip content when the child is hovered
+  final Widget tooltipChild;
+
+  /// The child widget that will trigger the tooltip when hovered or long-pressed.
+  final Widget child;
+
+  /// The duration for which the tooltip is shown.
+  final Duration showDuration;
+
+  /// The duration to wait before showing the tooltip.
+  final Duration waitDuration;
+
+  /// The semantic label for the tooltip.
+  final String? tooltipSemantics;
+
+  /// The style for the tooltip.
+  final RxTooltipStyle? style;
+
+  /// The variants for the tooltip.
+  final List<Variant> variants;
+
+  @override
+  State<RxTooltip> createState() => _RxTooltipState();
+}
+
+class _RxTooltipState extends State<RxTooltip> with TickerProviderStateMixin {
+  late AnimationController _animationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(vsync: this);
+  }
+
+  RxTooltipStyle get _style =>
+      RxTooltipStyle._default().merge(widget.style ?? RxTooltipStyle());
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Style(_style).applyVariants(widget.variants);
+
+    return MixBuilder(
+      style: style,
+      builder: (context) {
+        final spec = TooltipSpec.of(context);
+
+        final animationDuration = spec.animated?.duration ?? Duration.zero;
+
+        return NakedTooltip(
+          tooltipBuilder: (context) => SpecBuilder(
+            style: style,
+            builder: (context) {
+              final spec = TooltipSpec.of(context);
+
+              return FadeTransition(
+                opacity: _animationController.view,
+                child: spec.container(child: widget.tooltipChild),
+              );
+            },
+          ),
+          showDuration: widget.showDuration,
+          waitDuration: widget.waitDuration,
+          tooltipSemantics: widget.tooltipSemantics,
+          removalDelay: animationDuration,
+          onStateChange: (state) {
+            _animationController.duration = animationDuration;
+
+            if (state == OverlayChildLifecycleState.present) {
+              _animationController.forward();
+            } else {
+              _animationController.reverse();
+            }
+          },
+          child: widget.child,
+        );
+      },
+    );
+  }
+}

--- a/packages/remix/test/components/tooltip_test.dart
+++ b/packages/remix/test/components/tooltip_test.dart
@@ -1,0 +1,88 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+import 'package:remix/remix.dart';
+
+import '../utils/interaction_tests.dart';
+
+extension _WidgetTesterX on WidgetTester {
+  Future<TestGesture> simulateHoverOnTooltip(Key key,
+      {required VoidCallback? onHover}) async {
+    final gesture = await createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await pumpAndSettle();
+
+    await gesture.moveTo(getCenter(find.byKey(key)));
+    await pumpAndSettle();
+
+    onHover?.call();
+
+    await gesture.moveTo(Offset.zero);
+    await pumpAndSettle();
+
+    return gesture;
+  }
+}
+
+void main() {
+  group('RxTooltip', () {
+    const tooltipText = 'This is a tooltip';
+    const childText = 'Hover over me';
+    const tooltipChild = Text(tooltipText);
+    const child = Text(childText);
+    const showDuration = Duration(seconds: 1);
+    const waitDuration = Duration(seconds: 0);
+    const variants = [Variant('primary')];
+    final style = RxTooltipStyle();
+
+    testWidgets('should initialize with correct properties', (tester) async {
+      final tooltip = RxTooltip(
+        tooltipChild: tooltipChild,
+        showDuration: showDuration,
+        waitDuration: waitDuration,
+        style: style,
+        variants: variants,
+        child: child,
+      );
+
+      await tester.pumpRxWidget(tooltip);
+
+      expect(tooltip.tooltipChild, tooltipChild);
+      expect(tooltip.child, child);
+      expect(tooltip.showDuration, showDuration);
+      expect(tooltip.waitDuration, waitDuration);
+      expect(tooltip.style, style);
+      expect(tooltip.variants, variants);
+    });
+
+    testWidgets('should display tooltip on hover', (tester) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+
+      final tooltipKey = UniqueKey();
+      final childKey = UniqueKey();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RxTooltip(
+              tooltipChild: Text(tooltipText, key: tooltipKey),
+              child: Text(childText, key: childKey),
+            ),
+          ),
+        ),
+      );
+
+      final childFinder = find.text(childText);
+      expect(childFinder, findsOneWidget);
+
+      await tester.simulateHoverOnTooltip(childKey, onHover: () {
+        final tooltipFinder = find.text(tooltipText);
+        expect(tooltipFinder, findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Introduces a new RxTooltip component to the overlay package, including its implementation, default styling, and integration with the Mix system. Updates exports in remix.dart, provides a demo usage, and adds comprehensive widget tests for tooltip behavior and properties.

#### Related issue

Is it related to any opened issue?

### Description

Please summarize the changes.

### Changes

List specific changes made in this PR.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
