### PR TITLE
feat: add DurationToken and DurationRef for animation timing support

### DIFF
--- a/packages/mix/lib/src/theme/tokens/token_refs.dart
+++ b/packages/mix/lib/src/theme/tokens/token_refs.dart
@@ -166,6 +166,8 @@ T getReferenceValue<T>(MixToken<T> token) {
     return BorderSideRef(prop as Prop<BorderSide>) as T;
   } else if (T == FontWeight) {
     return FontWeightRef(prop as Prop<FontWeight>) as T;
+  } else if (T == Duration) {
+    return DurationRef(prop as Prop<Duration>) as T;
   } else if (T == List<Shadow>) {
     return ShadowListRef(prop as Prop<List<Shadow>>) as T;
   } else if (T == List<BoxShadow>) {

--- a/packages/mix/lib/src/theme/tokens/value_tokens.dart
+++ b/packages/mix/lib/src/theme/tokens/value_tokens.dart
@@ -103,3 +103,11 @@ class FontWeightToken extends MixToken<FontWeight> {
   @override
   FontWeightRef call() => FontWeightRef(Prop.token(this));
 }
+
+/// Design token for [Duration] values.
+class DurationToken extends MixToken<Duration> {
+  const DurationToken(super.name);
+
+  @override
+  DurationRef call() => DurationRef(Prop.token(this));
+}

--- a/packages/mix/test/src/theme/tokens/duration_token_integration_test.dart
+++ b/packages/mix/test/src/theme/tokens/duration_token_integration_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../../helpers/testing_utils.dart';
+
+void main() {
+  group('DurationToken Integration Tests', () {
+    test('DurationToken can be created and called', () {
+      const token = DurationToken('animation.duration.fast');
+      
+      // Calling the token should return a DurationRef
+      final ref = token();
+      
+      expect(ref, isA<DurationRef>());
+      expect(ref, PropMatcher.hasTokens);
+      expect(ref, PropMatcher.isToken(token));
+    });
+
+    testWidgets('DurationToken resolves through MixScope', (tester) async {
+      const durationToken = DurationToken('test.duration');
+      const testDuration = Duration(milliseconds: 300);
+
+      await tester.pumpWidget(
+        MixScope(
+          tokens: {durationToken: testDuration},
+          child: Builder(
+            builder: (context) {
+              final resolvedDuration = durationToken.resolve(context);
+              
+              expect(resolvedDuration, equals(testDuration));
+              expect(resolvedDuration, equals(Duration(milliseconds: 300)));
+              expect(resolvedDuration.inMilliseconds, equals(300));
+              
+              return Container();
+            },
+          ),
+        ),
+      );
+    });
+
+    test('DurationToken correctly prevents direct property access', () {
+      const durationToken = DurationToken('test.duration');
+      final durationRef = durationToken();
+      
+      // DurationRef should throw error when trying to access properties directly
+      expect(
+        () => durationRef.inMilliseconds,
+        throwsA(isA<UnimplementedError>()),
+        reason: 'DurationRef should prevent direct property access',
+      );
+      
+      expect(
+        () => durationRef.inSeconds,
+        throwsA(isA<UnimplementedError>()),
+        reason: 'DurationRef should prevent direct property access',
+      );
+    });
+
+    test('DurationToken integrates with getReferenceValue', () {
+      const durationToken = DurationToken('test.duration');
+      
+      final ref = getReferenceValue(durationToken);
+      
+      expect(ref, isA<Duration>());
+      expect(ref, isA<DurationRef>());
+      expect(ref, PropMatcher.hasTokens);
+      expect(ref, PropMatcher.isToken(durationToken));
+    });
+
+    test('DurationRef implements Duration interface', () {
+      const durationToken = DurationToken('test.duration');
+      final durationRef = durationToken();
+      
+      // Should be detectable as a token reference
+      expect(isAnyTokenRef(durationRef), isTrue);
+      
+      // Should implement Duration
+      expect(durationRef, isA<Duration>());
+    });
+
+    test('DurationToken works with common duration values', () {
+      const shortToken = DurationToken('duration.short');
+      const longToken = DurationToken('duration.long');
+      
+      final shortRef = shortToken();
+      final longRef = longToken();
+      
+      expect(shortRef, isA<DurationRef>());
+      expect(longRef, isA<DurationRef>());
+      expect(isAnyTokenRef(shortRef), isTrue);
+      expect(isAnyTokenRef(longRef), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds support for Duration tokens in the Mix theme system, enabling developers to define reusable animation timing values through the design token API.

This implementation follows the established patterns used by other tokens like FontWeightToken and ColorToken, providing consistent API surface and behavior.

### Changes Made

- **DurationToken**: New token class that extends `MixToken<Duration>`
- **DurationRef**: New reference implementation that extends `Prop<Duration>` with `ValueRef` mixin
- **Token Integration**: Updated `getReferenceValue` function to handle Duration type references
- **Comprehensive Tests**: Added integration tests covering token creation, resolution through MixScope, property access prevention, and interface compliance

### Usage Example

```dart
// Define duration tokens
const fastDuration = DurationToken('animation.duration.fast');
const slowDuration = DurationToken('animation.duration.slow');

// Use in MixScope
MixScope(
  tokens: {
    fastDuration: Duration(milliseconds: 200),
    slowDuration: Duration(milliseconds: 800),
  },
  child: MyWidget(),
)

// Reference in animations
final animationConfig = AnimationConfig(
  duration: fastDuration.resolve(context),
  curve: Curves.easeInOut,
);
```

## Test Plan

- [x] All existing tests continue to pass
- [x] New DurationToken integration tests pass (6/6 tests)
- [x] Token creation and calling returns correct DurationRef type
- [x] Token resolution works through MixScope
- [x] Direct property access prevention works as expected
- [x] Integration with getReferenceValue function
- [x] Duration interface implementation
- [x] Token reference detection works correctly