### PR TITLE
refactor: rename SpecUtility classes to MutableStyler for consistency

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -113,34 +113,34 @@ export 'src/specs/box/box_spec.dart';
 
 /// SPECS
 export 'src/specs/box/box_style.dart';
-export 'src/specs/box/box_util.dart';
+export 'src/specs/box/box_mutable_style.dart';
 export 'src/specs/box/box_widget.dart';
 export 'src/specs/flex/flex_spec.dart';
 export 'src/specs/flex/flex_style.dart';
-export 'src/specs/flex/flex_util.dart';
+export 'src/specs/flex/flex_mutable_style.dart';
 export 'src/specs/flexbox/flexbox_spec.dart';
 export 'src/specs/flexbox/flexbox_style.dart';
-export 'src/specs/flexbox/flexbox_util.dart';
+export 'src/specs/flexbox/flexbox_mutable_style.dart';
 export 'src/specs/flexbox/flexbox_widget.dart';
 export 'src/specs/icon/icon_spec.dart';
 export 'src/specs/icon/icon_style.dart';
-export 'src/specs/icon/icon_util.dart';
+export 'src/specs/icon/icon_mutable_style.dart';
 export 'src/specs/icon/icon_widget.dart';
 export 'src/specs/image/image_spec.dart';
 export 'src/specs/image/image_style.dart' hide ImageMix;
-export 'src/specs/image/image_util.dart';
+export 'src/specs/image/image_mutable_style.dart';
 export 'src/specs/image/image_widget.dart';
 export 'src/specs/pressable/pressable_widget.dart';
-export 'src/specs/spec_util.dart';
+export 'src/specs/mutable_stylers.dart';
 export 'src/specs/stack/stack_box_spec.dart';
 export 'src/specs/stack/stack_box_style.dart';
 export 'src/specs/stack/stack_spec.dart';
 export 'src/specs/stack/stack_style.dart' hide StackMix;
-export 'src/specs/stack/stack_util.dart';
+export 'src/specs/stack/stack_mutable_style.dart';
 export 'src/specs/stack/stack_widget.dart';
 export 'src/specs/text/text_spec.dart';
 export 'src/specs/text/text_style.dart';
-export 'src/specs/text/text_util.dart';
+export 'src/specs/text/text_mutable_style.dart';
 export 'src/specs/text/text_widget.dart';
 
 /// STYLE MIXINS

--- a/packages/mix/lib/src/specs/box/box_mutable_style.dart
+++ b/packages/mix/lib/src/specs/box/box_mutable_style.dart
@@ -21,7 +21,7 @@ import 'box_style.dart';
 ///
 /// Supports the same API as [BoxStyler] but maintains mutable internal state
 /// enabling fluid styling: `$box..color.red()..width(100)`.
