### PR TITLE
refactor: rename Modifier to WidgetModifier throughout codebase

### DIFF
--- a/packages/mix/example/lib/api/context_variants/responsive_size.dart
+++ b/packages/mix/example/lib/api/context_variants/responsive_size.dart
@@ -24,7 +24,7 @@ class Example extends StatelessWidget {
               .fontWeight(FontWeight.bold)
               .color(Colors.white),
         )
-        .wrap(ModifierConfig.align(alignment: Alignment.center))
+        .wrap(WidgetModifierConfig.align(alignment: Alignment.center))
         .animate(AnimationConfig.spring(const Duration(milliseconds: 300)));
 
     return Center(

--- a/packages/mix/example/lib/api/shaders/linear_gradient.dart
+++ b/packages/mix/example/lib/api/shaders/linear_gradient.dart
@@ -28,7 +28,7 @@ class LinearGradientIconExample extends StatelessWidget {
           .size(100)
           .color(Colors.white)
           .wrap(
-            ModifierConfig.shaderMask(
+            WidgetModifierConfig.shaderMask(
               shaderCallback: ShaderCallbackBuilder.linearGradient(
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,

--- a/packages/mix/example/lib/api/shaders/radial_gradient.dart
+++ b/packages/mix/example/lib/api/shaders/radial_gradient.dart
@@ -28,7 +28,7 @@ class LinearGradientIconExample extends StatelessWidget {
           .color(Colors.white)
           .fontWeight(FontWeight.bold)
           .wrap(
-            ModifierConfig.shaderMask(
+            WidgetModifierConfig.shaderMask(
               shaderCallback: ShaderCallbackBuilder.radialGradient(
                 center: Alignment.centerLeft,
                 radius: 0.7,

--- a/packages/mix/example/lib/api/shaders/sweep_gradient.dart
+++ b/packages/mix/example/lib/api/shaders/sweep_gradient.dart
@@ -28,7 +28,7 @@ class SweepGradientIconExample extends StatelessWidget {
           .size(100)
           .color(Colors.white)
           .wrap(
-            ModifierConfig.shaderMask(
+            WidgetModifierConfig.shaderMask(
               shaderCallback: ShaderCallbackBuilder.sweepGradient(
                 center: Alignment.topCenter,
                 colors: [

--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -33,7 +33,7 @@ export 'src/core/directive.dart';
 export 'src/core/extensions/extensions.dart';
 export 'src/core/helpers.dart';
 export 'src/core/mix_element.dart';
-export 'src/core/modifier.dart';
+export 'src/core/widget_modifier.dart';
 export 'src/core/pointer_position.dart';
 export 'src/core/prop.dart';
 export 'src/core/prop_refs.dart';
@@ -61,8 +61,8 @@ export 'src/modifiers/internal/reset_modifier.dart';
 export 'src/modifiers/intrinsic_modifier.dart';
 
 /// PROPERTIES
-export 'src/modifiers/modifier_config.dart';
-export 'src/modifiers/modifier_util.dart';
+export 'src/modifiers/widget_modifier_config.dart';
+export 'src/modifiers/widget_modifier_util.dart';
 export 'src/modifiers/mouse_cursor_modifier.dart';
 export 'src/modifiers/opacity_modifier.dart';
 export 'src/modifiers/padding_modifier.dart';
@@ -150,7 +150,7 @@ export 'src/style/mixins/border_style_mixin.dart';
 export 'src/style/mixins/constraint_style_mixin.dart';
 export 'src/style/mixins/decoration_style_mixin.dart';
 export 'src/style/mixins/flex_style_mixin.dart';
-export 'src/style/mixins/modifier_style_mixin.dart';
+export 'src/style/mixins/widget_modifier_style_mixin.dart';
 export 'src/style/mixins/shadow_style_mixin.dart';
 export 'src/style/mixins/spacing_style_mixin.dart';
 export 'src/style/mixins/text_style_mixin.dart';

--- a/packages/mix/lib/src/core/helpers.dart
+++ b/packages/mix/lib/src/core/helpers.dart
@@ -6,14 +6,14 @@ import 'package:flutter/rendering.dart' as r;
 import 'package:flutter/widgets.dart' as w;
 
 import '../animation/animation_config.dart';
-import '../modifiers/modifier_config.dart';
+import '../modifiers/widget_modifier_config.dart';
 import '../properties/painting/decoration_mix.dart';
 import '../properties/painting/shape_border_mix.dart';
 import 'decoration_merge.dart';
 import 'directive.dart';
 import 'internal/deep_collection_equality.dart';
 import 'mix_element.dart';
-import 'modifier.dart';
+import 'widget_modifier.dart';
 import 'prop.dart';
 import 'style.dart';
 import 'prop_source.dart';
@@ -57,9 +57,9 @@ class MixOps {
     return other ?? current;
   }
 
-  static ModifierConfig? mergeModifier(
-    ModifierConfig? current,
-    ModifierConfig? other,
+  static WidgetModifierConfig? mergeModifier(
+    WidgetModifierConfig? current,
+    WidgetModifierConfig? other,
   ) {
     return current?.merge(other) ?? other;
   }
@@ -173,9 +173,9 @@ T? _lerpSnap<T>(T? a, T? b, double t) {
 }
 
 /// Lerp modifier lists using ModifierListTween
-List<Modifier>? _lerpModifierList(
-  List<Modifier>? a,
-  List<Modifier>? b,
+List<WidgetModifier>? _lerpModifierList(
+  List<WidgetModifier>? a,
+  List<WidgetModifier>? b,
   double t,
 ) {
   return ModifierListTween(begin: a, end: b).lerp(t);
@@ -255,7 +255,7 @@ T? _lerpValue<T>(T? a, T? b, double t) {
     (Matrix4? a, Matrix4? b) => Matrix4Tween(begin: a, end: b).lerp(t) as T?,
 
     // List of Modifiers - use ModifierListTween for proper lerping
-    (List<Modifier>? a, List<Modifier>? b) => _lerpModifierList(a, b, t) as T?,
+    (List<WidgetModifier>? a, List<WidgetModifier>? b) => _lerpModifierList(a, b, t) as T?,
 
     // Default snap behavior for non-lerpable types
     _ => t < 0.5 ? a : b,

--- a/packages/mix/lib/src/core/spec_utility.dart
+++ b/packages/mix/lib/src/core/spec_utility.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../animation/animation_config.dart';
-import '../modifiers/modifier_config.dart';
+import '../modifiers/widget_modifier_config.dart';
 import 'spec.dart';
 import 'style.dart';
 import 'style_spec.dart';
@@ -37,7 +37,7 @@ abstract class StyleAttributeBuilder<S extends Spec<S>> extends Style<S>
   AnimationConfig? get $animation => style.$animation;
 
   @override
-  ModifierConfig? get $modifier => style.$modifier;
+  WidgetModifierConfig? get $modifier => style.$modifier;
 
   /// Mutable variants from internal attribute
   @override
@@ -77,7 +77,7 @@ abstract class StyleMutableBuilder<S extends Spec<S>> extends Style<S>
   AnimationConfig? get $animation => value.$animation;
 
   @override
-  ModifierConfig? get $modifier => value.$modifier;
+  WidgetModifierConfig? get $modifier => value.$modifier;
 
   /// Mutable variants from internal attribute
   @override

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../animation/animation_config.dart';
-import '../modifiers/modifier_config.dart';
+import '../modifiers/widget_modifier_config.dart';
 import '../specs/box/box_style.dart';
 import '../specs/flex/flex_style.dart';
 import '../specs/flexbox/flexbox_style.dart';
@@ -14,7 +14,7 @@ import '../specs/text/text_style.dart';
 import '../variants/variant.dart';
 import 'internal/compare_mixin.dart';
 import 'mix_element.dart';
-import 'modifier.dart';
+import 'widget_modifier.dart';
 import 'spec.dart';
 import 'style_spec.dart';
 
@@ -31,7 +31,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     implements StyleElement {
   final List<VariantStyle<S>>? $variants;
 
-  final ModifierConfig? $modifier;
+  final WidgetModifierConfig? $modifier;
   final AnimationConfig? $animation;
 
   static final box = BoxStyler.new;
@@ -45,7 +45,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
 
   const Style({
     required List<VariantStyle<S>>? variants,
-    required ModifierConfig? modifier,
+    required WidgetModifierConfig? modifier,
     required AnimationConfig? animation,
   }) : $modifier = modifier,
        $animation = animation,
@@ -145,7 +145,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
   }
 }
 
-abstract class ModifierMix<S extends Modifier<S>> extends Mix<S>
+abstract class ModifierMix<S extends WidgetModifier<S>> extends Mix<S>
     implements StyleElement {
   const ModifierMix();
 

--- a/packages/mix/lib/src/core/style_spec.dart
+++ b/packages/mix/lib/src/core/style_spec.dart
@@ -3,7 +3,7 @@ import 'package:flutter/widgets.dart';
 
 import '../animation/animation_config.dart';
 import 'helpers.dart';
-import 'modifier.dart';
+import 'widget_modifier.dart';
 import 'spec.dart';
 import 'style_builder.dart';
 
@@ -33,7 +33,7 @@ class StyleSpec<T extends Spec<T>> extends Spec<StyleSpec<T>>
   final AnimationConfig? animation;
 
   /// Widget-level modifiers to apply around the built widget.
-  final List<Modifier>? widgetModifiers;
+  final List<WidgetModifier>? widgetModifiers;
 
   /// Creates a [StyleSpec] with the provided spec and optional metadata.
   const StyleSpec({required this.spec, this.animation, this.widgetModifiers});
@@ -44,7 +44,7 @@ class StyleSpec<T extends Spec<T>> extends Spec<StyleSpec<T>>
   StyleSpec<T> copyWith({
     T? spec,
     AnimationConfig? animation,
-    List<Modifier>? widgetModifiers,
+    List<WidgetModifier>? widgetModifiers,
   }) {
     return StyleSpec(
       spec: spec ?? this.spec,
@@ -73,7 +73,7 @@ class StyleSpec<T extends Spec<T>> extends Spec<StyleSpec<T>>
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('animation', animation))
-      ..add(IterableProperty<Modifier>('widgetModifiers', widgetModifiers))
+      ..add(IterableProperty<WidgetModifier>('widgetModifiers', widgetModifiers))
       ..add(DiagnosticsProperty<T>('spec', spec));
   }
 

--- a/packages/mix/lib/src/core/widget_modifier.dart
+++ b/packages/mix/lib/src/core/widget_modifier.dart
@@ -2,12 +2,12 @@ import 'package:flutter/widgets.dart';
 
 import 'spec.dart';
 
-/// Unified base class for modifiers.
+/// Unified base class for widget modifiers.
 ///
 /// Provides a common interface for widget modifications that can be applied
 /// to styled elements in the Mix framework.
-abstract class Modifier<Self extends Modifier<Self>> extends Spec<Self> {
-  const Modifier();
+abstract class WidgetModifier<Self extends WidgetModifier<Self>> extends Spec<Self> {
+  const WidgetModifier();
 
   /// Builds the modified widget by wrapping or transforming [child].
   Widget build(Widget child);

--- a/packages/mix/lib/src/modifiers/align_modifier.dart
+++ b/packages/mix/lib/src/modifiers/align_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -10,7 +10,7 @@ import '../core/utility.dart';
 /// Modifier that aligns its child within the available space.
 ///
 /// Wraps the child in an [Align] widget with the specified alignment and size factors.
-final class AlignModifier extends Modifier<AlignModifier> with Diagnosticable {
+final class AlignModifier extends WidgetModifier<AlignModifier> with Diagnosticable {
   final AlignmentGeometry alignment;
   final double? widthFactor;
   final double? heightFactor;

--- a/packages/mix/lib/src/modifiers/aspect_ratio_modifier.dart
+++ b/packages/mix/lib/src/modifiers/aspect_ratio_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../theme/tokens/mix_token.dart';
 /// Modifier that constrains its child to a specific aspect ratio.
 ///
 /// Wraps the child in an [AspectRatio] widget with the specified ratio.
-final class AspectRatioModifier extends Modifier<AspectRatioModifier>
+final class AspectRatioModifier extends WidgetModifier<AspectRatioModifier>
     with Diagnosticable {
   final double aspectRatio;
 

--- a/packages/mix/lib/src/modifiers/box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/box_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
 import '../properties/layout/edge_insets_geometry_mix.dart';
@@ -14,7 +14,7 @@ import '../specs/box/box_widget.dart';
 /// Modifier that wraps its child in a styled Container using BoxSpec styling.
 ///
 /// Wraps the child in a [Container] widget with the specified box styling.
-final class BoxModifier extends Modifier<BoxModifier> with Diagnosticable {
+final class BoxModifier extends WidgetModifier<BoxModifier> with Diagnosticable {
   final BoxSpec spec;
 
   const BoxModifier(this.spec);

--- a/packages/mix/lib/src/modifiers/clip_modifier.dart
+++ b/packages/mix/lib/src/modifiers/clip_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../properties/painting/border_radius_mix.dart';
@@ -10,7 +10,7 @@ import '../properties/painting/border_radius_mix.dart';
 /// Modifier that clips its child to an oval shape.
 ///
 /// Wraps the child in a [ClipOval] widget with the specified clipper and clip behavior.
-final class ClipOvalModifier extends Modifier<ClipOvalModifier>
+final class ClipOvalModifier extends WidgetModifier<ClipOvalModifier>
     with Diagnosticable {
   final CustomClipper<Rect>? clipper;
   final Clip clipBehavior;
@@ -96,7 +96,7 @@ class ClipOvalModifierMix extends ModifierMix<ClipOvalModifier> {
 /// Modifier that clips its child to a rectangular shape.
 ///
 /// Wraps the child in a [ClipRect] widget with the specified clipper and clip behavior.
-final class ClipRectModifier extends Modifier<ClipRectModifier>
+final class ClipRectModifier extends WidgetModifier<ClipRectModifier>
     with Diagnosticable {
   final CustomClipper<Rect>? clipper;
   final Clip clipBehavior;
@@ -182,7 +182,7 @@ class ClipRectModifierMix extends ModifierMix<ClipRectModifier> {
 /// Modifier that clips its child to a rounded rectangular shape.
 ///
 /// Wraps the child in a [ClipRRect] widget with the specified border radius.
-final class ClipRRectModifier extends Modifier<ClipRRectModifier>
+final class ClipRRectModifier extends WidgetModifier<ClipRRectModifier>
     with Diagnosticable {
   final BorderRadiusGeometry borderRadius;
   final CustomClipper<RRect>? clipper;
@@ -293,7 +293,7 @@ class ClipRRectModifierMix extends ModifierMix<ClipRRectModifier> {
 /// Modifier that clips its child using a custom path.
 ///
 /// Wraps the child in a [ClipPath] widget with the specified clipper.
-final class ClipPathModifier extends Modifier<ClipPathModifier>
+final class ClipPathModifier extends WidgetModifier<ClipPathModifier>
     with Diagnosticable {
   final CustomClipper<Path>? clipper;
   final Clip clipBehavior;
@@ -379,7 +379,7 @@ class ClipPathModifierMix extends ModifierMix<ClipPathModifier> {
 /// Modifier that clips its child to a triangle shape.
 ///
 /// Wraps the child in a [ClipPath] widget using a triangle clipper.
-final class ClipTriangleModifier extends Modifier<ClipTriangleModifier>
+final class ClipTriangleModifier extends WidgetModifier<ClipTriangleModifier>
     with Diagnosticable {
   final Clip clipBehavior;
 

--- a/packages/mix/lib/src/modifiers/default_text_style_modifier.dart
+++ b/packages/mix/lib/src/modifiers/default_text_style_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -12,7 +12,7 @@ import '../properties/typography/text_style_mix.dart';
 /// Modifier that applies default text styling to its descendants.
 ///
 /// Wraps the child in a [DefaultTextStyle] widget with the specified text properties.
-final class DefaultTextStyleModifier extends Modifier<DefaultTextStyleModifier>
+final class DefaultTextStyleModifier extends WidgetModifier<DefaultTextStyleModifier>
     with Diagnosticable {
   final TextStyle style;
   final TextAlign? textAlign;

--- a/packages/mix/lib/src/modifiers/flexible_modifier.dart
+++ b/packages/mix/lib/src/modifiers/flexible_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../theme/tokens/mix_token.dart';
 /// Modifier that makes its child flexible within a flex layout.
 ///
 /// Wraps the child in a [Flexible] widget with the specified flex and fit properties.
-final class FlexibleModifier extends Modifier<FlexibleModifier>
+final class FlexibleModifier extends WidgetModifier<FlexibleModifier>
     with Diagnosticable {
   final int? flex;
   final FlexFit? fit;

--- a/packages/mix/lib/src/modifiers/fractionally_sized_box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/fractionally_sized_box_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../core/utility.dart';
 ///
 /// Wraps the child in a [FractionallySizedBox] widget with the specified factors.
 final class FractionallySizedBoxModifier
-    extends Modifier<FractionallySizedBoxModifier>
+    extends WidgetModifier<FractionallySizedBoxModifier>
     with Diagnosticable {
   final double? widthFactor;
   final double? heightFactor;

--- a/packages/mix/lib/src/modifiers/icon_theme_modifier.dart
+++ b/packages/mix/lib/src/modifiers/icon_theme_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../properties/painting/shadow_mix.dart';
 /// Modifier that applies icon theme data to its descendants.
 ///
 /// Wraps the child in an [IconTheme] widget with the specified theme data.
-final class IconThemeModifier extends Modifier<IconThemeModifier>
+final class IconThemeModifier extends WidgetModifier<IconThemeModifier>
     with Diagnosticable {
   final IconThemeData data;
 

--- a/packages/mix/lib/src/modifiers/internal/render_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_modifier.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../../core/modifier.dart';
+import '../../core/widget_modifier.dart';
 
 /// Renders a widget with applied modifiers in the correct order.
 @internal
@@ -19,7 +19,7 @@ class RenderModifiers extends StatelessWidget {
   final Widget child;
 
   /// List of modifiers to apply to the [child].
-  final List<Modifier> widgetModifiers;
+  final List<WidgetModifier> widgetModifiers;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +35,7 @@ class _RenderModifiers extends StatelessWidget {
   final Widget child;
 
   /// Modifiers to apply in sequence.
-  final Iterable<Modifier> modifiers;
+  final Iterable<WidgetModifier> modifiers;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mix/lib/src/modifiers/internal/reset_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/reset_modifier.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../../core/modifier.dart';
+import '../../core/widget_modifier.dart';
 import '../../core/style.dart';
 
 /// A modifier specification that resets the style context.
-final class ResetModifier extends Modifier<ResetModifier> with Diagnosticable {
+final class ResetModifier extends WidgetModifier<ResetModifier> with Diagnosticable {
   const ResetModifier();
 
   @override

--- a/packages/mix/lib/src/modifiers/intrinsic_modifier.dart
+++ b/packages/mix/lib/src/modifiers/intrinsic_modifier.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/style.dart';
 
 /// Modifier that forces its child to be exactly as tall as its intrinsic height.
 ///
 /// Wraps the child in an [IntrinsicHeight] widget.
-final class IntrinsicHeightModifier extends Modifier<IntrinsicHeightModifier>
+final class IntrinsicHeightModifier extends WidgetModifier<IntrinsicHeightModifier>
     with Diagnosticable {
   const IntrinsicHeightModifier();
 
@@ -40,7 +40,7 @@ final class IntrinsicHeightModifier extends Modifier<IntrinsicHeightModifier>
 /// Modifier that forces its child to be exactly as wide as its intrinsic width.
 ///
 /// Wraps the child in an [IntrinsicWidth] widget.
-final class IntrinsicWidthModifier extends Modifier<IntrinsicWidthModifier>
+final class IntrinsicWidthModifier extends WidgetModifier<IntrinsicWidthModifier>
     with Diagnosticable {
   const IntrinsicWidthModifier();
 

--- a/packages/mix/lib/src/modifiers/mouse_cursor_modifier.dart
+++ b/packages/mix/lib/src/modifiers/mouse_cursor_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -10,7 +10,7 @@ import '../core/utility.dart';
 /// Modifier that applies a mouse cursor to its child.
 ///
 /// Wraps the child in a [MouseRegion] widget with the specified cursor.
-class MouseCursorModifier extends Modifier<MouseCursorModifier>
+class MouseCursorModifier extends WidgetModifier<MouseCursorModifier>
     with Diagnosticable {
   final MouseCursor? mouseCursor;
 

--- a/packages/mix/lib/src/modifiers/opacity_modifier.dart
+++ b/packages/mix/lib/src/modifiers/opacity_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../theme/tokens/mix_token.dart';
 /// Modifier that applies opacity to its child.
 ///
 /// Wraps the child in an [Opacity] widget with the specified opacity value.
-final class OpacityModifier extends Modifier<OpacityModifier>
+final class OpacityModifier extends WidgetModifier<OpacityModifier>
     with Diagnosticable {
   /// Opacity value between 0.0 and 1.0 (inclusive).
   final double opacity;

--- a/packages/mix/lib/src/modifiers/padding_modifier.dart
+++ b/packages/mix/lib/src/modifiers/padding_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -12,7 +12,7 @@ import '../properties/layout/edge_insets_geometry_util.dart';
 /// Modifier that adds padding around its child.
 ///
 /// Wraps the child in a [Padding] widget with the specified padding.
-final class PaddingModifier extends Modifier<PaddingModifier>
+final class PaddingModifier extends WidgetModifier<PaddingModifier>
     with Diagnosticable {
   final EdgeInsetsGeometry padding;
 

--- a/packages/mix/lib/src/modifiers/rotated_box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/rotated_box_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -10,7 +10,7 @@ import '../core/utility.dart';
 /// Modifier that rotates its child by quarter turns.
 ///
 /// Wraps the child in a [RotatedBox] widget with the specified quarter turns.
-final class RotatedBoxModifier extends Modifier<RotatedBoxModifier>
+final class RotatedBoxModifier extends WidgetModifier<RotatedBoxModifier>
     with Diagnosticable {
   final int quarterTurns;
   const RotatedBoxModifier([int? quarterTurns])

--- a/packages/mix/lib/src/modifiers/scroll_view_modifier.dart
+++ b/packages/mix/lib/src/modifiers/scroll_view_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -12,7 +12,7 @@ import '../properties/layout/edge_insets_geometry_util.dart';
 /// Modifier that applies scroll view properties to its child.
 ///
 /// Wraps the child in a scrollable widget with the specified properties.
-final class ScrollViewModifier extends Modifier<ScrollViewModifier>
+final class ScrollViewModifier extends WidgetModifier<ScrollViewModifier>
     with Diagnosticable {
   final Axis? scrollDirection;
   final bool? reverse;

--- a/packages/mix/lib/src/modifiers/shader_mask_modifier.dart
+++ b/packages/mix/lib/src/modifiers/shader_mask_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -10,7 +10,7 @@ import '../core/utility.dart';
 /// Modifier that applies a shader mask to its child.
 ///
 /// Wraps the child in a [ShaderMask] widget with the specified shader callback and blend mode.
-final class ShaderMaskModifier extends Modifier<ShaderMaskModifier>
+final class ShaderMaskModifier extends WidgetModifier<ShaderMaskModifier>
     with Diagnosticable {
   final ShaderCallback shaderCallback;
   final BlendMode blendMode;

--- a/packages/mix/lib/src/modifiers/sized_box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/sized_box_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -10,7 +10,7 @@ import '../core/utility.dart';
 /// Modifier that constrains its child to a specific size.
 ///
 /// Wraps the child in a [SizedBox] widget with the specified width and height.
-final class SizedBoxModifier extends Modifier<SizedBoxModifier>
+final class SizedBoxModifier extends WidgetModifier<SizedBoxModifier>
     with Diagnosticable {
   final double? width;
   final double? height;

--- a/packages/mix/lib/src/modifiers/transform_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_modifier.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -12,7 +12,7 @@ import '../core/utility.dart';
 /// Modifier that applies matrix transformations to its child.
 ///
 /// Wraps the child in a [Transform] widget with the specified matrix and alignment.
-final class TransformModifier extends Modifier<TransformModifier>
+final class TransformModifier extends WidgetModifier<TransformModifier>
     with Diagnosticable {
   final Matrix4 transform;
   final Alignment? alignment;

--- a/packages/mix/lib/src/modifiers/visibility_modifier.dart
+++ b/packages/mix/lib/src/modifiers/visibility_modifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
@@ -11,7 +11,7 @@ import '../theme/tokens/mix_token.dart';
 /// Modifier that controls the visibility of its child.
 ///
 /// Wraps the child in a [Visibility] widget to show or hide it while maintaining layout space.
-final class VisibilityModifier extends Modifier<VisibilityModifier>
+final class VisibilityModifier extends WidgetModifier<VisibilityModifier>
     with Diagnosticable {
   /// Whether the child widget should be visible.
   final bool visible;

--- a/packages/mix/lib/src/modifiers/widget_modifier_config.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifier_config.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../core/internal/compare_mixin.dart';
-import '../core/modifier.dart';
+import '../core/widget_modifier.dart';
 import '../core/style.dart';
 import '../properties/layout/edge_insets_geometry_mix.dart';
 import '../properties/painting/border_radius_mix.dart';
@@ -34,65 +34,65 @@ import 'visibility_modifier.dart';
 /// Provides factory methods for creating and combining modifiers that can be
 /// applied to widgets. Modifiers are applied in a specific order and can be
 /// merged together using the Mix framework's accumulation strategy.
-final class ModifierConfig with Equatable {
+final class WidgetModifierConfig with Equatable {
   final List<Type>? $orderOfModifiers;
   final List<ModifierMix>? $modifiers;
 
-  const ModifierConfig({
+  const WidgetModifierConfig({
     List<ModifierMix>? modifiers,
     List<Type>? orderOfModifiers,
   }) : $modifiers = modifiers,
        $orderOfModifiers = orderOfModifiers;
 
-  factory ModifierConfig.modifier(ModifierMix value) {
-    return ModifierConfig(modifiers: [value]);
+  factory WidgetModifierConfig.modifier(ModifierMix value) {
+    return WidgetModifierConfig(modifiers: [value]);
   }
 
-  factory ModifierConfig.modifiers(List<ModifierMix> value) {
-    return ModifierConfig(modifiers: value);
+  factory WidgetModifierConfig.modifiers(List<ModifierMix> value) {
+    return WidgetModifierConfig(modifiers: value);
   }
 
-  factory ModifierConfig.orderOfModifiers(List<Type> value) {
-    return ModifierConfig(orderOfModifiers: value);
+  factory WidgetModifierConfig.orderOfModifiers(List<Type> value) {
+    return WidgetModifierConfig(orderOfModifiers: value);
   }
-  factory ModifierConfig.reset() {
-    return ModifierConfig.modifier(const ResetModifierMix());
-  }
-
-  factory ModifierConfig.opacity(double opacity) {
-    return ModifierConfig.modifier(OpacityModifierMix(opacity: opacity));
+  factory WidgetModifierConfig.reset() {
+    return WidgetModifierConfig.modifier(const ResetModifierMix());
   }
 
-  factory ModifierConfig.aspectRatio(double aspectRatio) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.opacity(double opacity) {
+    return WidgetModifierConfig.modifier(OpacityModifierMix(opacity: opacity));
+  }
+
+  factory WidgetModifierConfig.aspectRatio(double aspectRatio) {
+    return WidgetModifierConfig.modifier(
       AspectRatioModifierMix(aspectRatio: aspectRatio),
     );
   }
 
-  factory ModifierConfig.clipOval({
+  factory WidgetModifierConfig.clipOval({
     CustomClipper<Rect>? clipper,
     Clip? clipBehavior,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       ClipOvalModifierMix(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  factory ModifierConfig.clipRect({
+  factory WidgetModifierConfig.clipRect({
     CustomClipper<Rect>? clipper,
     Clip? clipBehavior,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       ClipRectModifierMix(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  factory ModifierConfig.clipRRect({
+  factory WidgetModifierConfig.clipRRect({
     BorderRadiusGeometryMix? borderRadius,
     CustomClipper<RRect>? clipper,
     Clip? clipBehavior,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       ClipRRectModifierMix(
         borderRadius: borderRadius,
         clipper: clipper,
@@ -101,35 +101,35 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.clipPath({
+  factory WidgetModifierConfig.clipPath({
     CustomClipper<Path>? clipper,
     Clip? clipBehavior,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       ClipPathModifierMix(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  factory ModifierConfig.clipTriangle({Clip? clipBehavior}) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.clipTriangle({Clip? clipBehavior}) {
+    return WidgetModifierConfig.modifier(
       ClipTriangleModifierMix(clipBehavior: clipBehavior),
     );
   }
 
-  factory ModifierConfig.transform({
+  factory WidgetModifierConfig.transform({
     Matrix4? transform,
     Alignment alignment = Alignment.center,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       TransformModifierMix(transform: transform, alignment: alignment),
     );
   }
 
-  factory ModifierConfig.shaderMask({
+  factory WidgetModifierConfig.shaderMask({
     required ShaderCallbackBuilder shaderCallback,
     BlendMode blendMode = BlendMode.modulate,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       ShaderMaskModifierMix(
         shaderCallback: shaderCallback.callback,
         blendMode: blendMode,
@@ -138,26 +138,26 @@ final class ModifierConfig with Equatable {
   }
 
   /// Scale using transform.
-  factory ModifierConfig.scale(
+  factory WidgetModifierConfig.scale(
     double scale, {
     Alignment alignment = Alignment.center,
   }) {
-    return ModifierConfig.transform(
+    return WidgetModifierConfig.transform(
       transform: Matrix4.diagonal3Values(scale, scale, 1.0),
       alignment: alignment,
     );
   }
 
-  factory ModifierConfig.visibility(bool visible) {
-    return ModifierConfig.modifier(VisibilityModifierMix(visible: visible));
+  factory WidgetModifierConfig.visibility(bool visible) {
+    return WidgetModifierConfig.modifier(VisibilityModifierMix(visible: visible));
   }
 
-  factory ModifierConfig.align({
+  factory WidgetModifierConfig.align({
     AlignmentGeometry? alignment,
     double? widthFactor,
     double? heightFactor,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       AlignModifierMix(
         alignment: alignment,
         widthFactor: widthFactor,
@@ -166,40 +166,40 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.padding(EdgeInsetsGeometryMix? padding) {
-    return ModifierConfig.modifier(PaddingModifierMix(padding: padding));
+  factory WidgetModifierConfig.padding(EdgeInsetsGeometryMix? padding) {
+    return WidgetModifierConfig.modifier(PaddingModifierMix(padding: padding));
   }
 
-  factory ModifierConfig.sizedBox({double? width, double? height}) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.sizedBox({double? width, double? height}) {
+    return WidgetModifierConfig.modifier(
       SizedBoxModifierMix(width: width, height: height),
     );
   }
 
-  factory ModifierConfig.flexible({int? flex, FlexFit? fit}) {
-    return ModifierConfig.modifier(FlexibleModifierMix(flex: flex, fit: fit));
+  factory WidgetModifierConfig.flexible({int? flex, FlexFit? fit}) {
+    return WidgetModifierConfig.modifier(FlexibleModifierMix(flex: flex, fit: fit));
   }
 
-  factory ModifierConfig.rotatedBox(int quarterTurns) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.rotatedBox(int quarterTurns) {
+    return WidgetModifierConfig.modifier(
       RotatedBoxModifierMix(quarterTurns: quarterTurns),
     );
   }
 
-  factory ModifierConfig.intrinsicHeight() {
-    return ModifierConfig.modifier(const IntrinsicHeightModifierMix());
+  factory WidgetModifierConfig.intrinsicHeight() {
+    return WidgetModifierConfig.modifier(const IntrinsicHeightModifierMix());
   }
 
-  factory ModifierConfig.intrinsicWidth() {
-    return ModifierConfig.modifier(const IntrinsicWidthModifierMix());
+  factory WidgetModifierConfig.intrinsicWidth() {
+    return WidgetModifierConfig.modifier(const IntrinsicWidthModifierMix());
   }
 
-  factory ModifierConfig.fractionallySizedBox({
+  factory WidgetModifierConfig.fractionallySizedBox({
     double? widthFactor,
     double? heightFactor,
     AlignmentGeometry? alignment,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       FractionallySizedBoxModifierMix(
         widthFactor: widthFactor,
         heightFactor: heightFactor,
@@ -208,7 +208,7 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.defaultTextStyle({
+  factory WidgetModifierConfig.defaultTextStyle({
     TextStyleMix? style,
     TextAlign? textAlign,
     bool? softWrap,
@@ -217,7 +217,7 @@ final class ModifierConfig with Equatable {
     TextWidthBasis? textWidthBasis,
     TextHeightBehaviorMix? textHeightBehavior,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       DefaultTextStyleModifierMix(
         style: style,
         textAlign: textAlign,
@@ -230,8 +230,8 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.defaultText(TextStyler textMix) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.defaultText(TextStyler textMix) {
+    return WidgetModifierConfig.modifier(
       DefaultTextStyleModifierMix.create(
         style: textMix.$style,
         textAlign: textMix.$textAlign,
@@ -244,8 +244,8 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.defaultIcon(IconStyler iconMix) {
-    return ModifierConfig.modifier(
+  factory WidgetModifierConfig.defaultIcon(IconStyler iconMix) {
+    return WidgetModifierConfig.modifier(
       IconThemeModifierMix.create(
         color: iconMix.$color,
         size: iconMix.$size,
@@ -259,7 +259,7 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.iconTheme({
+  factory WidgetModifierConfig.iconTheme({
     Color? color,
     double? size,
     double? fill,
@@ -270,7 +270,7 @@ final class ModifierConfig with Equatable {
     List<Shadow>? shadows,
     bool? applyTextScaling,
   }) {
-    return ModifierConfig.modifier(
+    return WidgetModifierConfig.modifier(
       IconThemeModifierMix(
         color: color,
         size: size,
@@ -285,8 +285,8 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  factory ModifierConfig.box(BoxStyler spec) {
-    return ModifierConfig.modifier(BoxModifierMix(spec));
+  factory WidgetModifierConfig.box(BoxStyler spec) {
+    return WidgetModifierConfig.modifier(BoxModifierMix(spec));
   }
 
   void _mergeWithReset(
@@ -305,7 +305,7 @@ final class ModifierConfig with Equatable {
 
   /// Orders modifiers according to the specified order or default order.
   @visibleForTesting
-  List<Modifier> reorderModifiers(List<Modifier> modifiers) {
+  List<WidgetModifier> reorderModifiers(List<WidgetModifier> modifiers) {
     if (modifiers.isEmpty) return modifiers;
 
     final orderOfModifiers = {
@@ -317,7 +317,7 @@ final class ModifierConfig with Equatable {
       ...modifiers.map((e) => e.runtimeType),
     }.toList();
 
-    final orderedSpecs = <Modifier>[];
+    final orderedSpecs = <WidgetModifier>[];
 
     for (final modifierType in orderOfModifiers) {
       // Find and add modifiers matching this type
@@ -332,53 +332,53 @@ final class ModifierConfig with Equatable {
     return orderedSpecs;
   }
 
-  ModifierConfig shaderMask({
+  WidgetModifierConfig shaderMask({
     required ShaderCallbackBuilder shaderCallback,
     BlendMode blendMode = BlendMode.modulate,
   }) {
     return merge(
-      ModifierConfig.shaderMask(
+      WidgetModifierConfig.shaderMask(
         shaderCallback: shaderCallback,
         blendMode: blendMode,
       ),
     );
   }
 
-  ModifierConfig scale(double scale, {Alignment alignment = Alignment.center}) {
-    return merge(ModifierConfig.scale(scale, alignment: alignment));
+  WidgetModifierConfig scale(double scale, {Alignment alignment = Alignment.center}) {
+    return merge(WidgetModifierConfig.scale(scale, alignment: alignment));
   }
 
-  ModifierConfig opacity(double value) {
-    return merge(ModifierConfig.opacity(value));
+  WidgetModifierConfig opacity(double value) {
+    return merge(WidgetModifierConfig.opacity(value));
   }
 
-  ModifierConfig aspectRatio(double value) {
-    return merge(ModifierConfig.aspectRatio(value));
+  WidgetModifierConfig aspectRatio(double value) {
+    return merge(WidgetModifierConfig.aspectRatio(value));
   }
 
-  ModifierConfig clipOval({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipOval({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return merge(
-      ModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  ModifierConfig clipRect({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipRect({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return merge(
-      ModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  ModifierConfig modifiers(List<ModifierMix> value) {
-    return merge(ModifierConfig.modifiers(value));
+  WidgetModifierConfig modifiers(List<ModifierMix> value) {
+    return merge(WidgetModifierConfig.modifiers(value));
   }
 
-  ModifierConfig clipRRect({
+  WidgetModifierConfig clipRRect({
     BorderRadiusGeometryMix? borderRadius,
     CustomClipper<RRect>? clipper,
     Clip? clipBehavior,
   }) {
     return merge(
-      ModifierConfig.clipRRect(
+      WidgetModifierConfig.clipRRect(
         borderRadius: borderRadius,
         clipper: clipper,
         clipBehavior: clipBehavior,
@@ -386,36 +386,36 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  ModifierConfig clipPath({CustomClipper<Path>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipPath({CustomClipper<Path>? clipper, Clip? clipBehavior}) {
     return merge(
-      ModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
-  ModifierConfig clipTriangle({Clip? clipBehavior}) {
-    return merge(ModifierConfig.clipTriangle(clipBehavior: clipBehavior));
+  WidgetModifierConfig clipTriangle({Clip? clipBehavior}) {
+    return merge(WidgetModifierConfig.clipTriangle(clipBehavior: clipBehavior));
   }
 
-  ModifierConfig transform({
+  WidgetModifierConfig transform({
     Matrix4? transform,
     Alignment alignment = Alignment.center,
   }) {
     return merge(
-      ModifierConfig.transform(transform: transform, alignment: alignment),
+      WidgetModifierConfig.transform(transform: transform, alignment: alignment),
     );
   }
 
-  ModifierConfig visibility(bool visible) {
-    return merge(ModifierConfig.visibility(visible));
+  WidgetModifierConfig visibility(bool visible) {
+    return merge(WidgetModifierConfig.visibility(visible));
   }
 
-  ModifierConfig align({
+  WidgetModifierConfig align({
     AlignmentGeometry? alignment,
     double? widthFactor,
     double? heightFactor,
   }) {
     return merge(
-      ModifierConfig.align(
+      WidgetModifierConfig.align(
         alignment: alignment,
         widthFactor: widthFactor,
         heightFactor: heightFactor,
@@ -423,37 +423,37 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  ModifierConfig padding(EdgeInsetsGeometryMix? padding) {
-    return merge(ModifierConfig.padding(padding));
+  WidgetModifierConfig padding(EdgeInsetsGeometryMix? padding) {
+    return merge(WidgetModifierConfig.padding(padding));
   }
 
-  ModifierConfig sizedBox({double? width, double? height}) {
-    return merge(ModifierConfig.sizedBox(width: width, height: height));
+  WidgetModifierConfig sizedBox({double? width, double? height}) {
+    return merge(WidgetModifierConfig.sizedBox(width: width, height: height));
   }
 
-  ModifierConfig flexible({int? flex, FlexFit? fit}) {
-    return merge(ModifierConfig.flexible(flex: flex, fit: fit));
+  WidgetModifierConfig flexible({int? flex, FlexFit? fit}) {
+    return merge(WidgetModifierConfig.flexible(flex: flex, fit: fit));
   }
 
-  ModifierConfig rotatedBox(int quarterTurns) {
-    return merge(ModifierConfig.rotatedBox(quarterTurns));
+  WidgetModifierConfig rotatedBox(int quarterTurns) {
+    return merge(WidgetModifierConfig.rotatedBox(quarterTurns));
   }
 
-  ModifierConfig intrinsicHeight() {
-    return merge(ModifierConfig.intrinsicHeight());
+  WidgetModifierConfig intrinsicHeight() {
+    return merge(WidgetModifierConfig.intrinsicHeight());
   }
 
-  ModifierConfig intrinsicWidth() {
-    return merge(ModifierConfig.intrinsicWidth());
+  WidgetModifierConfig intrinsicWidth() {
+    return merge(WidgetModifierConfig.intrinsicWidth());
   }
 
-  ModifierConfig fractionallySizedBox({
+  WidgetModifierConfig fractionallySizedBox({
     double? widthFactor,
     double? heightFactor,
     AlignmentGeometry? alignment,
   }) {
     return merge(
-      ModifierConfig.fractionallySizedBox(
+      WidgetModifierConfig.fractionallySizedBox(
         widthFactor: widthFactor,
         heightFactor: heightFactor,
         alignment: alignment,
@@ -461,7 +461,7 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  ModifierConfig defaultTextStyle({
+  WidgetModifierConfig defaultTextStyle({
     TextStyleMix? style,
     TextAlign? textAlign,
     bool? softWrap,
@@ -471,7 +471,7 @@ final class ModifierConfig with Equatable {
     TextHeightBehaviorMix? textHeightBehavior,
   }) {
     return merge(
-      ModifierConfig.defaultTextStyle(
+      WidgetModifierConfig.defaultTextStyle(
         style: style,
         textAlign: textAlign,
         softWrap: softWrap,
@@ -483,22 +483,22 @@ final class ModifierConfig with Equatable {
     );
   }
 
-  ModifierConfig defaultText(TextStyler textMix) {
-    return merge(ModifierConfig.defaultText(textMix));
+  WidgetModifierConfig defaultText(TextStyler textMix) {
+    return merge(WidgetModifierConfig.defaultText(textMix));
   }
 
-  ModifierConfig modifier(ModifierMix value) {
-    return merge(ModifierConfig.modifier(value));
+  WidgetModifierConfig modifier(ModifierMix value) {
+    return merge(WidgetModifierConfig.modifier(value));
   }
 
-  ModifierConfig orderOfModifiers(List<Type> value) {
-    return merge(ModifierConfig.orderOfModifiers(value));
+  WidgetModifierConfig orderOfModifiers(List<Type> value) {
+    return merge(WidgetModifierConfig.orderOfModifiers(value));
   }
 
-  ModifierConfig merge(ModifierConfig? other) {
+  WidgetModifierConfig merge(WidgetModifierConfig? other) {
     if (other == null) return this;
 
-    return ModifierConfig(
+    return WidgetModifierConfig(
       modifiers: mergeModifierLists($modifiers, other.$modifiers),
       orderOfModifiers: (other.$orderOfModifiers?.isNotEmpty == true)
           ? other.$orderOfModifiers
@@ -526,16 +526,16 @@ final class ModifierConfig with Equatable {
   /// Resolves the modifiers into a properly ordered list ready for rendering.
   ///
   /// It's important to order the list before resolving to ensure the correct order of modifiers.
-  List<Modifier> resolve(BuildContext context) {
+  List<WidgetModifier> resolve(BuildContext context) {
     if ($modifiers == null || $modifiers!.isEmpty) return [];
 
     // Resolve each modifier attribute to its corresponding modifier spec
-    final resolvedModifiers = <Modifier>[];
+    final resolvedModifiers = <WidgetModifier>[];
     for (final attribute in $modifiers!) {
       final resolved = attribute.resolve(context);
       // Filter out reset specs so they never reach rendering
       if (resolved is! ResetModifier) {
-        resolvedModifiers.add(resolved as Modifier);
+        resolvedModifiers.add(resolved as WidgetModifier);
       }
     }
 
@@ -648,18 +648,18 @@ final defaultModifier = {
   OpacityModifier: OpacityModifier(),
 };
 
-class ModifierListTween extends Tween<List<Modifier>?> {
+class ModifierListTween extends Tween<List<WidgetModifier>?> {
   ModifierListTween({super.begin, super.end});
 
   @override
-  List<Modifier>? lerp(double t) {
-    List<Modifier>? lerpedModifiers;
+  List<WidgetModifier>? lerp(double t) {
+    List<WidgetModifier>? lerpedModifiers;
     if (end != null) {
       final thisModifiers = begin!;
       final otherModifiers = end!;
 
       // Create a map of modifiers by runtime type from the other list
-      final thisModifierMap = <Type, Modifier>{};
+      final thisModifierMap = <Type, WidgetModifier>{};
 
       for (final modifier in thisModifiers) {
         thisModifierMap[modifier.runtimeType] = modifier;
@@ -668,13 +668,13 @@ class ModifierListTween extends Tween<List<Modifier>?> {
       // Lerp each modifier from this list with its matching type from other
       lerpedModifiers = [];
       for (final modifier in otherModifiers) {
-        Modifier? thisModifier = thisModifierMap[modifier.runtimeType];
-        thisModifier ??= defaultModifier[modifier.runtimeType] as Modifier?;
+        WidgetModifier? thisModifier = thisModifierMap[modifier.runtimeType];
+        thisModifier ??= defaultModifier[modifier.runtimeType] as WidgetModifier?;
 
         if (thisModifier != null) {
           // Both have this modifier type, lerp them
           // We need to use dynamic dispatch here since lerp is type-specific
-          final lerpedModifier = thisModifier.lerp(modifier, t) as Modifier;
+          final lerpedModifier = thisModifier.lerp(modifier, t) as WidgetModifier;
           lerpedModifiers.add(lerpedModifier);
         } else {
           // Only this has the modifier, fade it out if t > 0.5

--- a/packages/mix/lib/src/modifiers/widget_modifier_util.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifier_util.dart
@@ -18,8 +18,8 @@ import 'sized_box_modifier.dart';
 import 'transform_modifier.dart';
 import 'visibility_modifier.dart';
 
-/// Provides utilities for applying modifiers to styles.
-final class ModifierUtility<T extends Style<Object?>>
+/// Provides utilities for applying widget modifiers to styles.
+final class WidgetModifierUtility<T extends Style<Object?>>
     extends MixUtility<T, ModifierMix> {
   /// Opacity modifier utility.
   late final opacity = OpacityModifierUtility<T>(utilityBuilder);
@@ -56,7 +56,7 @@ final class ModifierUtility<T extends Style<Object?>>
   /// Icon theme modifier utility.
   late final iconTheme = IconThemeModifierUtility<T>(utilityBuilder);
 
-  ModifierUtility(super.utilityBuilder);
+  WidgetModifierUtility(super.utilityBuilder);
 
   /// Scales the widget by the given [value].
   T scale(double value) => transform.scale(value);

--- a/packages/mix/lib/src/specs/box/box_mutable_style.dart
+++ b/packages/mix/lib/src/specs/box/box_mutable_style.dart
@@ -7,8 +7,8 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/layout/constraints_util.dart';
 import '../../properties/layout/edge_insets_geometry_util.dart';
 import '../../properties/painting/decoration_util.dart';
@@ -47,8 +47,8 @@ class BoxMutableStyler extends StyleMutableBuilder<BoxSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Convenience accessors for commonly used decoration properties.

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -6,7 +6,7 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/layout/constraints_mix.dart';
 import '../../properties/layout/edge_insets_geometry_mix.dart';
 import '../../properties/painting/border_mix.dart';
@@ -17,7 +17,7 @@ import '../../style/mixins/border_radius_style_mixin.dart';
 import '../../style/mixins/border_style_mixin.dart';
 import '../../style/mixins/constraint_style_mixin.dart';
 import '../../style/mixins/decoration_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/shadow_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
@@ -36,7 +36,7 @@ typedef BoxMix = BoxStyler;
 class BoxStyler extends Style<BoxSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<BoxStyler, BoxSpec>,
+        WidgetModifierStyleMixin<BoxStyler, BoxSpec>,
         VariantStyleMixin<BoxStyler, BoxSpec>,
         BorderStyleMixin<BoxStyler>,
         BorderRadiusStyleMixin<BoxStyler>,
@@ -90,7 +90,7 @@ class BoxStyler extends Style<BoxSpec>
     AlignmentGeometry? transformAlignment,
     Clip? clipBehavior,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<BoxSpec>>? variants,
   }) : this.create(
          alignment: Prop.maybe(alignment),
@@ -126,7 +126,7 @@ class BoxStyler extends Style<BoxSpec>
   }
 
   /// Modifier instance method
-  BoxStyler modifier(ModifierConfig value) {
+  BoxStyler modifier(WidgetModifierConfig value) {
     return merge(BoxStyler(modifier: value));
   }
 
@@ -176,7 +176,7 @@ class BoxStyler extends Style<BoxSpec>
 
   /// Mixin implementation
   @override
-  BoxStyler wrap(ModifierConfig value) {
+  BoxStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
@@ -6,8 +6,8 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../variants/variant.dart';
 import '../../variants/variant_util.dart';
 import 'flex_spec.dart';
@@ -43,8 +43,8 @@ class FlexMutableStyler extends StyleMutableBuilder<FlexSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Internal mutable state for accumulating flex styling properties.

--- a/packages/mix/lib/src/specs/flex/flex_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.dart
@@ -7,10 +7,10 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/flex_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'flex_spec.dart';
 import 'flex_mutable_style.dart';
@@ -28,7 +28,7 @@ typedef FlexMix = FlexStyler;
 class FlexStyler extends Style<FlexSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<FlexStyler, FlexSpec>,
+        WidgetModifierStyleMixin<FlexStyler, FlexSpec>,
         VariantStyleMixin<FlexStyler, FlexSpec>,
         FlexStyleMixin<FlexStyler>,
         AnimationStyleMixin<FlexSpec, FlexStyler> {
@@ -86,7 +86,7 @@ class FlexStyler extends Style<FlexSpec>
     )
     double? gap,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<FlexSpec>>? variants,
   }) : this.create(
          direction: Prop.maybe(direction),
@@ -130,7 +130,7 @@ class FlexStyler extends Style<FlexSpec>
     return merge(FlexStyler(spacing: value));
   }
 
-  FlexStyler modifier(ModifierConfig value) {
+  FlexStyler modifier(WidgetModifierConfig value) {
     return merge(FlexStyler(modifier: value));
   }
 
@@ -231,7 +231,7 @@ class FlexStyler extends Style<FlexSpec>
   }
 
   @override
-  FlexStyler wrap(ModifierConfig value) {
+  FlexStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
@@ -7,8 +7,8 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/layout/constraints_util.dart';
 import '../../properties/layout/edge_insets_geometry_util.dart';
 import '../../properties/painting/decoration_util.dart';
@@ -47,8 +47,8 @@ class FlexBoxMutableStyler extends StyleMutableBuilder<FlexBoxSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Container decoration convenience accessors.

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -6,7 +6,7 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/layout/constraints_mix.dart';
 import '../../properties/layout/edge_insets_geometry_mix.dart';
 import '../../properties/painting/border_mix.dart';
@@ -17,7 +17,7 @@ import '../../style/mixins/border_style_mixin.dart';
 import '../../style/mixins/constraint_style_mixin.dart';
 import '../../style/mixins/decoration_style_mixin.dart';
 import '../../style/mixins/flex_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/shadow_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
@@ -41,7 +41,7 @@ typedef FlexBoxMix = FlexBoxStyler;
 class FlexBoxStyler extends Style<FlexBoxSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<FlexBoxStyler, FlexBoxSpec>,
+        WidgetModifierStyleMixin<FlexBoxStyler, FlexBoxSpec>,
         VariantStyleMixin<FlexBoxStyler, FlexBoxSpec>,
         BorderStyleMixin<FlexBoxStyler>,
         BorderRadiusStyleMixin<FlexBoxStyler>,
@@ -78,7 +78,7 @@ class FlexBoxStyler extends Style<FlexBoxSpec>
     double? spacing,
     // Style properties
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<FlexBoxSpec>>? variants,
   }) : this.create(
          box: Prop.maybeMix(
@@ -157,7 +157,7 @@ class FlexBoxStyler extends Style<FlexBoxSpec>
     return merge(FlexBoxStyler(spacing: value));
   }
 
-  FlexBoxStyler modifier(ModifierConfig value) {
+  FlexBoxStyler modifier(WidgetModifierConfig value) {
     return merge(FlexBoxStyler(modifier: value));
   }
 
@@ -209,7 +209,7 @@ class FlexBoxStyler extends Style<FlexBoxSpec>
 
   /// Modifier instance method
   @override
-  FlexBoxStyler wrap(ModifierConfig value) {
+  FlexBoxStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
@@ -6,8 +6,8 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
 import '../../properties/painting/shadow_mix.dart';
 import '../../properties/painting/shadow_util.dart';
@@ -38,8 +38,8 @@ class IconMutableStyler extends StyleMutableBuilder<IconSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Internal mutable state for accumulating icon styling properties.

--- a/packages/mix/lib/src/specs/icon/icon_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.dart
@@ -6,10 +6,10 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/painting/shadow_mix.dart';
 import '../../style/mixins/animation_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'icon_spec.dart';
 import 'icon_mutable_style.dart';
@@ -20,7 +20,7 @@ typedef IconMix = IconStyler;
 class IconStyler extends Style<IconSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<IconStyler, IconSpec>,
+        WidgetModifierStyleMixin<IconStyler, IconSpec>,
         VariantStyleMixin<IconStyler, IconSpec>,
         AnimationStyleMixin<IconSpec, IconStyler> {
   final Prop<Color>? $color;
@@ -83,7 +83,7 @@ class IconStyler extends Style<IconSpec>
     BlendMode? blendMode,
     IconData? icon,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<IconSpec>>? variants,
   }) : this.create(
          color: Prop.maybe(color),
@@ -184,7 +184,7 @@ class IconStyler extends Style<IconSpec>
     return StyledIcon(icon: icon, semanticLabel: semanticLabel, style: this);
   }
 
-  IconStyler modifier(ModifierConfig value) {
+  IconStyler modifier(WidgetModifierConfig value) {
     return merge(IconStyler(modifier: value));
   }
 
@@ -269,7 +269,7 @@ class IconStyler extends Style<IconSpec>
   }
 
   @override
-  IconStyler wrap(ModifierConfig value) {
+  IconStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/image/image_mutable_style.dart
+++ b/packages/mix/lib/src/specs/image/image_mutable_style.dart
@@ -6,8 +6,8 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
 import '../../variants/variant.dart';
 import '../../variants/variant_util.dart';
@@ -44,8 +44,8 @@ class ImageMutableStyler extends StyleMutableBuilder<ImageSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Internal mutable state for accumulating image styling properties.

--- a/packages/mix/lib/src/specs/image/image_style.dart
+++ b/packages/mix/lib/src/specs/image/image_style.dart
@@ -6,8 +6,8 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'image_spec.dart';
 import 'image_mutable_style.dart';
@@ -18,7 +18,7 @@ typedef ImageMix = ImageStyler;
 class ImageStyler extends Style<ImageSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<ImageStyler, ImageSpec>,
+        WidgetModifierStyleMixin<ImageStyler, ImageSpec>,
         VariantStyleMixin<ImageStyler, ImageSpec> {
   final Prop<ImageProvider<Object>>? $image;
   final Prop<double>? $width;
@@ -88,7 +88,7 @@ class ImageStyler extends Style<ImageSpec>
     bool? isAntiAlias,
     bool? matchTextDirection,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<ImageSpec>>? variants,
   }) : this.create(
          image: Prop.maybe(image),
@@ -209,7 +209,7 @@ class ImageStyler extends Style<ImageSpec>
     return merge(ImageStyler(matchTextDirection: value));
   }
 
-  ImageStyler modifier(ModifierConfig value) {
+  ImageStyler modifier(WidgetModifierConfig value) {
     return merge(ImageStyler(modifier: value));
   }
 
@@ -302,7 +302,7 @@ class ImageStyler extends Style<ImageSpec>
   }
 
   @override
-  ImageStyler wrap(ModifierConfig value) {
+  ImageStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/stack/stack_box_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_box_style.dart
@@ -6,7 +6,7 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/layout/constraints_mix.dart';
 import '../../properties/layout/edge_insets_geometry_mix.dart';
 import '../../properties/painting/border_radius_mix.dart';
@@ -106,7 +106,7 @@ class StackBoxStyler extends Style<ZBoxSpec>
     return merge(StackBoxStyler(animation: animation));
   }
 
-  StackBoxStyler modifier(ModifierConfig value) {
+  StackBoxStyler modifier(WidgetModifierConfig value) {
     return merge(StackBoxStyler(modifier: value));
   }
 
@@ -292,7 +292,7 @@ class StackBoxMutableStyler {
     TextDirection? textDirection,
     Clip? stackClipBehavior,
     // Style properties
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     AnimationConfig? animation,
     List<VariantStyle<ZBoxSpec>>? variants,
   }) {

--- a/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
@@ -7,8 +7,8 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../variants/variant.dart';
 import '../../variants/variant_util.dart';
 import 'stack_spec.dart';
@@ -36,8 +36,8 @@ class StackMutableStyler extends StyleMutableBuilder<StackSpec>
     (v) => mutable.variants([v]),
   );
 
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   /// Internal mutable state for accumulating stack styling properties.

--- a/packages/mix/lib/src/specs/stack/stack_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.dart
@@ -6,9 +6,9 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../style/mixins/animation_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'stack_spec.dart';
 import 'stack_mutable_style.dart';
@@ -25,7 +25,7 @@ typedef StackMix = StackStyler;
 class StackStyler extends Style<StackSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<StackStyler, StackSpec>,
+        WidgetModifierStyleMixin<StackStyler, StackSpec>,
         VariantStyleMixin<StackStyler, StackSpec>,
         AnimationStyleMixin<StackSpec, StackStyler> {
   final Prop<AlignmentGeometry>? $alignment;
@@ -52,7 +52,7 @@ class StackStyler extends Style<StackSpec>
     TextDirection? textDirection,
     Clip? clipBehavior,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<StackSpec>>? variants,
   }) : this.create(
          alignment: Prop.maybe(alignment),
@@ -90,7 +90,7 @@ class StackStyler extends Style<StackSpec>
     return merge(StackStyler(clipBehavior: value));
   }
 
-  StackStyler modifier(ModifierConfig value) {
+  StackStyler modifier(WidgetModifierConfig value) {
     return merge(StackStyler(modifier: value));
   }
 
@@ -147,7 +147,7 @@ class StackStyler extends Style<StackSpec>
   }
 
   @override
-  StackStyler wrap(ModifierConfig value) {
+  StackStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/specs/text/text_mutable_style.dart
+++ b/packages/mix/lib/src/specs/text/text_mutable_style.dart
@@ -6,8 +6,8 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
-import '../../modifiers/modifier_config.dart';
-import '../../modifiers/modifier_util.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
 import '../../properties/typography/strut_style_util.dart';
 import '../../properties/typography/text_height_behavior_util.dart';
@@ -51,8 +51,8 @@ class TextMutableStyler extends StyleMutableBuilder<TextSpec>
   late final on = OnContextVariantUtility<TextSpec, TextStyler>(
     (v) => mutable.variants([v]),
   );
-  late final wrap = ModifierUtility(
-    (prop) => mutable.wrap(ModifierConfig(modifiers: [prop])),
+  late final wrap = WidgetModifierUtility(
+    (prop) => mutable.wrap(WidgetModifierConfig(modifiers: [prop])),
   );
 
   // Direct access to commonly used style properties

--- a/packages/mix/lib/src/specs/text/text_style.dart
+++ b/packages/mix/lib/src/specs/text/text_style.dart
@@ -7,12 +7,12 @@ import '../../core/helpers.dart';
 import '../../core/prop.dart';
 import '../../core/style.dart';
 import '../../core/style_spec.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/typography/strut_style_mix.dart';
 import '../../properties/typography/text_height_behavior_mix.dart';
 import '../../properties/typography/text_style_mix.dart';
 import '../../style/mixins/animation_style_mixin.dart';
-import '../../style/mixins/modifier_style_mixin.dart';
+import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/text_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import 'text_spec.dart';
@@ -31,7 +31,7 @@ typedef TextMix = TextStyler;
 class TextStyler extends Style<TextSpec>
     with
         Diagnosticable,
-        ModifierStyleMixin<TextStyler, TextSpec>,
+        WidgetModifierStyleMixin<TextStyler, TextSpec>,
         VariantStyleMixin<TextStyler, TextSpec>,
         TextStyleMixin<TextStyler>,
         AnimationStyleMixin<TextSpec, TextStyler> {
@@ -99,7 +99,7 @@ class TextStyler extends Style<TextSpec>
     String? semanticsLabel,
     Locale? locale,
     AnimationConfig? animation,
-    ModifierConfig? modifier,
+    WidgetModifierConfig? modifier,
     List<VariantStyle<TextSpec>>? variants,
   }) : this.create(
          overflow: Prop.maybe(overflow),
@@ -235,7 +235,7 @@ class TextStyler extends Style<TextSpec>
     );
   }
 
-  TextStyler modifier(ModifierConfig value) {
+  TextStyler modifier(WidgetModifierConfig value) {
     return merge(TextStyler(modifier: value));
   }
 
@@ -345,7 +345,7 @@ class TextStyler extends Style<TextSpec>
   }
 
   @override
-  TextStyler wrap(ModifierConfig value) {
+  TextStyler wrap(WidgetModifierConfig value) {
     return modifier(value);
   }
 

--- a/packages/mix/lib/src/style/mixins/widget_modifier_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/widget_modifier_style_mixin.dart
@@ -2,52 +2,52 @@ import 'package:flutter/widgets.dart';
 
 import '../../core/spec.dart';
 import '../../core/style.dart';
-import '../../modifiers/modifier_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/mouse_cursor_modifier.dart';
 import '../../properties/layout/edge_insets_geometry_mix.dart';
 import '../../properties/painting/border_radius_mix.dart';
 import '../../properties/typography/text_style_mix.dart';
 import '../../specs/box/box_style.dart';
 
-/// Provides convenient modifier styling methods for spec attributes.
-mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
-  /// Applies the given [value] modifier configuration.
-  T wrap(ModifierConfig value);
+/// Provides convenient widget modifier styling methods for spec attributes.
+mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
+  /// Applies the given [value] widget modifier configuration.
+  T wrap(WidgetModifierConfig value);
 
   /// Wraps the widget with an opacity modifier.
   T wrapOpacity(double opacity) {
-    return wrap(ModifierConfig.opacity(opacity));
+    return wrap(WidgetModifierConfig.opacity(opacity));
   }
 
   /// Wraps the widget with a padding modifier.
   T wrapPadding(EdgeInsetsGeometryMix padding) {
-    return wrap(ModifierConfig.padding(padding));
+    return wrap(WidgetModifierConfig.padding(padding));
   }
 
   /// Wraps the widget with a clip oval modifier.
   T wrapClipOval({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return wrap(
-      ModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
   /// Wraps the widget with a clip rect modifier.
   T wrapClipRect({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return wrap(
-      ModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
   /// Wraps the widget with a clip path modifier.
   T wrapClipPath({CustomClipper<Path>? clipper, Clip? clipBehavior}) {
     return wrap(
-      ModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
     );
   }
 
   /// Wraps the widget with a clip triangle modifier.
   T wrapClipTriangle({Clip? clipBehavior}) {
-    return wrap(ModifierConfig.clipTriangle(clipBehavior: clipBehavior));
+    return wrap(WidgetModifierConfig.clipTriangle(clipBehavior: clipBehavior));
   }
 
   /// Wraps the widget with a clip rounded rectangle modifier.
@@ -57,7 +57,7 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
     Clip? clipBehavior,
   }) {
     return wrap(
-      ModifierConfig.clipRRect(
+      WidgetModifierConfig.clipRRect(
         borderRadius: BorderRadiusMix.value(borderRadius),
         clipper: clipper,
         clipBehavior: clipBehavior,
@@ -67,28 +67,28 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
 
   /// Wraps the widget with a visibility modifier.
   T wrapVisibility(bool visible) {
-    return wrap(ModifierConfig.visibility(visible));
+    return wrap(WidgetModifierConfig.visibility(visible));
   }
 
   /// Wraps the widget with an aspect ratio modifier.
   T wrapAspectRatio(double aspectRatio) {
-    return wrap(ModifierConfig.aspectRatio(aspectRatio));
+    return wrap(WidgetModifierConfig.aspectRatio(aspectRatio));
   }
 
   /// Wraps the widget with a flexible modifier.
   T wrapFlexible({int flex = 1, FlexFit fit = FlexFit.loose}) {
-    return wrap(ModifierConfig.flexible(flex: flex, fit: fit));
+    return wrap(WidgetModifierConfig.flexible(flex: flex, fit: fit));
   }
 
   /// Wraps the widget with an expanded modifier.
   T wrapExpanded({int flex = 1}) {
-    return wrap(ModifierConfig.flexible(flex: flex, fit: FlexFit.tight));
+    return wrap(WidgetModifierConfig.flexible(flex: flex, fit: FlexFit.tight));
   }
 
   /// Wraps the widget with a scale transform modifier.
   T wrapScale(double scale, {Alignment alignment = Alignment.center}) {
     return wrap(
-      ModifierConfig.transform(
+      WidgetModifierConfig.transform(
         transform: Matrix4.diagonal3Values(scale, scale, 1.0),
         alignment: alignment,
       ),
@@ -98,7 +98,7 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
   /// Wraps the widget with a rotate transform modifier.
   T wrapRotate(double angle, {Alignment alignment = Alignment.center}) {
     return wrap(
-      ModifierConfig.transform(
+      WidgetModifierConfig.transform(
         transform: Matrix4.rotationZ(angle),
         alignment: alignment,
       ),
@@ -108,27 +108,27 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
   /// Wraps the widget with a translate transform modifier.
   T wrapTranslate(double x, double y, [double z = 0.0]) {
     return wrap(
-      ModifierConfig.transform(transform: Matrix4.translationValues(x, y, z)),
+      WidgetModifierConfig.transform(transform: Matrix4.translationValues(x, y, z)),
     );
   }
 
   /// Wraps the widget with a transform modifier.
   T wrapTransform(Matrix4 transform, {Alignment alignment = Alignment.center}) {
     return wrap(
-      ModifierConfig.transform(transform: transform, alignment: alignment),
+      WidgetModifierConfig.transform(transform: transform, alignment: alignment),
     );
   }
 
   /// Wraps the widget with a sized box modifier.
   T wrapSizedBox({double? width, double? height}) {
-    return wrap(ModifierConfig.sizedBox(width: width, height: height));
+    return wrap(WidgetModifierConfig.sizedBox(width: width, height: height));
   }
 
   /// Wraps the widget with constrained box modifier.
   T wrapConstrainedBox(BoxConstraints constraints) {
     // Convert BoxConstraints to SizedBox for simplicity
     return wrap(
-      ModifierConfig.sizedBox(
+      WidgetModifierConfig.sizedBox(
         width: constraints.hasBoundedWidth ? constraints.maxWidth : null,
         height: constraints.hasBoundedHeight ? constraints.maxHeight : null,
       ),
@@ -137,12 +137,12 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
 
   /// Wraps the widget with an align modifier.
   T wrapAlign(AlignmentGeometry alignment) {
-    return wrap(ModifierConfig.align(alignment: alignment));
+    return wrap(WidgetModifierConfig.align(alignment: alignment));
   }
 
   /// Wraps the widget with a center modifier.
   T wrapCenter() {
-    return wrap(ModifierConfig.align(alignment: Alignment.center));
+    return wrap(WidgetModifierConfig.align(alignment: Alignment.center));
   }
 
   /// Wraps the widget with a fractionally sized box modifier.
@@ -152,7 +152,7 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
     AlignmentGeometry alignment = Alignment.center,
   }) {
     return wrap(
-      ModifierConfig.fractionallySizedBox(
+      WidgetModifierConfig.fractionallySizedBox(
         widthFactor: widthFactor,
         heightFactor: heightFactor,
         alignment: alignment,
@@ -162,36 +162,36 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
 
   /// Wraps the widget with a rotated box modifier.
   T wrapRotatedBox(int quarterTurns) {
-    return wrap(ModifierConfig.rotatedBox(quarterTurns));
+    return wrap(WidgetModifierConfig.rotatedBox(quarterTurns));
   }
 
   /// Wraps the widget with an intrinsic width modifier.
   T wrapIntrinsicWidth() {
-    return wrap(ModifierConfig.intrinsicWidth());
+    return wrap(WidgetModifierConfig.intrinsicWidth());
   }
 
   /// Wraps the widget with an intrinsic height modifier.
   T wrapIntrinsicHeight() {
-    return wrap(ModifierConfig.intrinsicHeight());
+    return wrap(WidgetModifierConfig.intrinsicHeight());
   }
 
   /// Wraps the widget with a mouse cursor modifier.
   T wrapMouseCursor(MouseCursor cursor) {
-    // Note: MouseCursorModifierMix needs to be wrapped in ModifierConfig
+    // Note: MouseCursorModifierMix needs to be wrapped in WidgetModifierConfig
     return wrap(
-      ModifierConfig.modifier(MouseCursorModifierMix(mouseCursor: cursor)),
+      WidgetModifierConfig.modifier(MouseCursorModifierMix(mouseCursor: cursor)),
     );
   }
 
   /// Wraps the widget with a default text style modifier.
   T wrapDefaultTextStyle(TextStyleMix style) {
-    return wrap(ModifierConfig.defaultTextStyle(style: style));
+    return wrap(WidgetModifierConfig.defaultTextStyle(style: style));
   }
 
   /// Wraps the widget with an icon theme modifier.
   T wrapIconTheme(IconThemeData data) {
     return wrap(
-      ModifierConfig.iconTheme(
+      WidgetModifierConfig.iconTheme(
         color: data.color,
         size: data.size,
         fill: data.fill,
@@ -212,7 +212,7 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
   //   BlendMode blendMode = BlendMode.modulate,
   // }) {
   //   return wrap(
-  //     ModifierConfig.shaderMask(
+  //     WidgetModifierConfig.shaderMask(
   //       shaderCallback: shaderCallback,
   //       blendMode: blendMode,
   //     ),
@@ -221,6 +221,6 @@ mixin ModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
 
   /// Wraps the widget with a box modifier.
   T wrapBox(BoxStyler spec) {
-    return wrap(ModifierConfig.box(spec));
+    return wrap(WidgetModifierConfig.box(spec));
   }
 }

--- a/packages/mix/test/helpers/override_modifiers_order.dart
+++ b/packages/mix/test/helpers/override_modifiers_order.dart
@@ -7,7 +7,7 @@ Future<void> testOverrideModifiersOrder(
   required Widget Function(Style, List<Type>) widgetBuilder,
 }) async {
   final style = Style.box().modifier(
-    ModifierConfig(
+    WidgetModifierConfig(
       modifiers: [
         VisibilityModifierMix(visible: true),
         OpacityModifierMix(opacity: 1.0),

--- a/packages/mix/test/src/core/style_builder_test.dart
+++ b/packages/mix/test/src/core/style_builder_test.dart
@@ -201,7 +201,7 @@ void main() {
             .height(100)
             .alignment(Alignment.center)
             .wrap(
-              ModifierConfig.modifiers([
+              WidgetModifierConfig.modifiers([
                 OpacityModifierMix(opacity: 0.5),
                 PaddingModifierMix(padding: EdgeInsetsGeometryMix.all(10)),
                 ClipOvalModifierMix(),
@@ -250,7 +250,7 @@ void main() {
             .height(100)
             .color(Colors.blue)
             .wrap(
-              ModifierConfig.modifiers([
+              WidgetModifierConfig.modifiers([
                 OpacityModifierMix(opacity: 0.5),
                 PaddingModifierMix(padding: EdgeInsetsGeometryMix.all(10)),
                 ClipOvalModifierMix(),
@@ -324,7 +324,7 @@ void main() {
             .height(100)
             .color(Colors.blue)
             .wrap(
-              ModifierConfig.modifiers([
+              WidgetModifierConfig.modifiers([
                 OpacityModifierMix(opacity: 0.5),
                 PaddingModifierMix(padding: EdgeInsetsGeometryMix.all(10)),
                 ClipOvalModifierMix(),

--- a/packages/mix/test/src/core/style_merge_parameters_test.dart
+++ b/packages/mix/test/src/core/style_merge_parameters_test.dart
@@ -10,14 +10,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers([
+          modifier: WidgetModifierConfig.orderOfModifiers([
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig.orderOfModifiers([
+          modifier: WidgetModifierConfig.orderOfModifiers([
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -33,7 +33,7 @@ void main() {
       test('preserves first orderOfModifiers when second is empty', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers([
+          modifier: WidgetModifierConfig.orderOfModifiers([
             OpacityModifier,
             PaddingModifier,
           ]),
@@ -97,11 +97,11 @@ void main() {
 
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig(modifiers: firstModifiers),
+          modifier: WidgetModifierConfig(modifiers: firstModifiers),
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig(modifiers: secondModifiers),
+          modifier: WidgetModifierConfig(modifiers: secondModifiers),
         );
 
         final merged = first.merge(second);
@@ -146,7 +146,7 @@ void main() {
       test('handles null merge correctly', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers(const [OpacityModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [OpacityModifier]),
         );
 
         final merged = first.merge(null);
@@ -159,14 +159,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = TextStyler(
           maxLines: 2,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = TextStyler(
           overflow: TextOverflow.ellipsis,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -184,14 +184,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = IconStyler(
           size: 24.0,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = IconStyler(
           color: Colors.red,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -209,14 +209,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = FlexStyler(
           direction: Axis.horizontal,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = FlexStyler(
           spacing: 8.0,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -234,14 +234,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = ImageStyler(
           width: 100.0,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = ImageStyler(
           height: 200.0,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -259,14 +259,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = StackStyler(
           alignment: Alignment.center,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = StackStyler(
           fit: StackFit.expand,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -284,14 +284,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = FlexBoxStyler(
           constraints: BoxConstraintsMix.width(100),
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = FlexBoxStyler(
           spacing: 8.0,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -309,14 +309,14 @@ void main() {
       test('merges orderOfModifiers correctly', () {
         final first = StackBoxStyler(
           constraints: BoxConstraintsMix.width(100),
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             OpacityModifier,
             PaddingModifier,
           ]),
         );
         final second = StackBoxStyler(
           stackAlignment: Alignment.center,
-          modifier: ModifierConfig.orderOfModifiers(const [
+          modifier: WidgetModifierConfig.orderOfModifiers(const [
             ClipOvalModifier,
             TransformModifier,
           ]),
@@ -334,15 +334,15 @@ void main() {
       test('chained merges preserve final values', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers(const [OpacityModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [OpacityModifier]),
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig.orderOfModifiers(const [PaddingModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [PaddingModifier]),
         );
         final third = BoxStyler(
           decoration: DecorationMix.color(Colors.blue),
-          modifier: ModifierConfig.orderOfModifiers(const [ClipOvalModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [ClipOvalModifier]),
         );
 
         final merged = first.merge(second).merge(third);
@@ -357,11 +357,11 @@ void main() {
 
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig(modifiers: [firstOpacity]),
+          modifier: WidgetModifierConfig(modifiers: [firstOpacity]),
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig(modifiers: [secondOpacity]),
+          modifier: WidgetModifierConfig(modifiers: [secondOpacity]),
         );
 
         final merged = first.merge(second);
@@ -405,11 +405,11 @@ void main() {
       test('empty orderOfModifiers list behavior', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers(const [OpacityModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [OpacityModifier]),
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig.orderOfModifiers(const []),
+          modifier: WidgetModifierConfig.orderOfModifiers(const []),
         );
 
         final merged = first.merge(second);
@@ -420,7 +420,7 @@ void main() {
       test('null vs empty list handling for modifiers', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig(
+          modifier: WidgetModifierConfig(
             modifiers: [OpacityModifierMix(opacity: 0.5)],
           ),
         );
@@ -461,7 +461,7 @@ void main() {
       test('merge with self returns same instance', () {
         final style = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers(const [OpacityModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [OpacityModifier]),
         );
 
         final merged = style.merge(style);
@@ -489,12 +489,12 @@ void main() {
       test('mixed null and non-null parameters', () {
         final first = BoxStyler(
           constraints: BoxConstraintsMix.width(100.0),
-          modifier: ModifierConfig.orderOfModifiers(const [OpacityModifier]),
+          modifier: WidgetModifierConfig.orderOfModifiers(const [OpacityModifier]),
           animation: null,
         );
         final second = BoxStyler(
           constraints: BoxConstraintsMix.height(200.0),
-          modifier: ModifierConfig.orderOfModifiers(const []),
+          modifier: WidgetModifierConfig.orderOfModifiers(const []),
           animation: const CurveAnimationConfig(
             duration: Duration(milliseconds: 100),
             curve: Curves.linear,

--- a/packages/mix/test/src/core/style_spec_test.dart
+++ b/packages/mix/test/src/core/style_spec_test.dart
@@ -88,7 +88,7 @@ void main() {
     testWidgets('createBuilder applies modifiers', (WidgetTester tester) async {
       // Create a modifier mix
       final opacityModifierMix = OpacityModifierMix(opacity: 0.5);
-      final modifierConfig = ModifierConfig(modifiers: [opacityModifierMix]);
+      final modifierConfig = WidgetModifierConfig(modifiers: [opacityModifierMix]);
 
       final style = BoxStyler().color(Colors.blue).modifier(modifierConfig);
 

--- a/packages/mix/test/src/modifiers/icon_theme_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/icon_theme_modifier_test.dart
@@ -156,7 +156,7 @@ void main() {
 
     setUp(() {
       utility = IconThemeModifierUtility(
-        (attr) => BoxStyler(modifier: ModifierConfig.modifier(attr)),
+        (attr) => BoxStyler(modifier: WidgetModifierConfig.modifier(attr)),
       );
     });
 

--- a/packages/mix/test/src/modifiers/reset_behavior_test.dart
+++ b/packages/mix/test/src/modifiers/reset_behavior_test.dart
@@ -9,12 +9,12 @@ void main() {
     test(
       'merge clears when reset is encountered in other and reset is not included',
       () {
-        final current = ModifierConfig.modifiers([
+        final current = WidgetModifierConfig.modifiers([
           OpacityModifierMix(opacity: 0.2),
           AlignModifierMix(alignment: Alignment.center),
         ]);
 
-        final other = ModifierConfig.modifiers([
+        final other = WidgetModifierConfig.modifiers([
           const ResetModifierMix(),
           PaddingModifierMix(padding: EdgeInsetsDirectionalMix(top: 8.0)),
           OpacityModifierMix(opacity: 0.8),
@@ -40,13 +40,13 @@ void main() {
     test(
       'merge clears when reset is encountered in current list and continues',
       () {
-        final current = ModifierConfig.modifiers([
+        final current = WidgetModifierConfig.modifiers([
           OpacityModifierMix(opacity: 0.2),
           const ResetModifierMix(),
           AlignModifierMix(alignment: Alignment.centerRight),
         ]);
 
-        final other = ModifierConfig.modifiers([
+        final other = WidgetModifierConfig.modifiers([
           PaddingModifierMix(padding: EdgeInsetsDirectionalMix(bottom: 4.0)),
         ]);
 
@@ -68,7 +68,7 @@ void main() {
     );
 
     test('resolve filters out reset when present alone', () {
-      final cfg = ModifierConfig.modifiers([const ResetModifierMix()]);
+      final cfg = WidgetModifierConfig.modifiers([const ResetModifierMix()]);
 
       final resolved = cfg.resolve(MockBuildContext());
       expect(resolved, isEmpty);

--- a/packages/mix/test/src/specs/box/box_style_test.dart
+++ b/packages/mix/test/src/specs/box/box_style_test.dart
@@ -379,14 +379,14 @@ void main() {
 
     group('Modifier Methods', () {
       test('modifier method sets modifier config', () {
-        final modifier = ModifierConfig();
+        final modifier = WidgetModifierConfig();
         final boxMix = BoxStyler().modifier(modifier);
 
         expect(boxMix.$modifier, modifier);
       });
 
       test('wrap method sets modifier config', () {
-        final modifier = ModifierConfig();
+        final modifier = WidgetModifierConfig();
         final boxMix = BoxStyler().wrap(modifier);
 
         expect(boxMix.$modifier, modifier);

--- a/packages/mix/test/src/specs/box/box_util_test.dart
+++ b/packages/mix/test/src/specs/box/box_util_test.dart
@@ -48,8 +48,8 @@ void main() {
         expect(util.on, isA<OnContextVariantUtility<BoxSpec, BoxStyler>>());
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<BoxStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<BoxStyler>>());
       });
     });
 

--- a/packages/mix/test/src/specs/flex_style_test.dart
+++ b/packages/mix/test/src/specs/flex_style_test.dart
@@ -439,7 +439,7 @@ void main() {
   group('Modifiers', () {
     test('modifiers can be added to attribute', () {
       final attribute = FlexStyler(
-        modifier: ModifierConfig(
+        modifier: WidgetModifierConfig(
           modifiers: [
             OpacityModifierMix(opacity: 0.5),
             PaddingModifierMix(padding: EdgeInsetsMix.all(8.0)),
@@ -453,11 +453,11 @@ void main() {
 
     test('modifiers merge correctly', () {
       final first = FlexStyler(
-        modifier: ModifierConfig(modifiers: [OpacityModifierMix(opacity: 0.5)]),
+        modifier: WidgetModifierConfig(modifiers: [OpacityModifierMix(opacity: 0.5)]),
       );
 
       final second = FlexStyler(
-        modifier: ModifierConfig(
+        modifier: WidgetModifierConfig(
           modifiers: [PaddingModifierMix(padding: EdgeInsetsMix.all(8.0))],
         ),
       );

--- a/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_spec_test.dart
@@ -197,7 +197,7 @@ void main() {
     group('Modifiers', () {
       test('modifiers can be added to attribute', () {
         final attribute = FlexBoxStyler(
-          modifier: ModifierConfig(
+          modifier: WidgetModifierConfig(
             modifiers: [
               OpacityModifierMix(opacity: 0.5),
               TransformModifierMix(
@@ -214,13 +214,13 @@ void main() {
 
       test('modifiers are merged correctly', () {
         final first = FlexBoxStyler(
-          modifier: ModifierConfig(
+          modifier: WidgetModifierConfig(
             modifiers: [OpacityModifierMix(opacity: 0.5)],
           ),
         );
 
         final second = FlexBoxStyler(
-          modifier: ModifierConfig(
+          modifier: WidgetModifierConfig(
             modifiers: [TransformModifierMix(transform: Matrix4.identity())],
           ),
         );

--- a/packages/mix/test/src/specs/flexbox/flexbox_util_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_util_test.dart
@@ -53,8 +53,8 @@ void main() {
         );
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<FlexBoxStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<FlexBoxStyler>>());
       });
     });
 

--- a/packages/mix/test/src/specs/icon/icon_util_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_util_test.dart
@@ -73,8 +73,8 @@ void main() {
         expect(util.on, isA<OnContextVariantUtility<IconSpec, IconStyler>>());
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<IconStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<IconStyler>>());
       });
     });
 

--- a/packages/mix/test/src/specs/image/image_util_test.dart
+++ b/packages/mix/test/src/specs/image/image_util_test.dart
@@ -96,8 +96,8 @@ void main() {
         expect(util.on, isA<OnContextVariantUtility<ImageSpec, ImageStyler>>());
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<ImageStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<ImageStyler>>());
       });
     });
 

--- a/packages/mix/test/src/specs/stack/stack_util_test.dart
+++ b/packages/mix/test/src/specs/stack/stack_util_test.dart
@@ -56,8 +56,8 @@ void main() {
         expect(util.on, isA<OnContextVariantUtility<StackSpec, StackStyler>>());
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<StackStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<StackStyler>>());
       });
     });
 

--- a/packages/mix/test/src/specs/text/text_util_test.dart
+++ b/packages/mix/test/src/specs/text/text_util_test.dart
@@ -95,8 +95,8 @@ void main() {
         expect(util.on, isA<OnContextVariantUtility<TextSpec, TextStyler>>());
       });
 
-      test('wrap utility is ModifierUtility', () {
-        expect(util.wrap, isA<ModifierUtility<TextStyler>>());
+      test('wrap utility is WidgetModifierUtility', () {
+        expect(util.wrap, isA<WidgetModifierUtility<TextStyler>>());
       });
     });
 


### PR DESCRIPTION
## Summary
- Rename core classes: `Modifier` → `WidgetModifier`, `ModifierConfig` → `WidgetModifierConfig`, `ModifierUtility` → `WidgetModifierUtility`
- Rename files: `modifier.dart` → `widget_modifier.dart`, `modifier_config.dart` → `widget_modifier_config.dart`, etc.
- Update all imports, exports, and type references across codebase to maintain consistency

## Changes Made
- **Core Classes**: Renamed `Modifier`, `ModifierConfig`, `ModifierUtility` to their `Widget*` equivalents
- **Files**: Renamed corresponding `.dart` files to match new class names
- **Imports/Exports**: Updated all import and export statements across the codebase
- **Type References**: Updated all type references in method signatures, generics, and field declarations
- **Spec Utilities**: Updated all mutable style classes to use `WidgetModifierUtility` and `WidgetModifierConfig`
- **Tests**: Updated test files to use new class names
- **Preserved Specificity**: Maintained specific modifier utility names (e.g., `FlexibleModifierUtility`) without Widget prefix

## Test Plan
- [x] All compilation errors resolved
- [x] Flutter analyze passes with no errors
- [x] Core tests pass successfully
- [ ] Full test suite should be run to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)