-class BoxSpecUtility extends StyleMutableBuilder<BoxSpec>
+class BoxMutableStyler extends StyleMutableBuilder<BoxSpec>
     with UtilityVariantMixin<BoxSpec, BoxStyler> {
   late final padding = EdgeInsetsGeometryUtility<BoxStyler>(
     (prop) => mutable.merge(BoxStyler.create(padding: Prop.mix(prop))),
@@ -75,10 +75,10 @@ class BoxSpecUtility extends StyleMutableBuilder<BoxSpec>
   /// Internal mutable state for accumulating box styling properties.
   @override
   @protected
-  late final MutableBoxStyle mutable;
+  late final BoxMutableState mutable;
 
-  BoxSpecUtility([BoxStyler? attribute]) {
-    mutable = MutableBoxStyle(attribute ?? BoxStyler());
+  BoxMutableStyler([BoxStyler? attribute]) {
+    mutable = BoxMutableState(attribute ?? BoxStyler());
   }
 
   /// Applies animation configuration to the box styling.
@@ -95,14 +95,14 @@ class BoxSpecUtility extends StyleMutableBuilder<BoxSpec>
   }
 
   @override
-  BoxSpecUtility merge(Style<BoxSpec>? other) {
+  BoxMutableStyler merge(Style<BoxSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is BoxSpecUtility) {
-      return BoxSpecUtility(mutable.merge(other.mutable.value));
+    if (other is BoxMutableStyler) {
+      return BoxMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is BoxStyler) {
-      return BoxSpecUtility(mutable.merge(other));
+      return BoxMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -123,10 +123,10 @@ class BoxSpecUtility extends StyleMutableBuilder<BoxSpec>
 
 /// Mutable implementation of [BoxStyler] for efficient style accumulation.
 ///
-/// Used internally by [BoxSpecUtility] to accumulate styling changes
+/// Used internally by [BoxMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
-class MutableBoxStyle extends BoxStyler with Mutable<BoxSpec, BoxStyler> {
-  MutableBoxStyle(BoxStyler style) {
+class BoxMutableState extends BoxStyler with Mutable<BoxSpec, BoxStyler> {
+  BoxMutableState(BoxStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -23,7 +23,7 @@ import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'box_spec.dart';
-import 'box_util.dart';
+import 'box_mutable_style.dart';
 import 'box_widget.dart';
 
 typedef BoxMix = BoxStyler;
@@ -111,7 +111,7 @@ class BoxStyler extends Style<BoxSpec>
     return BoxStyler().builder(fn);
   }
 
-  static BoxSpecUtility get chain => BoxSpecUtility(BoxStyler());
+  static BoxMutableStyler get chain => BoxMutableStyler(BoxStyler());
 
   BoxStyler clipBehavior(Clip value) {
     return merge(BoxStyler(clipBehavior: value));

--- a/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
@@ -17,7 +17,7 @@ import 'flex_style.dart';
 ///
 /// Supports the same API as [FlexStyler] but maintains mutable internal state
 /// enabling fluid styling: `$flex..direction(Axis.horizontal)..spacing(8)`.
-class FlexSpecUtility extends StyleMutableBuilder<FlexSpec>
+class FlexMutableStyler extends StyleMutableBuilder<FlexSpec>
     with UtilityVariantMixin<FlexSpec, FlexStyler> {
   late final direction = MixUtility(mutable.direction);
 
@@ -50,10 +50,10 @@ class FlexSpecUtility extends StyleMutableBuilder<FlexSpec>
   /// Internal mutable state for accumulating flex styling properties.
   @override
   @protected
-  late final MutableFlexStyle mutable;
+  late final FlexMutableState mutable;
 
-  FlexSpecUtility([FlexStyler? attribute]) {
-    mutable = MutableFlexStyle(attribute ?? FlexStyler());
+  FlexMutableStyler([FlexStyler? attribute]) {
+    mutable = FlexMutableState(attribute ?? FlexStyler());
   }
 
   /// Sets the spacing between children in the flex layout.
@@ -86,14 +86,14 @@ class FlexSpecUtility extends StyleMutableBuilder<FlexSpec>
   }
 
   @override
-  FlexSpecUtility merge(Style<FlexSpec>? other) {
+  FlexMutableStyler merge(Style<FlexSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is FlexSpecUtility) {
-      return FlexSpecUtility(mutable.merge(other.mutable.value));
+    if (other is FlexMutableStyler) {
+      return FlexMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is FlexStyler) {
-      return FlexSpecUtility(mutable.merge(other));
+      return FlexMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -114,10 +114,10 @@ class FlexSpecUtility extends StyleMutableBuilder<FlexSpec>
 
 /// Mutable implementation of [FlexStyler] for efficient style accumulation.
 ///
-/// Used internally by [FlexSpecUtility] to accumulate styling changes
+/// Used internally by [FlexMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
-class MutableFlexStyle extends FlexStyler with Mutable<FlexSpec, FlexStyler> {
-  MutableFlexStyle(FlexStyler style) {
+class FlexMutableState extends FlexStyler with Mutable<FlexSpec, FlexStyler> {
+  FlexMutableState(FlexStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/flex/flex_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.dart
@@ -13,7 +13,7 @@ import '../../style/mixins/flex_style_mixin.dart';
 import '../../style/mixins/modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'flex_spec.dart';
-import 'flex_util.dart';
+import 'flex_mutable_style.dart';
 
 typedef FlexMix = FlexStyler;
 
@@ -107,7 +107,7 @@ class FlexStyler extends Style<FlexSpec>
     return FlexStyler().builder(fn);
   }
 
-  static FlexSpecUtility get chain => FlexSpecUtility(FlexStyler());
+  static FlexMutableStyler get chain => FlexMutableStyler(FlexStyler());
 
   /// The gap between children.
   @Deprecated(

--- a/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
@@ -21,7 +21,7 @@ import 'flexbox_style.dart';
 ///
 /// Combines box and flex styling capabilities. Supports the same API as [FlexBoxStyler]
 /// but maintains mutable internal state enabling fluid styling: `$flexbox..color.red()..width(100)`.
-class FlexBoxSpecUtility extends StyleMutableBuilder<FlexBoxSpec>
+class FlexBoxMutableStyler extends StyleMutableBuilder<FlexBoxSpec>
     with UtilityVariantMixin<FlexBoxSpec, FlexBoxStyler> {
   late final padding = EdgeInsetsGeometryUtility<FlexBoxStyler>(
     (prop) => mutable.merge(FlexBoxStyler(padding: prop)),
@@ -117,10 +117,10 @@ class FlexBoxSpecUtility extends StyleMutableBuilder<FlexBoxSpec>
   /// Internal mutable state for accumulating flexbox styling properties.
   @override
   @protected
-  late final MutableFlexBoxStyle mutable;
+  late final FlexBoxMutableState mutable;
 
-  FlexBoxSpecUtility([FlexBoxStyler? attribute]) {
-    mutable = MutableFlexBoxStyle(attribute ?? const FlexBoxStyler.create());
+  FlexBoxMutableStyler([FlexBoxStyler? attribute]) {
+    mutable = FlexBoxMutableState(attribute ?? const FlexBoxStyler.create());
   }
 
   /// Sets the spacing between children in the flex layout.
@@ -149,14 +149,14 @@ class FlexBoxSpecUtility extends StyleMutableBuilder<FlexBoxSpec>
   }
 
   @override
-  FlexBoxSpecUtility merge(Style<FlexBoxSpec>? other) {
+  FlexBoxMutableStyler merge(Style<FlexBoxSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is FlexBoxSpecUtility) {
-      return FlexBoxSpecUtility(mutable.merge(other.mutable.value));
+    if (other is FlexBoxMutableStyler) {
+      return FlexBoxMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is FlexBoxStyler) {
-      return FlexBoxSpecUtility(mutable.merge(other));
+      return FlexBoxMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -177,11 +177,11 @@ class FlexBoxSpecUtility extends StyleMutableBuilder<FlexBoxSpec>
 
 /// Mutable implementation of [FlexBoxStyler] for efficient style accumulation.
 ///
-/// Used internally by [FlexBoxSpecUtility] to accumulate styling changes
+/// Used internally by [FlexBoxMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
-class MutableFlexBoxStyle extends FlexBoxStyler
+class FlexBoxMutableState extends FlexBoxStyler
     with Mutable<FlexBoxSpec, FlexBoxStyler> {
-  MutableFlexBoxStyle(FlexBoxStyler style) {
+  FlexBoxMutableState(FlexBoxStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -27,7 +27,7 @@ import '../box/box_style.dart';
 import '../flex/flex_spec.dart';
 import '../flex/flex_style.dart';
 import 'flexbox_spec.dart';
-import 'flexbox_util.dart';
+import 'flexbox_mutable_style.dart';
 
 typedef FlexBoxMix = FlexBoxStyler;
 
@@ -126,7 +126,7 @@ class FlexBoxStyler extends Style<FlexBoxSpec>
     return FlexBoxStyler().builder(fn);
   }
 
-  static FlexBoxSpecUtility get chain => FlexBoxSpecUtility(FlexBoxStyler());
+  static FlexBoxMutableStyler get chain => FlexBoxMutableStyler(FlexBoxStyler());
 
   /// Sets animation
   FlexBoxStyler animate(AnimationConfig animation) {

--- a/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
@@ -20,7 +20,7 @@ import 'icon_style.dart';
 ///
 /// Supports the same API as [IconStyler] but maintains mutable internal state
 /// enabling fluid styling: `$icon..color(Colors.blue)..size(24)..weight(400)`.
-class IconSpecUtility extends StyleMutableBuilder<IconSpec>
+class IconMutableStyler extends StyleMutableBuilder<IconSpec>
     with UtilityVariantMixin<IconSpec, IconStyler> {
   late final color = ColorUtility<IconStyler>(
     (prop) => mutable.merge(IconStyler.create(color: prop)),
@@ -45,10 +45,10 @@ class IconSpecUtility extends StyleMutableBuilder<IconSpec>
   /// Internal mutable state for accumulating icon styling properties.
   @override
   @protected
-  late final MutableIconStyle mutable;
+  late final IconMutableState mutable;
 
-  IconSpecUtility([IconStyler? attribute]) {
-    mutable = MutableIconStyle(attribute ?? IconStyler());
+  IconMutableStyler([IconStyler? attribute]) {
+    mutable = IconMutableState(attribute ?? IconStyler());
   }
 
   IconStyler size(double v) => mutable.size(v);
@@ -80,14 +80,14 @@ class IconSpecUtility extends StyleMutableBuilder<IconSpec>
   }
 
   @override
-  IconSpecUtility merge(Style<IconSpec>? other) {
+  IconMutableStyler merge(Style<IconSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is IconSpecUtility) {
-      return IconSpecUtility(mutable.merge(other.mutable.value));
+    if (other is IconMutableStyler) {
+      return IconMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is IconStyler) {
-      return IconSpecUtility(mutable.merge(other));
+      return IconMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -106,8 +106,8 @@ class IconSpecUtility extends StyleMutableBuilder<IconSpec>
   IconStyler get value => mutable.value;
 }
 
-class MutableIconStyle extends IconStyler with Mutable<IconSpec, IconStyler> {
-  MutableIconStyle(IconStyler style) {
+class IconMutableState extends IconStyler with Mutable<IconSpec, IconStyler> {
+  IconMutableState(IconStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/icon/icon_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.dart
@@ -12,7 +12,7 @@ import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'icon_spec.dart';
-import 'icon_util.dart';
+import 'icon_mutable_style.dart';
 import 'icon_widget.dart';
 
 typedef IconMix = IconStyler;
@@ -108,7 +108,7 @@ class IconStyler extends Style<IconSpec>
     return IconStyler().builder(fn);
   }
 
-  static IconSpecUtility get chain => IconSpecUtility(IconStyler());
+  static IconMutableStyler get chain => IconMutableStyler(IconStyler());
 
   /// Sets icon color
   IconStyler color(Color value) {

--- a/packages/mix/lib/src/specs/image/image_mutable_style.dart
+++ b/packages/mix/lib/src/specs/image/image_mutable_style.dart
@@ -18,7 +18,7 @@ import 'image_style.dart';
 ///
 /// Supports the same API as [ImageStyler] but maintains mutable internal state
 /// enabling fluid styling: `$image..width(100)..height(100)..fit(BoxFit.cover)`.
-class ImageSpecUtility extends StyleMutableBuilder<ImageSpec>
+class ImageMutableStyler extends StyleMutableBuilder<ImageSpec>
     with UtilityVariantMixin<ImageSpec, ImageStyler> {
   late final color = ColorUtility(
     (prop) => mutable.merge(ImageStyler.create(color: prop)),
@@ -51,7 +51,7 @@ class ImageSpecUtility extends StyleMutableBuilder<ImageSpec>
   /// Internal mutable state for accumulating image styling properties.
   @override
   @protected
-  late final MutableImageStyle mutable;
+  late final ImageMutableState mutable;
 
   late final image = mutable.image;
 
@@ -68,8 +68,8 @@ class ImageSpecUtility extends StyleMutableBuilder<ImageSpec>
   late final matchTextDirection = mutable.matchTextDirection;
   late final animate = mutable.animate;
   late final variants = mutable.variants;
-  ImageSpecUtility([ImageStyler? attribute]) {
-    mutable = MutableImageStyle(attribute ?? ImageStyler());
+  ImageMutableStyler([ImageStyler? attribute]) {
+    mutable = ImageMutableState(attribute ?? ImageStyler());
   }
 
   @override
@@ -83,14 +83,14 @@ class ImageSpecUtility extends StyleMutableBuilder<ImageSpec>
   }
 
   @override
-  ImageSpecUtility merge(Style<ImageSpec>? other) {
+  ImageMutableStyler merge(Style<ImageSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is ImageSpecUtility) {
-      return ImageSpecUtility(mutable.merge(other.mutable.value));
+    if (other is ImageMutableStyler) {
+      return ImageMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is ImageStyler) {
-      return ImageSpecUtility(mutable.merge(other));
+      return ImageMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -109,9 +109,9 @@ class ImageSpecUtility extends StyleMutableBuilder<ImageSpec>
   ImageStyler get value => mutable.value;
 }
 
-class MutableImageStyle extends ImageStyler
+class ImageMutableState extends ImageStyler
     with Mutable<ImageSpec, ImageStyler> {
-  MutableImageStyle(ImageStyler style) {
+  ImageMutableState(ImageStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/image/image_style.dart
+++ b/packages/mix/lib/src/specs/image/image_style.dart
@@ -10,7 +10,7 @@ import '../../modifiers/modifier_config.dart';
 import '../../modifiers/modifier_util.dart';
 import '../../variants/variant_util.dart';
 import 'image_spec.dart';
-import 'image_util.dart';
+import 'image_mutable_style.dart';
 import 'image_widget.dart';
 
 typedef ImageMix = ImageStyler;
@@ -115,7 +115,7 @@ class ImageStyler extends Style<ImageSpec>
     return ImageStyler().builder(fn);
   }
 
-  static ImageSpecUtility get chain => ImageSpecUtility(ImageStyler());
+  static ImageMutableStyler get chain => ImageMutableStyler(ImageStyler());
 
   /// Sets image provider
   ImageStyler image(ImageProvider<Object> value) {

--- a/packages/mix/lib/src/specs/mutable_stylers.dart
+++ b/packages/mix/lib/src/specs/mutable_stylers.dart
@@ -7,34 +7,34 @@ library;
 // Global utilities for $on and $wrap functionality are now available via spec-specific utilities:
 // - $box.on.hover(), $box.wrap.opacity(), etc.
 // - $text.on.dark(), $text.wrap.padding(), etc.
-import 'box/box_util.dart';
-import 'flex/flex_util.dart';
-import 'flexbox/flexbox_util.dart';
-import 'icon/icon_util.dart';
-import 'image/image_util.dart';
-import 'stack/stack_util.dart';
-import 'text/text_util.dart';
+import 'box/box_mutable_style.dart';
+import 'flex/flex_mutable_style.dart';
+import 'flexbox/flexbox_mutable_style.dart';
+import 'icon/icon_mutable_style.dart';
+import 'image/image_mutable_style.dart';
+import 'stack/stack_mutable_style.dart';
+import 'text/text_mutable_style.dart';
 
 /// Global accessor for box specification utilities.
-BoxSpecUtility get $box => BoxSpecUtility();
+BoxMutableStyler get $box => BoxMutableStyler();
 
 /// Global accessor for flex specification utilities.
-FlexSpecUtility get $flex => FlexSpecUtility();
+FlexMutableStyler get $flex => FlexMutableStyler();
 
 /// Global accessor for flexbox specification utilities.
-FlexBoxSpecUtility get $flexbox => FlexBoxSpecUtility();
+FlexBoxMutableStyler get $flexbox => FlexBoxMutableStyler();
 
 /// Global accessor for image specification utilities.
-ImageSpecUtility get $image => ImageSpecUtility();
+ImageMutableStyler get $image => ImageMutableStyler();
 
 /// Global accessor for icon specification utilities.
-IconSpecUtility get $icon => IconSpecUtility();
+IconMutableStyler get $icon => IconMutableStyler();
 
 /// Global accessor for text specification utilities.
-TextSpecUtility get $text => TextSpecUtility();
+TextMutableStyler get $text => TextMutableStyler();
 
 /// Global accessor for stack specification utilities.
-StackSpecUtility get $stack => StackSpecUtility();
+StackMutableStyler get $stack => StackMutableStyler();
 
 // Global $on and $wrap utilities have been replaced by spec-specific utilities:
 //

--- a/packages/mix/lib/src/specs/stack/stack_box_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_box_style.dart
@@ -99,7 +99,7 @@ class StackBoxStyler extends Style<ZBoxSpec>
     return StackBoxStyler().builder(fn);
   }
 
-  static StackBoxSpecUtility get chain => StackBoxSpecUtility.self;
+  static StackBoxMutableStyler get chain => StackBoxMutableStyler.self;
 
   /// Sets animation
   StackBoxStyler animate(AnimationConfig animation) {
@@ -265,16 +265,16 @@ class StackBoxStyler extends Style<ZBoxSpec>
 ///
 /// This class provides methods to set individual properties of a [ZBoxSpec].
 /// Use the methods of this class to configure specific properties of a [ZBoxSpec].
-class StackBoxSpecUtility {
+class StackBoxMutableStyler {
   /// Utility for defining [StackBoxStyler] box properties
   final box = BoxStyler();
 
   /// Utility for defining [StackBoxStyler.stack]
   final stack = StackStyler();
 
-  StackBoxSpecUtility();
+  StackBoxMutableStyler();
 
-  static StackBoxSpecUtility get self => StackBoxSpecUtility();
+  static StackBoxMutableStyler get self => StackBoxMutableStyler();
 
   /// Returns a new [StackBoxStyler] with the specified properties.
   StackBoxStyler only({

--- a/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
@@ -18,7 +18,7 @@ import 'stack_style.dart';
 ///
 /// Supports the same API as [StackStyler] but maintains mutable internal state
 /// enabling fluid styling: `$stack..alignment(Alignment.center)..fit(StackFit.expand)`.
-class StackSpecUtility extends StyleMutableBuilder<StackSpec>
+class StackMutableStyler extends StyleMutableBuilder<StackSpec>
     with UtilityVariantMixin<StackSpec, StackStyler> {
   late final alignment = MixUtility(mutable.alignment);
 
@@ -43,10 +43,10 @@ class StackSpecUtility extends StyleMutableBuilder<StackSpec>
   /// Internal mutable state for accumulating stack styling properties.
   @override
   @protected
-  late final MutableStackStyle mutable;
+  late final StackMutableState mutable;
 
-  StackSpecUtility([StackStyler? attribute]) {
-    mutable = MutableStackStyle(attribute ?? StackStyler());
+  StackMutableStyler([StackStyler? attribute]) {
+    mutable = StackMutableState(attribute ?? StackStyler());
   }
 
   /// Applies animation configuration to the stack styling.
@@ -63,14 +63,14 @@ class StackSpecUtility extends StyleMutableBuilder<StackSpec>
   }
 
   @override
-  StackSpecUtility merge(Style<StackSpec>? other) {
+  StackMutableStyler merge(Style<StackSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is StackSpecUtility) {
-      return StackSpecUtility(mutable.merge(other.mutable.value));
+    if (other is StackMutableStyler) {
+      return StackMutableStyler(mutable.merge(other.mutable.value));
     }
     if (other is StackStyler) {
-      return StackSpecUtility(mutable.merge(other));
+      return StackMutableStyler(mutable.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -89,9 +89,9 @@ class StackSpecUtility extends StyleMutableBuilder<StackSpec>
   StackStyler get value => mutable.value;
 }
 
-class MutableStackStyle extends StackStyler
+class StackMutableState extends StackStyler
     with Mutable<StackSpec, StackStyler> {
-  MutableStackStyle(StackStyler style) {
+  StackMutableState(StackStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/stack/stack_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.dart
@@ -11,7 +11,7 @@ import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'stack_spec.dart';
-import 'stack_util.dart';
+import 'stack_mutable_style.dart';
 
 typedef StackMix = StackStyler;
 
@@ -68,7 +68,7 @@ class StackStyler extends Style<StackSpec>
     return StackStyler().builder(fn);
   }
 
-  static StackSpecUtility get chain => StackSpecUtility(StackStyler());
+  static StackMutableStyler get chain => StackMutableStyler(StackStyler());
 
   /// Sets stack alignment
   StackStyler alignment(AlignmentGeometry value) {

--- a/packages/mix/lib/src/specs/text/text_mutable_style.dart
+++ b/packages/mix/lib/src/specs/text/text_mutable_style.dart
@@ -19,9 +19,9 @@ import 'text_style.dart';
 
 /// Provides mutable utility for text styling with cascade notation support.
 ///
-/// Supports the same API as [TextStyle] but maintains mutable internal state
+/// Supports the same API as [TextStyler] but maintains mutable internal state
 /// enabling fluid styling: `$text..color.red()..fontSize(16)`.
-class TextSpecUtility extends StyleMutableBuilder<TextSpec>
+class TextMutableStyler extends StyleMutableBuilder<TextSpec>
     with UtilityVariantMixin<TextSpec, TextStyler> {
   late final textOverflow = MixUtility(mutable.overflow);
 
@@ -81,9 +81,9 @@ class TextSpecUtility extends StyleMutableBuilder<TextSpec>
   /// Internal mutable state for accumulating text styling properties.
   @override
   @protected
-  late final MutableTextMix mutable;
-  TextSpecUtility([TextStyler? attribute]) {
-    mutable = MutableTextMix(attribute ?? TextStyler());
+  late final TextMutableState mutable;
+  TextMutableStyler([TextStyler? attribute]) {
+    mutable = TextMutableState(attribute ?? TextStyler());
   }
 
   TextStyler maxLines(int v) => mutable.maxLines(v);
@@ -112,14 +112,14 @@ class TextSpecUtility extends StyleMutableBuilder<TextSpec>
   }
 
   @override
-  TextSpecUtility merge(Style<TextSpec>? other) {
+  TextMutableStyler merge(Style<TextSpec>? other) {
     if (other == null) return this;
     // Always create new instance (StyleAttribute contract)
-    if (other is TextSpecUtility) {
-      return TextSpecUtility(mutable.value.merge(other.mutable.value));
+    if (other is TextMutableStyler) {
+      return TextMutableStyler(mutable.value.merge(other.mutable.value));
     }
     if (other is TextStyler) {
-      return TextSpecUtility(mutable.value.merge(other));
+      return TextMutableStyler(mutable.value.merge(other));
     }
 
     throw FlutterError('Unsupported merge type: ${other.runtimeType}');
@@ -133,13 +133,13 @@ class TextSpecUtility extends StyleMutableBuilder<TextSpec>
   @override
   TextStyler get currentValue => mutable.value;
 
-  /// The accumulated [TextStyle] with all applied styling properties.
+  /// The accumulated [TextStyler] with all applied styling properties.
   @override
   TextStyler get value => mutable.value;
 }
 
-class MutableTextMix extends TextStyler with Mutable<TextSpec, TextStyler> {
-  MutableTextMix(TextStyler style) {
+class TextMutableState extends TextStyler with Mutable<TextSpec, TextStyler> {
+  TextMutableState(TextStyler style) {
     value = style;
   }
 }

--- a/packages/mix/lib/src/specs/text/text_style.dart
+++ b/packages/mix/lib/src/specs/text/text_style.dart
@@ -16,7 +16,7 @@ import '../../style/mixins/modifier_style_mixin.dart';
 import '../../style/mixins/text_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'text_spec.dart';
-import 'text_util.dart';
+import 'text_mutable_style.dart';
 import 'text_widget.dart';
 
 typedef TextMix = TextStyler;
@@ -125,7 +125,7 @@ class TextStyler extends Style<TextSpec>
     return TextStyler().builder(fn);
   }
 
-  static TextSpecUtility get chain => TextSpecUtility(TextStyler());
+  static TextMutableStyler get chain => TextMutableStyler(TextStyler());
 
   StyledText call(String text) {
     return StyledText(text, style: this);

--- a/packages/mix/test/src/specs/box/box_util_test.dart
+++ b/packages/mix/test/src/specs/box/box_util_test.dart
@@ -5,21 +5,21 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('BoxSpecUtility', () {
-    late BoxSpecUtility util;
+  group('BoxMutableStyler', () {
+    late BoxMutableStyler util;
 
     setUp(() {
-      util = BoxSpecUtility();
+      util = BoxMutableStyler();
     });
 
     group('Constructor', () {
       test('creates with provided BoxMix attribute', () {
         final boxMix = BoxStyler(alignment: Alignment.center);
-        final utility = BoxSpecUtility(boxMix);
+        final utility = BoxMutableStyler(boxMix);
         final context = MockBuildContext();
         final spec = utility.resolve(context);
 
-        expect(utility, isA<BoxSpecUtility>());
+        expect(utility, isA<BoxMutableStyler>());
         expect(
           spec,
           StyleSpec(spec: const BoxSpec(alignment: Alignment.center)),
@@ -178,14 +178,14 @@ void main() {
         expect(result, same(util));
       });
 
-      test('merge with BoxSpecUtility creates new instance', () {
-        final other = BoxSpecUtility(BoxStyler(alignment: Alignment.center));
+      test('merge with BoxMutableStyler creates new instance', () {
+        final other = BoxMutableStyler(BoxStyler(alignment: Alignment.center));
         final result = util.merge(other);
         final context = MockBuildContext();
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<BoxSpecUtility>());
+        expect(result, isA<BoxMutableStyler>());
         expect(spec.spec.alignment, Alignment.center);
       });
 
@@ -196,7 +196,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<BoxSpecUtility>());
+        expect(result, isA<BoxMutableStyler>());
         expect(spec.spec.alignment, Alignment.topRight);
       });
 
@@ -208,8 +208,8 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = BoxSpecUtility(BoxStyler(alignment: Alignment.center));
-        final other = BoxSpecUtility(BoxStyler(clipBehavior: Clip.antiAlias));
+        final util1 = BoxMutableStyler(BoxStyler(alignment: Alignment.center));
+        final other = BoxMutableStyler(BoxStyler(clipBehavior: Clip.antiAlias));
 
         final result = util1.merge(other);
         final context = MockBuildContext();
@@ -222,7 +222,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('resolve returns BoxSpec with resolved properties', () {
-        final testUtil = BoxSpecUtility(
+        final testUtil = BoxMutableStyler(
           BoxStyler(
             alignment: Alignment.center,
             clipBehavior: Clip.antiAlias,
@@ -252,7 +252,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic alignment mutation test', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
 
         final result = util.alignment(Alignment.center);
         expect(result, isA<BoxStyler>());
@@ -264,7 +264,7 @@ void main() {
       });
 
       test('basic transform mutation test', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
         final matrix = Matrix4.identity();
 
         final result = util.transform(matrix);
@@ -277,7 +277,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
         final matrix = Matrix4.identity();
 
         // Chain multiple method calls - these mutate internal state
@@ -296,7 +296,7 @@ void main() {
 
       test('cascade notation works with utility methods', () {
         final matrix = Matrix4.identity();
-        final util = BoxSpecUtility()
+        final util = BoxMutableStyler()
           ..alignment(Alignment.center)
           ..transform(matrix)
           ..clipBehavior(Clip.antiAlias);
@@ -310,7 +310,7 @@ void main() {
       });
 
       test('individual utility calls return BoxMix for further chaining', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
         final matrix = Matrix4.identity();
 
         // Each utility call should return a BoxStyle
@@ -334,7 +334,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -352,7 +352,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
         final matrix = Matrix4.identity();
 
         util.alignment(Alignment.center);
@@ -369,7 +369,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = BoxSpecUtility();
+        final util = BoxMutableStyler();
         final matrix = Matrix4.identity();
 
         // In a builder pattern, this would create new instances
@@ -391,7 +391,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('utility resolves to correct BoxSpec', () {
-        final testUtil = BoxSpecUtility(
+        final testUtil = BoxMutableStyler(
           BoxStyler(alignment: Alignment.center, clipBehavior: Clip.antiAlias),
         );
 
@@ -424,9 +424,9 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = BoxSpecUtility(BoxStyler(alignment: Alignment.center));
-        final util2 = BoxSpecUtility(BoxStyler(clipBehavior: Clip.antiAlias));
-        final util3 = BoxSpecUtility(BoxStyler(transform: Matrix4.identity()));
+        final util1 = BoxMutableStyler(BoxStyler(alignment: Alignment.center));
+        final util2 = BoxMutableStyler(BoxStyler(clipBehavior: Clip.antiAlias));
+        final util3 = BoxMutableStyler(BoxStyler(transform: Matrix4.identity()));
 
         final result = util1.merge(util2).merge(util3);
         final context = MockBuildContext();
@@ -440,7 +440,7 @@ void main() {
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = BoxSpecUtility();
+        final emptyUtil = BoxMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -450,7 +450,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = BoxSpecUtility(BoxStyler(alignment: Alignment.center));
+        final testUtil = BoxMutableStyler(BoxStyler(alignment: Alignment.center));
         final result = testUtil.merge(testUtil);
         final context = MockBuildContext();
         final spec = result.resolve(context);

--- a/packages/mix/test/src/specs/flex/flex_util_test.dart
+++ b/packages/mix/test/src/specs/flex/flex_util_test.dart
@@ -5,11 +5,11 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('FlexSpecUtility', () {
-    late FlexSpecUtility util;
+  group('FlexMutableStyler', () {
+    late FlexMutableStyler util;
 
     setUp(() {
-      util = FlexSpecUtility();
+      util = FlexMutableStyler();
     });
 
     group('individual utility methods', () {
@@ -159,14 +159,14 @@ void main() {
     group('utility construction', () {
       test('', () {
         final initialMix = FlexStyler(direction: Axis.horizontal);
-        final utility = FlexSpecUtility(initialMix);
+        final utility = FlexMutableStyler(initialMix);
 
         final spec = utility.resolve(MockBuildContext());
         expect(spec.spec, const FlexSpec(direction: Axis.horizontal));
       });
 
       test('', () {
-        final utility = FlexSpecUtility();
+        final utility = FlexMutableStyler();
 
         final spec = utility.resolve(MockBuildContext());
         expect(spec.spec.direction, isNull);
@@ -181,11 +181,11 @@ void main() {
       });
 
       test('', () {
-        final other = FlexSpecUtility(FlexStyler(direction: Axis.horizontal));
+        final other = FlexMutableStyler(FlexStyler(direction: Axis.horizontal));
         final result = util.merge(other);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<FlexSpecUtility>());
+        expect(result, isA<FlexMutableStyler>());
 
         final spec = result.resolve(MockBuildContext());
         expect(spec.spec, const FlexSpec(direction: Axis.horizontal));
@@ -196,17 +196,17 @@ void main() {
         final result = util.merge(otherMix);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<FlexSpecUtility>());
+        expect(result, isA<FlexMutableStyler>());
 
         final spec = result.resolve(MockBuildContext());
         expect(spec.spec, const FlexSpec(spacing: 8.0));
       });
 
       test('merge combines properties correctly', () {
-        final util1 = FlexSpecUtility(
+        final util1 = FlexMutableStyler(
           FlexStyler(direction: Axis.horizontal, spacing: 4.0),
         );
-        final util2 = FlexSpecUtility(
+        final util2 = FlexMutableStyler(
           FlexStyler(spacing: 8.0, clipBehavior: Clip.hardEdge),
         );
 
@@ -224,9 +224,9 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = FlexSpecUtility(FlexStyler(direction: Axis.horizontal));
-        final util2 = FlexSpecUtility(FlexStyler(spacing: 8.0));
-        final util3 = FlexSpecUtility(
+        final util1 = FlexMutableStyler(FlexStyler(direction: Axis.horizontal));
+        final util2 = FlexMutableStyler(FlexStyler(spacing: 8.0));
+        final util3 = FlexMutableStyler(
           FlexStyler(mainAxisAlignment: MainAxisAlignment.center),
         );
 
@@ -301,7 +301,7 @@ void main() {
         const gapToken = MixToken<double>('gap');
         final context = MockBuildContext(tokens: {gapToken.defineValue(24.0)});
 
-        final utility = FlexSpecUtility(
+        final utility = FlexMutableStyler(
           FlexStyler.create(spacing: Prop.token(gapToken)),
         );
         final spec = utility.resolve(context);
@@ -330,10 +330,10 @@ void main() {
 
     group('complex scenarios', () {
       test('combines chaining with merge', () {
-        final util1 = FlexSpecUtility()
+        final util1 = FlexMutableStyler()
           ..direction(Axis.horizontal)
           ..spacing(4.0);
-        final util2 = FlexSpecUtility()
+        final util2 = FlexMutableStyler()
           ..mainAxisAlignment(MainAxisAlignment.center);
 
         final result = util1.merge(util2);
@@ -350,7 +350,7 @@ void main() {
       });
 
       test('chaining after construction with initial mix', () {
-        final utility = FlexSpecUtility(FlexStyler(direction: Axis.horizontal))
+        final utility = FlexMutableStyler(FlexStyler(direction: Axis.horizontal))
           ..gap(8.0)
           ..mainAxisAlignment(MainAxisAlignment.center);
 
@@ -384,7 +384,7 @@ void main() {
 
       test('empty utility after chaining with null values', () {
         // This tests the behavior when properties are explicitly set to null
-        final utility = FlexSpecUtility(FlexStyler(direction: Axis.horizontal));
+        final utility = FlexMutableStyler(FlexStyler(direction: Axis.horizontal));
         final spec = utility.resolve(MockBuildContext());
 
         expect(spec.spec.direction, Axis.horizontal);

--- a/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
@@ -5,7 +5,7 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('FlexStyleSpecUtility', () {
+  group('FlexBoxMutableStyler', () {
     group('Constructor', () {
       test('', () {
         final containerAttr = BoxStyler(
@@ -350,7 +350,7 @@ void main() {
       });
 
       test('handles complex nested chaining', () {
-        final utility = FlexBoxSpecUtility();
+        final utility = FlexBoxMutableStyler();
 
         // Build complex nested structure using mutable utilities
         utility.alignment(Alignment.center);
@@ -380,7 +380,7 @@ void main() {
     });
   });
 
-  group('FlexStyleSpecUtility', () {
+  group('FlexBoxMutableStyler', () {
     test('', () {
       final spec = FlexBoxSpec();
 

--- a/packages/mix/test/src/specs/flexbox/flexbox_util_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_util_test.dart
@@ -5,26 +5,26 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('FlexBoxSpecUtility', () {
-    late FlexBoxSpecUtility util;
+  group('FlexBoxMutableStyler', () {
+    late FlexBoxMutableStyler util;
 
     setUp(() {
-      util = FlexBoxSpecUtility();
+      util = FlexBoxMutableStyler();
     });
 
     group('Constructor', () {
       test('', () {
-        final utility = FlexBoxSpecUtility();
-        expect(utility, isA<FlexBoxSpecUtility>());
+        final utility = FlexBoxMutableStyler();
+        expect(utility, isA<FlexBoxMutableStyler>());
       });
 
       test('', () {
         final flexBoxMix = FlexBoxStyler(direction: Axis.horizontal);
-        final utility = FlexBoxSpecUtility(flexBoxMix);
+        final utility = FlexBoxMutableStyler(flexBoxMix);
         final context = MockBuildContext();
         final spec = utility.resolve(context);
 
-        expect(utility, isA<FlexBoxSpecUtility>());
+        expect(utility, isA<FlexBoxMutableStyler>());
         expect(spec.flex?.direction, Axis.horizontal);
       });
     });
@@ -212,13 +212,13 @@ void main() {
       });
 
       test('', () {
-        final other = FlexBoxSpecUtility(
+        final other = FlexBoxMutableStyler(
           FlexBoxStyler(direction: Axis.horizontal),
         );
         final result = util.merge(other);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<FlexBoxSpecUtility>());
+        expect(result, isA<FlexBoxMutableStyler>());
       });
 
       test('', () {
@@ -226,7 +226,7 @@ void main() {
         final result = util.merge(otherMix);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<FlexBoxSpecUtility>());
+        expect(result, isA<FlexBoxMutableStyler>());
       });
 
       test('merge throws error for unsupported type', () {
@@ -237,10 +237,10 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = FlexBoxSpecUtility(
+        final util1 = FlexBoxMutableStyler(
           FlexBoxStyler(direction: Axis.horizontal),
         );
-        final other = FlexBoxSpecUtility(
+        final other = FlexBoxMutableStyler(
           FlexBoxStyler(
             spacing: 8.0,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -259,7 +259,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('', () {
-        final testUtil = FlexBoxSpecUtility(
+        final testUtil = FlexBoxMutableStyler(
           FlexBoxStyler(
             direction: Axis.vertical,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -289,7 +289,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic direction mutation test', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         final result = util.direction(Axis.vertical);
         expect(result, isA<FlexBoxStyler>());
@@ -301,7 +301,7 @@ void main() {
       });
 
       test('basic gap mutation test', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         final result = util.spacing(16.0);
         expect(result, isA<FlexBoxStyler>());
@@ -313,7 +313,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         // Chain multiple method calls - these mutate internal state
         util.direction(Axis.vertical);
@@ -330,7 +330,7 @@ void main() {
       });
 
       test('cascade notation works with utility methods', () {
-        final util = FlexBoxSpecUtility()
+        final util = FlexBoxMutableStyler()
           ..direction(Axis.vertical)
           ..mainAxisAlignment(MainAxisAlignment.center)
           ..spacing(16.0);
@@ -344,7 +344,7 @@ void main() {
       });
 
       test('', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         // Each utility call should return a FlexBoxStyle
         final directionResult = util.direction(Axis.vertical);
@@ -369,7 +369,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -387,7 +387,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         util.direction(Axis.vertical);
         util.mainAxisAlignment(MainAxisAlignment.center);
@@ -403,7 +403,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = FlexBoxSpecUtility();
+        final util = FlexBoxMutableStyler();
 
         // In a builder pattern, this would create new instances
         // In mutable pattern, this modifies the same instance
@@ -424,7 +424,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('', () {
-        final testUtil = FlexBoxSpecUtility(
+        final testUtil = FlexBoxMutableStyler(
           FlexBoxStyler(
             direction: Axis.horizontal,
             mainAxisAlignment: MainAxisAlignment.center,
@@ -461,7 +461,7 @@ void main() {
         const gapToken = MixToken<double>('gap');
         final context = MockBuildContext(tokens: {gapToken.defineValue(24.0)});
 
-        final testUtil = FlexBoxSpecUtility(
+        final testUtil = FlexBoxMutableStyler(
           FlexBoxStyler.create(
             flex: Prop.maybeMix(
               FlexStyler.create(spacing: Prop.token(gapToken)),
@@ -490,23 +490,23 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = FlexBoxSpecUtility(
+        final util1 = FlexBoxMutableStyler(
           FlexBoxStyler(direction: Axis.horizontal),
         );
-        final util2 = FlexBoxSpecUtility(FlexBoxStyler(spacing: 8.0));
-        final util3 = FlexBoxSpecUtility(
+        final util2 = FlexBoxMutableStyler(FlexBoxStyler(spacing: 8.0));
+        final util3 = FlexBoxMutableStyler(
           FlexBoxStyler(mainAxisAlignment: MainAxisAlignment.center),
         );
 
         final result = util1.merge(util2).merge(util3);
 
-        expect(result, isA<FlexBoxSpecUtility>());
+        expect(result, isA<FlexBoxMutableStyler>());
       });
     });
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = FlexBoxSpecUtility();
+        final emptyUtil = FlexBoxMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -516,7 +516,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = FlexBoxSpecUtility(
+        final testUtil = FlexBoxMutableStyler(
           FlexBoxStyler(direction: Axis.horizontal),
         );
         final result = testUtil.merge(testUtil);

--- a/packages/mix/test/src/specs/icon/icon_spec_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_spec_test.dart
@@ -7,7 +7,7 @@ import 'package:mix/mix.dart';
 import 'package:mix/src/specs/icon/icon_spec.dart';
 
 void main() {
-  group('FlexStyleSpecUtility', () {
+  group('IconMutableStyler', () {
     group('Constructor', () {
       test('', () {
         const spec = IconSpec(

--- a/packages/mix/test/src/specs/icon/icon_style_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_style_test.dart
@@ -5,7 +5,7 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('FlexStyleSpecUtility', () {
+  group('IconMutableStyler', () {
     group('Constructor', () {
       test('', () {
         final attribute = IconStyler(

--- a/packages/mix/test/src/specs/icon/icon_util_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_util_test.dart
@@ -5,26 +5,26 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('IconSpecUtility', () {
-    late IconSpecUtility util;
+  group('IconMutableStyler', () {
+    late IconMutableStyler util;
 
     setUp(() {
-      util = IconSpecUtility();
+      util = IconMutableStyler();
     });
 
     group('Constructor', () {
       test('', () {
-        final utility = IconSpecUtility();
-        expect(utility, isA<IconSpecUtility>());
+        final utility = IconMutableStyler();
+        expect(utility, isA<IconMutableStyler>());
       });
 
       test('', () {
         final iconMix = IconStyler(size: 24.0);
-        final utility = IconSpecUtility(iconMix);
+        final utility = IconMutableStyler(iconMix);
         final context = MockBuildContext();
         final spec = utility.resolve(context);
 
-        expect(utility, isA<IconSpecUtility>());
+        expect(utility, isA<IconMutableStyler>());
         expect(spec.spec.size, 24.0);
       });
     });
@@ -211,13 +211,13 @@ void main() {
       });
 
       test('', () {
-        final other = IconSpecUtility(IconStyler(size: 32.0));
+        final other = IconMutableStyler(IconStyler(size: 32.0));
         final result = util.merge(other);
         final context = MockBuildContext();
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<IconSpecUtility>());
+        expect(result, isA<IconMutableStyler>());
         expect(spec.spec.size, 32.0);
       });
 
@@ -228,7 +228,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<IconSpecUtility>());
+        expect(result, isA<IconMutableStyler>());
         expect(spec.spec.weight, 600.0);
       });
 
@@ -240,8 +240,8 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = IconSpecUtility(IconStyler(size: 24.0, weight: 400.0));
-        final other = IconSpecUtility(IconStyler(weight: 600.0, fill: 0.8));
+        final util1 = IconMutableStyler(IconStyler(size: 24.0, weight: 400.0));
+        final other = IconMutableStyler(IconStyler(weight: 600.0, fill: 0.8));
 
         final result = util1.merge(other);
         final context = MockBuildContext();
@@ -255,7 +255,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('', () {
-        final testUtil = IconSpecUtility(
+        final testUtil = IconMutableStyler(
           IconStyler(size: 24.0, weight: 400.0, fill: 0.8),
         );
 
@@ -281,7 +281,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic size mutation test', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         final result = util.size(24.0);
         expect(result, isA<IconStyler>());
@@ -293,7 +293,7 @@ void main() {
       });
 
       test('basic weight mutation test', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         final result = util.weight(400.0);
         expect(result, isA<IconStyler>());
@@ -305,7 +305,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         // Chain multiple method calls - these mutate internal state
         util.size(24.0);
@@ -322,7 +322,7 @@ void main() {
       });
 
       test('cascade notation works with utility methods', () {
-        final util = IconSpecUtility()
+        final util = IconMutableStyler()
           ..size(24.0)
           ..weight(400.0)
           ..fill(0.8);
@@ -336,7 +336,7 @@ void main() {
       });
 
       test('', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         // Each utility call should return an IconStyle
         final sizeResult = util.size(24.0);
@@ -359,7 +359,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -377,7 +377,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         util.size(24.0);
         util.weight(400.0);
@@ -393,7 +393,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = IconSpecUtility();
+        final util = IconMutableStyler();
 
         // In a builder pattern, this would create new instances
         // In mutable pattern, this modifies the same instance
@@ -414,7 +414,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('', () {
-        final testUtil = IconSpecUtility(
+        final testUtil = IconMutableStyler(
           IconStyler(size: 24.0, weight: 400.0, fill: 0.8),
         );
 
@@ -434,7 +434,7 @@ void main() {
         const sizeToken = MixToken<double>('iconSize');
         final context = MockBuildContext(tokens: {sizeToken.defineValue(32.0)});
 
-        final testUtil = IconSpecUtility(
+        final testUtil = IconMutableStyler(
           IconStyler.create(size: Prop.token(sizeToken)),
         );
         final spec = testUtil.resolve(context);
@@ -456,9 +456,9 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = IconSpecUtility(IconStyler(size: 24.0));
-        final util2 = IconSpecUtility(IconStyler(weight: 400.0));
-        final util3 = IconSpecUtility(IconStyler(fill: 0.8));
+        final util1 = IconMutableStyler(IconStyler(size: 24.0));
+        final util2 = IconMutableStyler(IconStyler(weight: 400.0));
+        final util3 = IconMutableStyler(IconStyler(fill: 0.8));
 
         final result = util1.merge(util2).merge(util3);
         final context = MockBuildContext();
@@ -472,7 +472,7 @@ void main() {
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = IconSpecUtility();
+        final emptyUtil = IconMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -482,7 +482,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = IconSpecUtility(IconStyler(size: 24.0));
+        final testUtil = IconMutableStyler(IconStyler(size: 24.0));
         final result = testUtil.merge(testUtil);
         final context = MockBuildContext();
         final spec = result.resolve(context);

--- a/packages/mix/test/src/specs/image/image_spec_test.dart
+++ b/packages/mix/test/src/specs/image/image_spec_test.dart
@@ -7,7 +7,7 @@ import 'package:mix/mix.dart';
 import 'package:mix/src/specs/image/image_spec.dart';
 
 void main() {
-  group('FlexStyleSpecUtility', () {
+  group('ImageMutableStyler', () {
     group('Constructor', () {
       test('', () {
         const spec = ImageSpec(

--- a/packages/mix/test/src/specs/image/image_style_test.dart
+++ b/packages/mix/test/src/specs/image/image_style_test.dart
@@ -5,7 +5,7 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('FlexStyleSpecUtility', () {
+  group('ImageMutableStyler', () {
     group('Constructor', () {
       test('', () {
         final attribute = ImageStyler(

--- a/packages/mix/test/src/specs/image/image_util_test.dart
+++ b/packages/mix/test/src/specs/image/image_util_test.dart
@@ -5,26 +5,26 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('ImageSpecUtility', () {
-    late ImageSpecUtility util;
+  group('ImageMutableStyler', () {
+    late ImageMutableStyler util;
 
     setUp(() {
-      util = ImageSpecUtility();
+      util = ImageMutableStyler();
     });
 
     group('Constructor', () {
       test('', () {
-        final utility = ImageSpecUtility();
-        expect(utility, isA<ImageSpecUtility>());
+        final utility = ImageMutableStyler();
+        expect(utility, isA<ImageMutableStyler>());
       });
 
       test('', () {
         final imageMix = ImageStyler(width: 100.0);
-        final utility = ImageSpecUtility(imageMix);
+        final utility = ImageMutableStyler(imageMix);
         final context = MockBuildContext();
         final spec = utility.resolve(context);
 
-        expect(utility, isA<ImageSpecUtility>());
+        expect(utility, isA<ImageMutableStyler>());
         expect(spec.spec.width, 100.0);
       });
     });
@@ -279,13 +279,13 @@ void main() {
       });
 
       test('', () {
-        final other = ImageSpecUtility(ImageStyler(width: 150.0));
+        final other = ImageMutableStyler(ImageStyler(width: 150.0));
         final result = util.merge(other);
         final context = MockBuildContext();
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<ImageSpecUtility>());
+        expect(result, isA<ImageMutableStyler>());
         expect(spec.spec.width, 150.0);
       });
 
@@ -296,7 +296,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<ImageSpecUtility>());
+        expect(result, isA<ImageMutableStyler>());
         expect(spec.spec.height, 250.0);
       });
 
@@ -308,10 +308,10 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = ImageSpecUtility(
+        final util1 = ImageMutableStyler(
           ImageStyler(width: 100.0, height: 200.0),
         );
-        final other = ImageSpecUtility(
+        final other = ImageMutableStyler(
           ImageStyler(height: 300.0, fit: BoxFit.cover),
         );
 
@@ -327,7 +327,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('', () {
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler(width: 100.0, height: 200.0, fit: BoxFit.cover),
         );
 
@@ -351,7 +351,7 @@ void main() {
       });
 
       test('resolve handles all properties correctly', () {
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler(
             width: 100.0,
             height: 200.0,
@@ -401,7 +401,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic width mutation test', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         final result = util.width(100.0);
         expect(result, isA<ImageStyler>());
@@ -413,7 +413,7 @@ void main() {
       });
 
       test('basic height mutation test', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         final result = util.height(200.0);
         expect(result, isA<ImageStyler>());
@@ -425,7 +425,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         // Chain multiple method calls - these mutate internal state
         util.width(100.0);
@@ -442,7 +442,7 @@ void main() {
       });
 
       test('cascade notation works with utility methods', () {
-        final util = ImageSpecUtility()
+        final util = ImageMutableStyler()
           ..width(100.0)
           ..height(200.0)
           ..fit(BoxFit.cover);
@@ -456,7 +456,7 @@ void main() {
       });
 
       test('', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         // Each utility call should return an ImageStyle
         final widthResult = util.width(100.0);
@@ -479,7 +479,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -497,7 +497,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         util.width(100.0);
         util.height(200.0);
@@ -513,7 +513,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = ImageSpecUtility();
+        final util = ImageMutableStyler();
 
         // In a builder pattern, this would create new instances
         // In mutable pattern, this modifies the same instance
@@ -534,7 +534,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('', () {
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler(width: 100.0, height: 200.0, fit: BoxFit.cover),
         );
 
@@ -560,7 +560,7 @@ void main() {
           tokens: {widthToken.defineValue(150.0)},
         );
 
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler.create(width: Prop.token(widthToken)),
         );
         final spec = testUtil.resolve(context);
@@ -581,7 +581,7 @@ void main() {
           },
         );
 
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler.create(
             width: Prop.token(widthToken),
             height: Prop.token(heightToken),
@@ -610,7 +610,7 @@ void main() {
           },
         );
 
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler.create(
             fit: Prop.token(fitToken),
             repeat: Prop.token(repeatToken),
@@ -637,7 +637,7 @@ void main() {
           },
         );
 
-        final testUtil = ImageSpecUtility(
+        final testUtil = ImageMutableStyler(
           ImageStyler.create(
             semanticLabel: Prop.token(labelToken),
             excludeFromSemantics: Prop.token(excludeToken),
@@ -665,9 +665,9 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = ImageSpecUtility(ImageStyler(width: 100.0));
-        final util2 = ImageSpecUtility(ImageStyler(height: 200.0));
-        final util3 = ImageSpecUtility(ImageStyler(fit: BoxFit.cover));
+        final util1 = ImageMutableStyler(ImageStyler(width: 100.0));
+        final util2 = ImageMutableStyler(ImageStyler(height: 200.0));
+        final util3 = ImageMutableStyler(ImageStyler(fit: BoxFit.cover));
 
         final result = util1.merge(util2).merge(util3);
         final context = MockBuildContext();
@@ -681,7 +681,7 @@ void main() {
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = ImageSpecUtility();
+        final emptyUtil = ImageMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -691,7 +691,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = ImageSpecUtility(ImageStyler(width: 100.0));
+        final testUtil = ImageMutableStyler(ImageStyler(width: 100.0));
         final result = testUtil.merge(testUtil);
         final context = MockBuildContext();
         final spec = result.resolve(context);

--- a/packages/mix/test/src/specs/spec_util_test.dart
+++ b/packages/mix/test/src/specs/spec_util_test.dart
@@ -4,43 +4,43 @@ import 'package:mix/mix.dart';
 
 void main() {
   group('Spec Utilities Global Getters', () {
-    test('\$box returns BoxSpecUtility instance', () {
-      expect($box, isA<BoxSpecUtility>());
+    test('\$box returns BoxMutableStyler instance', () {
+      expect($box, isA<BoxMutableStyler>());
       // Each call returns a new instance
       expect($box, isNot(same($box)));
     });
 
-    test('\$flexbox returns FlexBoxSpecUtility instance', () {
-      expect($flexbox, isA<FlexBoxSpecUtility>());
+    test('\$flexbox returns FlexBoxMutableStyler instance', () {
+      expect($flexbox, isA<FlexBoxMutableStyler>());
       expect($flexbox, isNot(same($flexbox))); // New instance each time
     });
 
-    test('\$flex returns FlexSpecUtility instance', () {
-      expect($flex, isA<FlexSpecUtility>());
+    test('\$flex returns FlexMutableStyler instance', () {
+      expect($flex, isA<FlexMutableStyler>());
       // Each call returns a new instance
       expect($flex, isNot(same($flex)));
     });
 
-    test('\$image returns ImageSpecUtility instance', () {
-      expect($image, isA<ImageSpecUtility>());
+    test('\$image returns ImageMutableStyler instance', () {
+      expect($image, isA<ImageMutableStyler>());
       // Each call returns a new instance
       expect($image, isNot(same($image)));
     });
 
-    test('\$icon returns IconSpecUtility instance', () {
-      expect($icon, isA<IconSpecUtility>());
+    test('\$icon returns IconMutableStyler instance', () {
+      expect($icon, isA<IconMutableStyler>());
       // Each call returns a new instance
       expect($icon, isNot(same($icon)));
     });
 
-    test('\$text returns TextSpecUtility instance', () {
-      expect($text, isA<TextSpecUtility>());
+    test('\$text returns TextMutableStyler instance', () {
+      expect($text, isA<TextMutableStyler>());
       // Each call returns a new instance
       expect($text, isNot(same($text)));
     });
 
-    test('\$stack returns StackSpecUtility instance', () {
-      expect($stack, isA<StackSpecUtility>());
+    test('\$stack returns StackMutableStyler instance', () {
+      expect($stack, isA<StackMutableStyler>());
       // Each call returns a new instance
       expect($stack, isNot(same($stack)));
     });
@@ -52,39 +52,39 @@ void main() {
       final box = $box
         ..width(100)
         ..height(200);
-      expect(box, isA<BoxSpecUtility>());
+      expect(box, isA<BoxMutableStyler>());
     });
 
     test('flex getter can be used to create attributes', () {
       final flex = $flex..direction(Axis.horizontal);
-      expect(flex, isA<FlexSpecUtility>());
+      expect(flex, isA<FlexMutableStyler>());
     });
 
     test('flexbox getter provides utility methods', () {
-      expect($flexbox, isA<FlexBoxSpecUtility>());
+      expect($flexbox, isA<FlexBoxMutableStyler>());
       // Verify it can be used to create attributes
       final flexbox = $flexbox..direction(Axis.vertical);
-      expect(flexbox, isA<FlexBoxSpecUtility>());
+      expect(flexbox, isA<FlexBoxMutableStyler>());
     });
 
     test('image getter can be used to create attributes', () {
       final image = $image..fit(BoxFit.cover);
-      expect(image, isA<ImageSpecUtility>());
+      expect(image, isA<ImageMutableStyler>());
     });
 
     test('icon getter can be used to create attributes', () {
       final icon = $icon..size(24);
-      expect(icon, isA<IconSpecUtility>());
+      expect(icon, isA<IconMutableStyler>());
     });
 
     test('text getter can be used to create attributes', () {
       final text = $text..style.fontSize(16);
-      expect(text, isA<TextSpecUtility>());
+      expect(text, isA<TextMutableStyler>());
     });
 
     test('stack getter can be used to create attributes', () {
       final stack = $stack..alignment(Alignment.center);
-      expect(stack, isA<StackSpecUtility>());
+      expect(stack, isA<StackMutableStyler>());
     });
 
   });
@@ -106,13 +106,13 @@ void main() {
     });
 
     test('all getters return correct types', () {
-      expect($box, isA<BoxSpecUtility>());
-      expect($flex, isA<FlexSpecUtility>());
-      expect($flexbox, isA<FlexBoxSpecUtility>());
-      expect($image, isA<ImageSpecUtility>());
-      expect($icon, isA<IconSpecUtility>());
-      expect($text, isA<TextSpecUtility>());
-      expect($stack, isA<StackSpecUtility>());
+      expect($box, isA<BoxMutableStyler>());
+      expect($flex, isA<FlexMutableStyler>());
+      expect($flexbox, isA<FlexBoxMutableStyler>());
+      expect($image, isA<ImageMutableStyler>());
+      expect($icon, isA<IconMutableStyler>());
+      expect($text, isA<TextMutableStyler>());
+      expect($stack, isA<StackMutableStyler>());
     });
   });
 }

--- a/packages/mix/test/src/specs/stack/stack_util_test.dart
+++ b/packages/mix/test/src/specs/stack/stack_util_test.dart
@@ -5,26 +5,26 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('StackSpecUtility', () {
-    late StackSpecUtility util;
+  group('StackMutableStyler', () {
+    late StackMutableStyler util;
 
     setUp(() {
-      util = StackSpecUtility();
+      util = StackMutableStyler();
     });
 
     group('Constructor', () {
       test('', () {
-        final utility = StackSpecUtility();
-        expect(utility, isA<StackSpecUtility>());
+        final utility = StackMutableStyler();
+        expect(utility, isA<StackMutableStyler>());
       });
 
       test('', () {
         final stackMix = StackStyler(alignment: Alignment.center);
-        final utility = StackSpecUtility(stackMix);
+        final utility = StackMutableStyler(stackMix);
         final context = MockBuildContext();
         final spec = utility.resolve(context);
 
-        expect(utility, isA<StackSpecUtility>());
+        expect(utility, isA<StackMutableStyler>());
         expect(spec.spec.alignment, Alignment.center);
       });
     });
@@ -135,7 +135,7 @@ void main() {
       });
 
       test('', () {
-        final other = StackSpecUtility(
+        final other = StackMutableStyler(
           StackStyler(alignment: Alignment.center),
         );
         final result = util.merge(other);
@@ -143,7 +143,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<StackSpecUtility>());
+        expect(result, isA<StackMutableStyler>());
         expect(spec.spec.alignment, Alignment.center);
       });
 
@@ -154,7 +154,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<StackSpecUtility>());
+        expect(result, isA<StackMutableStyler>());
         expect(spec.spec.fit, StackFit.expand);
       });
 
@@ -166,10 +166,10 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = StackSpecUtility(
+        final util1 = StackMutableStyler(
           StackStyler(alignment: Alignment.center, fit: StackFit.loose),
         );
-        final other = StackSpecUtility(
+        final other = StackMutableStyler(
           StackStyler(fit: StackFit.expand, clipBehavior: Clip.antiAlias),
         );
 
@@ -185,7 +185,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('', () {
-        final testUtil = StackSpecUtility(
+        final testUtil = StackMutableStyler(
           StackStyler(
             alignment: Alignment.center,
             fit: StackFit.expand,
@@ -215,7 +215,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic alignment mutation test', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         final result = util.alignment(Alignment.center);
         expect(result, isA<StackStyler>());
@@ -227,7 +227,7 @@ void main() {
       });
 
       test('basic fit mutation test', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         final result = util.fit(StackFit.expand);
         expect(result, isA<StackStyler>());
@@ -239,7 +239,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         // Chain multiple method calls - these mutate internal state
         util.alignment(Alignment.center);
@@ -256,7 +256,7 @@ void main() {
       });
 
       test('cascade notation works with utility methods', () {
-        final util = StackSpecUtility()
+        final util = StackMutableStyler()
           ..alignment(Alignment.center)
           ..fit(StackFit.expand)
           ..clipBehavior(Clip.antiAlias);
@@ -270,7 +270,7 @@ void main() {
       });
 
       test('', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         // Each utility call should return a StackStyle
         final alignmentResult = util.alignment(Alignment.center);
@@ -293,7 +293,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -311,7 +311,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         util.alignment(Alignment.center);
         util.fit(StackFit.expand);
@@ -327,7 +327,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = StackSpecUtility();
+        final util = StackMutableStyler();
 
         // In a builder pattern, this would create new instances
         // In mutable pattern, this modifies the same instance
@@ -348,7 +348,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('', () {
-        final testUtil = StackSpecUtility(
+        final testUtil = StackMutableStyler(
           StackStyler(
             alignment: Alignment.center,
             fit: StackFit.expand,
@@ -378,7 +378,7 @@ void main() {
           tokens: {alignmentToken.defineValue(Alignment.topLeft)},
         );
 
-        final testUtil = StackSpecUtility(
+        final testUtil = StackMutableStyler(
           StackStyler.create(alignment: Prop.token(alignmentToken)),
         );
         final spec = testUtil.resolve(context);
@@ -400,11 +400,11 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = StackSpecUtility(
+        final util1 = StackMutableStyler(
           StackStyler(alignment: Alignment.center),
         );
-        final util2 = StackSpecUtility(StackStyler(fit: StackFit.expand));
-        final util3 = StackSpecUtility(
+        final util2 = StackMutableStyler(StackStyler(fit: StackFit.expand));
+        final util3 = StackMutableStyler(
           StackStyler(clipBehavior: Clip.antiAlias),
         );
 
@@ -420,7 +420,7 @@ void main() {
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = StackSpecUtility();
+        final emptyUtil = StackMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -430,7 +430,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = StackSpecUtility(
+        final testUtil = StackMutableStyler(
           StackStyler(alignment: Alignment.center),
         );
         final result = testUtil.merge(testUtil);

--- a/packages/mix/test/src/specs/text/text_util_test.dart
+++ b/packages/mix/test/src/specs/text/text_util_test.dart
@@ -5,17 +5,17 @@ import 'package:mix/mix.dart';
 import '../../../helpers/testing_utils.dart';
 
 void main() {
-  group('TextSpecUtility', () {
-    late TextSpecUtility util;
+  group('TextMutableStyler', () {
+    late TextMutableStyler util;
 
     setUp(() {
-      util = TextSpecUtility();
+      util = TextMutableStyler();
     });
 
     group('Constructor', () {
       test('creates with provided TextStyling attribute', () {
         final textMix = TextStyler(maxLines: 3);
-        final utility = TextSpecUtility(textMix);
+        final utility = TextMutableStyler(textMix);
 
         expect(utility.value, equals(textMix));
         expect(utility.value.$maxLines, resolvesTo(3));
@@ -226,7 +226,7 @@ void main() {
       });
 
       test('semanticsLabel utility creates correct TextStyling', () {
-        final result = TextSpecUtility().semanticsLabel('Custom label');
+        final result = TextMutableStyler().semanticsLabel('Custom label');
         expect(result.$semanticsLabel, resolvesTo('Custom label'));
       });
 
@@ -284,14 +284,14 @@ void main() {
         expect(result, same(util));
       });
 
-      test('merge with TextSpecUtility creates new instance', () {
-        final other = TextSpecUtility(TextStyler(maxLines: 5));
+      test('merge with TextMutableStyler creates new instance', () {
+        final other = TextMutableStyler(TextStyler(maxLines: 5));
         final result = util.merge(other);
         final context = MockBuildContext();
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<TextSpecUtility>());
+        expect(result, isA<TextMutableStyler>());
         expect(spec.spec.maxLines, 5);
       });
 
@@ -302,7 +302,7 @@ void main() {
         final spec = result.resolve(context);
 
         expect(result, isNot(same(util)));
-        expect(result, isA<TextSpecUtility>());
+        expect(result, isA<TextMutableStyler>());
         expect(spec.spec.textAlign, TextAlign.center);
       });
 
@@ -314,10 +314,10 @@ void main() {
       });
 
       test('merge combines properties correctly', () {
-        final util1 = TextSpecUtility(
+        final util1 = TextMutableStyler(
           TextStyler(maxLines: 3, textAlign: TextAlign.left),
         );
-        final other = TextSpecUtility(
+        final other = TextMutableStyler(
           TextStyler(textAlign: TextAlign.center, softWrap: false),
         );
 
@@ -333,7 +333,7 @@ void main() {
 
     group('Resolve functionality', () {
       test('resolve returns TextSpec with resolved properties', () {
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler(
             maxLines: 3,
             textAlign: TextAlign.center,
@@ -383,7 +383,7 @@ void main() {
 
     group('Integration with resolvesTo matcher', () {
       test('utility resolves to correct TextSpec', () {
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler(maxLines: 3, textAlign: TextAlign.center, softWrap: false),
         );
 
@@ -409,7 +409,7 @@ void main() {
           tokens: {maxLinesToken.defineValue(5)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(maxLines: Prop.token(maxLinesToken)),
         );
         final spec = testUtil.resolve(context);
@@ -423,7 +423,7 @@ void main() {
           tokens: {textAlignToken.defineValue(TextAlign.center)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(textAlign: Prop.token(textAlignToken)),
         );
         final spec = testUtil.resolve(context);
@@ -437,7 +437,7 @@ void main() {
           tokens: {softWrapToken.defineValue(false)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(softWrap: Prop.token(softWrapToken)),
         );
         final spec = testUtil.resolve(context);
@@ -451,7 +451,7 @@ void main() {
           tokens: {selectionColorToken.defineValue(Colors.red)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(selectionColor: Prop.token(selectionColorToken)),
         );
         final spec = testUtil.resolve(context);
@@ -465,7 +465,7 @@ void main() {
           tokens: {textDirectionToken.defineValue(TextDirection.rtl)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(textDirection: Prop.token(textDirectionToken)),
         );
         final spec = testUtil.resolve(context);
@@ -479,7 +479,7 @@ void main() {
           tokens: {semanticsLabelToken.defineValue('Custom label')},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(semanticsLabel: Prop.token(semanticsLabelToken)),
         );
         final spec = testUtil.resolve(context);
@@ -494,7 +494,7 @@ void main() {
           tokens: {localeToken.defineValue(locale)},
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(locale: Prop.token(localeToken)),
         );
         final spec = testUtil.resolve(context);
@@ -519,7 +519,7 @@ void main() {
           },
         );
 
-        final testUtil = TextSpecUtility(
+        final testUtil = TextMutableStyler(
           TextStyler.create(
             maxLines: Prop.token(maxLinesToken),
             textAlign: Prop.token(textAlignToken),
@@ -555,9 +555,9 @@ void main() {
       });
 
       test('handles multiple merges correctly', () {
-        final util1 = TextSpecUtility(TextStyler(maxLines: 3));
-        final util2 = TextSpecUtility(TextStyler(textAlign: TextAlign.center));
-        final util3 = TextSpecUtility(TextStyler(softWrap: false));
+        final util1 = TextMutableStyler(TextStyler(maxLines: 3));
+        final util2 = TextMutableStyler(TextStyler(textAlign: TextAlign.center));
+        final util3 = TextMutableStyler(TextStyler(softWrap: false));
 
         final result = util1.merge(util2).merge(util3);
         final context = MockBuildContext();
@@ -571,7 +571,7 @@ void main() {
 
     group('Edge cases', () {
       test('handles empty utility', () {
-        final emptyUtil = TextSpecUtility();
+        final emptyUtil = TextMutableStyler();
         final context = MockBuildContext();
         final spec = emptyUtil.resolve(context);
 
@@ -581,7 +581,7 @@ void main() {
       });
 
       test('merge with self returns new instance', () {
-        final testUtil = TextSpecUtility(TextStyler(maxLines: 3));
+        final testUtil = TextMutableStyler(TextStyler(maxLines: 3));
         final result = testUtil.merge(testUtil);
         final context = MockBuildContext();
         final spec = result.resolve(context);
@@ -593,7 +593,7 @@ void main() {
 
     group('Chaining methods', () {
       test('basic maxLines mutation test', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         final result = util.maxLines(5);
         expect(result, isA<TextStyler>());
@@ -605,7 +605,7 @@ void main() {
       });
 
       test('basic color mutation test', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         final result = util.color.red();
         expect(result, isA<TextStyler>());
@@ -617,7 +617,7 @@ void main() {
       });
 
       test('chaining utility methods accumulates properties', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         // Chain multiple method calls - these mutate internal state
         util.color.red();
@@ -634,7 +634,7 @@ void main() {
       });
 
       test('cascade notation works with utility methods', () {
-        final util = TextSpecUtility()
+        final util = TextMutableStyler()
           ..color.red()
           ..fontSize(16)
           ..maxLines(3);
@@ -650,7 +650,7 @@ void main() {
       test(
         'individual utility calls return TextStyling for further chaining',
         () {
-          final util = TextSpecUtility();
+          final util = TextMutableStyler();
 
           // Each utility call should return a TextStyle
           final colorResult = util.color.red();
@@ -674,7 +674,7 @@ void main() {
 
     group('Mutating behavior vs Builder pattern', () {
       test('utility mutates internal state (not builder pattern)', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         // Store initial resolution
         final context = MockBuildContext();
@@ -692,7 +692,7 @@ void main() {
       });
 
       test('multiple calls accumulate on same instance', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         util.color.red();
         util.fontSize(16);
@@ -708,7 +708,7 @@ void main() {
       });
 
       test('demonstrates difference from immutable builder pattern', () {
-        final util = TextSpecUtility();
+        final util = TextMutableStyler();
 
         // In a builder pattern, this would create new instances
         // In mutable pattern, this modifies the same instance

--- a/packages/mix_generator/lib/src/core/spec/spec_utility_builder.dart
+++ b/packages/mix_generator/lib/src/core/spec/spec_utility_builder.dart
@@ -11,7 +11,7 @@ class SpecUtilityBuilder implements CodeBuilder {
   String build() {
     final specName = metadata.name;
     final attributeName = '${specName}Attribute';
-    final utilityName = '${specName}Utility';
+    final utilityName = '${specName}MutableStyler';
 
     // Generate utility fields using UtilityCodeGenerator:
     final generatedFields = UtilityCodeGenerator.generateUtilityFields(

--- a/packages/mix_generator/test/src/helpers/test_helpers.dart
+++ b/packages/mix_generator/test/src/helpers/test_helpers.dart
@@ -192,8 +192,8 @@ mixin Diagnosticable {
 }
 
 /// Utility class for Specs
-class SpecUtility {
-  const SpecUtility();
+class MutableStyler {
+  const MutableStyler();
 }
 
 /// Mix data container

--- a/website/pages/docs/tutorials/creating-a-widget.md
+++ b/website/pages/docs/tutorials/creating-a-widget.md
@@ -149,7 +149,7 @@ Additionally, you will find the following generated classes:
 
 - `ButtonSpecAttribute`: It is similar to `ButtonSpec`, but it has attribute equivalents, which allow values to be passed within Mix and merged before resolving to the spec.
 - `ButtonSpecTween`: It is generated so you can use it for animations involving `ButtonSpec` instances.
-- `ButtonSpecUtility`: This is the API utility class that you will be using to interact with your button. It provides convenient methods for applying the button's styling.
+- `ButtonMutableStyler`: This is the API utility class that you will be using to interact with your button. It provides convenient methods for applying the button's styling.
 
 Make sure to run the build runner whenever you make changes to the `ButtonSpec` class or any other classes with Mix annotations to keep the generated code up to date.
 
@@ -258,7 +258,7 @@ Create a new file called `button_styles.dart`.
 You can use the utility that was generated and create references for each part of the button like so:
 
 ```dart
-final _util = ButtonSpecUtility.self;
+final _util = ButtonMutableStyler.self;
 final _label = _util.label;
 final _container = _util.container;
 final _flex = _util.flex;

--- a/website/pages/docs/widgets/flex.mdx
+++ b/website/pages/docs/widgets/flex.mdx
@@ -59,7 +59,7 @@ VBox(
 
 ## Utilities
 
-The Flex utility provides an easy way to compose `FlexSpecAttribute`. The `$flex` variable is an instance of the `FlexSpecUtility` class, serving as an entry point for building the styling attributes for  `StyledFlex`, `StyledRow`, `StyledColumn`, `FlexBox`, `HBox`, and `VBox`.
+The Flex utility provides an easy way to compose `FlexSpecAttribute`. The `$flex` variable is an instance of the `FlexMutableStyler` class, serving as an entry point for building the styling attributes for  `StyledFlex`, `StyledRow`, `StyledColumn`, `FlexBox`, `HBox`, and `VBox`.
 
 ### **direction**
 

--- a/website/pages/docs/widgets/icon.mdx
+++ b/website/pages/docs/widgets/icon.mdx
@@ -49,7 +49,7 @@ AnimatedStyledIcon(
 
 ## Utilities
 
-The `$icon` constant alias is an instance of `IconSpecUtility`, which facilitates the construction of `IconSpecAttribute` objects. These attributes are used to style and manage properties of `StyledIcon` and `AnimatedStyledIcon`.
+The `$icon` constant alias is an instance of `IconMutableStyler`, which facilitates the construction of `IconSpecAttribute` objects. These attributes are used to style and manage properties of `StyledIcon` and `AnimatedStyledIcon`.
 
 #### **color**
 

--- a/website/pages/docs/widgets/image.mdx
+++ b/website/pages/docs/widgets/image.mdx
@@ -43,7 +43,7 @@ In this example, the `StyledImage` widget will inherit the image height and colo
 
 ## Utilities
 
-The `$image` constant alias is an instance of `ImageSpecUtility`, which facilitates the construction of `ImageSpecAttribute` objects. These attributes are used to style and manage properties of `StyledImage` widgets.
+The `$image` constant alias is an instance of `ImageMutableStyler`, which facilitates the construction of `ImageSpecAttribute` objects. These attributes are used to style and manage properties of `StyledImage` widgets.
 
 #### **color**
 

--- a/website/pages/docs/widgets/stack.mdx
+++ b/website/pages/docs/widgets/stack.mdx
@@ -25,7 +25,7 @@ ZBox(
 
 ## Utilities
 
-The `$stack` variable is an instance of `StackSpecUtility`, which facilitates the construction of `StackSpecAttribute` objects. These objects are used to style and manage the visuals of `ZBox` and `StyledStack`.
+The `$stack` variable is an instance of `StackMutableStyler`, which facilitates the construction of `StackSpecAttribute` objects. These objects are used to style and manage the visuals of `ZBox` and `StyledStack`.
 
 ### **alignment**
 

--- a/website/pages/docs/widgets/text.mdx
+++ b/website/pages/docs/widgets/text.mdx
@@ -32,7 +32,7 @@ In this example all `StyledText` widgets will inherit the style attributes from 
 
 ## Utilities
 
-The `$text` variable is an instance of `TextSpecUtility`, which facilitates the construction of `TextSpecAttribute` objects. These objects are used to style and manage the visuals of `StyledText` and `AnimatedTextSpecWidget`.
+The `$text` variable is an instance of `TextMutableStyler`, which facilitates the construction of `TextSpecAttribute` objects. These objects are used to style and manage the visuals of `StyledText` and `AnimatedTextSpecWidget`.
 
 #### **overflow**
 


### PR DESCRIPTION
## Summary
• Rename all `XxxSpecUtility` classes to `XxxMutableStyler` for better naming consistency and alignment with the existing Style/Styler pattern
• Rename internal mutable state classes from `MutableXxxStyle` to `XxxMutableState` with proper encapsulation
• Update file names from `*_util.dart` to `*_mutable_style.dart` and `spec_util.dart` to `mutable_stylers.dart` for better organization
• Comprehensive updates to code generator, tests, and documentation to maintain full functionality

## Test plan
- [x] All existing tests pass with updated class names
- [x] Code analysis passes (`dart analyze` - no issues found)
- [x] Code quality checks pass (`dcm analyze` - only 1 unrelated style issue)  
- [x] Global accessors (`$box`, `$flex`, etc.) correctly return new MutableStyler classes
- [x] Documentation updated across all `.mdx` files and tutorials
- [x] Code generator produces correct MutableStyler naming for future classes
- [x] File renames preserve git history (87-90% similarity detected)
- [x] No breaking changes to public API functionality - only naming changes