### PR TITLE
feat: multi transform support

### DIFF
--- a/packages/mix/example/lib/api/animation/keyframe.heart.dart
+++ b/packages/mix/example/lib/api/animation/keyframe.heart.dart
@@ -100,13 +100,10 @@ class _HeartAnimationState extends State<HeartAnimation> {
             final verticalStretch = values.get('verticalStretch');
             final angle = values.get('angle');
 
-            return style.transform(
-              Matrix4.identity()
-                ..scaleByDouble(scale, scale, scale, 1.0)
-                ..translateByDouble(0, verticalOffset, 0, 1)
-                ..scaleByDouble(1, verticalStretch, 1, 1)
-                ..rotateZ(angle),
-            );
+            return style
+                .wrapScale(x: scale, y: scale * verticalStretch)
+                .wrapTranslate(x: 0, y: verticalOffset)
+                .wrapRotate(angle);
           },
         ),
         child: ShaderMask(

--- a/packages/mix/example/lib/api/animation/phase.arrow.dart
+++ b/packages/mix/example/lib/api/animation/phase.arrow.dart
@@ -103,7 +103,7 @@ class ArrowIconButton extends StatelessWidget {
           trigger: animationTrigger,
           phases: ArrowPhases.values,
           styleBuilder: (phase, style) =>
-              style.wrapTranslate(phase.offset.dx, phase.offset.dy),
+              style.wrapTranslate(x: phase.offset.dx, y: phase.offset.dy),
           configBuilder: (phase) => CurveAnimationConfig(
             duration: phase.duration,
             curve: phase.curve,

--- a/packages/mix/lib/src/modifiers/transform_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_modifier.dart
@@ -4,21 +4,43 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../core/helpers.dart';
-import '../core/widget_modifier.dart';
 import '../core/prop.dart';
 import '../core/style.dart';
 import '../core/utility.dart';
+import '../core/widget_modifier.dart';
 
-/// Modifier that applies matrix transformations to its child.
-///
-/// Wraps the child in a [Transform] widget with the specified matrix and alignment.
-final class TransformModifier extends WidgetModifier<TransformModifier>
+abstract class _TransformModifier<T extends _TransformModifier<T>>
+    extends WidgetModifier<T>
     with Diagnosticable {
   final Matrix4 transform;
   final Alignment? alignment;
 
-  TransformModifier({Matrix4? transform, this.alignment = Alignment.center})
+  _TransformModifier({Matrix4? transform, this.alignment = Alignment.center})
     : transform = transform ?? Matrix4.identity();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('transform', transform))
+      ..add(DiagnosticsProperty('alignment', alignment));
+  }
+
+  @override
+  List<Object?> get props => [transform, alignment];
+
+  @override
+  Widget build(Widget child) {
+    return Transform(transform: transform, alignment: alignment, child: child);
+  }
+}
+
+/// Modifier that applies matrix transformations to its child.
+///
+/// Wraps the child in a [Transform] widget with the specified matrix and alignment.
+class TransformModifier extends _TransformModifier<TransformModifier> {
+  TransformModifier({Matrix4? transform, super.alignment})
+    : super(transform: transform ?? Matrix4.identity());
 
   @override
   TransformModifier copyWith({Matrix4? transform, Alignment? alignment}) {
@@ -36,22 +58,6 @@ final class TransformModifier extends WidgetModifier<TransformModifier>
       transform: MixOps.lerp(transform, other.transform, t),
       alignment: MixOps.lerp(alignment, other.alignment, t)!,
     );
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties
-      ..add(DiagnosticsProperty('transform', transform))
-      ..add(DiagnosticsProperty('alignment', alignment));
-  }
-
-  @override
-  List<Object?> get props => [transform, alignment];
-
-  @override
-  Widget build(Widget child) {
-    return Transform(transform: transform, alignment: alignment, child: child);
   }
 }
 
@@ -155,4 +161,331 @@ class TransformModifierMix extends ModifierMix<TransformModifier>
 
   @override
   List<Object?> get props => [transform, alignment];
+}
+
+class ScaleModifier extends _TransformModifier<ScaleModifier> {
+  ScaleModifier({double x = 1.0, double y = 1.0, super.alignment})
+    : super(transform: Matrix4.diagonal3Values(x, y, 1.0));
+
+  ScaleModifier._({super.transform, super.alignment});
+
+  @override
+  // ignore: avoid-incomplete-copy-with
+  ScaleModifier copyWith({double? x, double? y, Alignment? alignment}) {
+    final matrix = Matrix4.diagonal3Values(x ?? 1, y ?? 1, 1.0);
+
+    return ScaleModifier._(
+      transform: x != null || y != null ? matrix : transform,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+
+  @override
+  ScaleModifier lerp(ScaleModifier? other, double t) {
+    if (other == null) return this;
+
+    return ScaleModifier._(
+      transform: MixOps.lerp(transform, other.transform, t),
+      alignment: MixOps.lerp(alignment, other.alignment, t)!,
+    );
+  }
+}
+
+/// Mix class for applying scale transform modifications.
+///
+/// This class allows for mixing and resolving scale transform properties.
+class ScaleModifierMix extends ModifierMix<ScaleModifier> with Diagnosticable {
+  final Prop<double>? x;
+  final Prop<double>? y;
+  final Prop<Alignment>? alignment;
+
+  const ScaleModifierMix.create({this.x, this.y, this.alignment});
+
+  ScaleModifierMix({
+    double? x,
+    double? y,
+    Alignment? alignment,
+    double? scale, // for backward compatibility
+  }) : this.create(
+         x: x != null
+             ? Prop.value(x)
+             : (scale != null ? Prop.value(scale) : null),
+         y: y != null
+             ? Prop.value(y)
+             : (scale != null ? Prop.value(scale) : null),
+         alignment: Prop.maybe(alignment),
+       );
+
+  @override
+  ScaleModifier resolve(BuildContext context) {
+    final resolvedx = MixOps.resolve(context, x) ?? 1.0;
+    final resolvedy = MixOps.resolve(context, y) ?? 1.0;
+    final resolvedAlignment =
+        MixOps.resolve(context, alignment) ?? Alignment.center;
+
+    return ScaleModifier(
+      x: resolvedx,
+      y: resolvedy,
+      alignment: resolvedAlignment,
+    );
+  }
+
+  @override
+  ScaleModifierMix merge(ScaleModifierMix? other) {
+    if (other == null) return this;
+
+    return ScaleModifierMix.create(
+      x: MixOps.merge(x, other.x),
+      y: MixOps.merge(y, other.y),
+      alignment: MixOps.merge(alignment, other.alignment),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('x', x))
+      ..add(DiagnosticsProperty('y', y))
+      ..add(DiagnosticsProperty('alignment', alignment));
+  }
+
+  @override
+  Type get mergeKey => ScaleModifierMix;
+
+  @override
+  List<Object?> get props => [x, y, alignment];
+}
+
+class TranslateModifier extends _TransformModifier<TranslateModifier> {
+  TranslateModifier({double x = 0.0, double y = 0.0})
+    : super(transform: Matrix4.translationValues(x, y, 0.0));
+
+  TranslateModifier._({super.transform, super.alignment});
+
+  @override
+  // ignore: avoid-incomplete-copy-with
+  TranslateModifier copyWith({double? x, double? y, Alignment? alignment}) {
+    final matrix = Matrix4.translationValues(x ?? 0.0, y ?? 0.0, 0.0);
+
+    return TranslateModifier._(
+      transform: x != null || y != null ? matrix : transform,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+
+  @override
+  TranslateModifier lerp(TranslateModifier? other, double t) {
+    if (other == null) return this;
+
+    return TranslateModifier._(
+      transform: MixOps.lerp(transform, other.transform, t),
+      alignment: MixOps.lerp(alignment, other.alignment, t)!,
+    );
+  }
+}
+
+/// ModifierMix for translation transform.
+class TranslateModifierMix extends ModifierMix<TranslateModifier>
+    with Diagnosticable {
+  final Prop<double>? x;
+  final Prop<double>? y;
+
+  const TranslateModifierMix.create({this.x, this.y});
+
+  TranslateModifierMix({double? x, double? y})
+    : this.create(x: Prop.maybe(x), y: Prop.maybe(y));
+
+  @override
+  TranslateModifier resolve(BuildContext context) {
+    final resolvedX = MixOps.resolve(context, x) ?? 0.0;
+    final resolvedY = MixOps.resolve(context, y) ?? 0.0;
+
+    return TranslateModifier(x: resolvedX, y: resolvedY);
+  }
+
+  @override
+  TranslateModifierMix merge(TranslateModifierMix? other) {
+    if (other == null) return this;
+
+    return TranslateModifierMix.create(
+      x: MixOps.merge(x, other.x),
+      y: MixOps.merge(y, other.y),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('x', x))
+      ..add(DiagnosticsProperty('y', y));
+  }
+
+  @override
+  Type get mergeKey => TranslateModifierMix;
+
+  @override
+  List<Object?> get props => [x, y];
+}
+
+class RotateModifier extends _TransformModifier<RotateModifier> {
+  RotateModifier({double radians = 0.0, super.alignment})
+    : super(transform: Matrix4.rotationZ(radians));
+
+  RotateModifier._({super.transform, super.alignment});
+
+  @override
+  RotateModifier lerp(RotateModifier? other, double t) {
+    if (other == null) return this;
+
+    return RotateModifier._(
+      transform: MixOps.lerp(transform, other.transform, t),
+      alignment: MixOps.lerp(alignment, other.alignment, t)!,
+    );
+  }
+
+  @override
+  // ignore: avoid-incomplete-copy-with
+  RotateModifier copyWith({double? radians, Alignment? alignment}) {
+    return RotateModifier._(
+      transform: radians != null ? Matrix4.rotationZ(radians) : transform,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+}
+
+/// ModifierMix for rotation transform (around Z axis).
+class RotateModifierMix extends ModifierMix<RotateModifier>
+    with Diagnosticable {
+  final Prop<double>? radians;
+  final Prop<Alignment>? alignment;
+
+  const RotateModifierMix.create({this.radians, this.alignment});
+
+  RotateModifierMix({double? radians, Alignment? alignment})
+    : this.create(
+        radians: Prop.maybe(radians),
+        alignment: Prop.maybe(alignment),
+      );
+
+  @override
+  RotateModifier resolve(BuildContext context) {
+    final resolvedRadians = MixOps.resolve(context, radians) ?? 0.0;
+    final resolvedAlignment =
+        MixOps.resolve(context, alignment) ?? Alignment.center;
+
+    return RotateModifier(
+      radians: resolvedRadians,
+      alignment: resolvedAlignment,
+    );
+  }
+
+  @override
+  RotateModifierMix merge(RotateModifierMix? other) {
+    if (other == null) return this;
+
+    return RotateModifierMix.create(
+      radians: MixOps.merge(radians, other.radians),
+      alignment: MixOps.merge(alignment, other.alignment),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('radians', radians))
+      ..add(DiagnosticsProperty('alignment', alignment));
+  }
+
+  @override
+  Type get mergeKey => RotateModifierMix;
+
+  @override
+  List<Object?> get props => [radians, alignment];
+}
+
+class SkewModifier extends _TransformModifier<SkewModifier> {
+  SkewModifier({double skewX = 0.0, double skewY = 0.0, super.alignment})
+    : super(transform: Matrix4.skew(skewX, skewY));
+
+  SkewModifier._({super.transform, super.alignment});
+
+  @override
+  SkewModifier lerp(SkewModifier? other, double t) {
+    if (other == null) return this;
+
+    return SkewModifier._(
+      transform: MixOps.lerp(transform, other.transform, t),
+      alignment: MixOps.lerp(alignment, other.alignment, t)!,
+    );
+  }
+
+  @override
+  // ignore: avoid-incomplete-copy-with
+  SkewModifier copyWith({double? skewX, double? skewY, Alignment? alignment}) {
+    return SkewModifier._(
+      transform: skewX != null || skewY != null
+          ? Matrix4.skew(skewX ?? 0.0, skewY ?? 0.0)
+          : transform,
+      alignment: alignment ?? this.alignment,
+    );
+  }
+}
+
+/// ModifierMix for skew transform.
+class SkewModifierMix extends ModifierMix<SkewModifier> with Diagnosticable {
+  final Prop<double>? skewX;
+  final Prop<double>? skewY;
+  final Prop<Alignment>? alignment;
+
+  const SkewModifierMix.create({this.skewX, this.skewY, this.alignment});
+
+  SkewModifierMix({double? skewX, double? skewY, Alignment? alignment})
+    : this.create(
+        skewX: Prop.maybe(skewX),
+        skewY: Prop.maybe(skewY),
+        alignment: Prop.maybe(alignment),
+      );
+
+  @override
+  SkewModifier resolve(BuildContext context) {
+    final resolvedSkewX = MixOps.resolve(context, skewX) ?? 0.0;
+    final resolvedSkewY = MixOps.resolve(context, skewY) ?? 0.0;
+    final resolvedAlignment =
+        MixOps.resolve(context, alignment) ?? Alignment.center;
+
+    return SkewModifier(
+      skewX: resolvedSkewX,
+      skewY: resolvedSkewY,
+      alignment: resolvedAlignment,
+    );
+  }
+
+  @override
+  SkewModifierMix merge(SkewModifierMix? other) {
+    if (other == null) return this;
+
+    return SkewModifierMix.create(
+      skewX: MixOps.merge(skewX, other.skewX),
+      skewY: MixOps.merge(skewY, other.skewY),
+      alignment: MixOps.merge(alignment, other.alignment),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('skewX', skewX))
+      ..add(DiagnosticsProperty('skewY', skewY))
+      ..add(DiagnosticsProperty('alignment', alignment));
+  }
+
+  @override
+  Type get mergeKey => SkewModifierMix;
+
+  @override
+  List<Object?> get props => [skewX, skewY, alignment];
 }

--- a/packages/mix/lib/src/modifiers/widget_modifier_config.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifier_config.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/widgets.dart';
 
 import '../core/internal/compare_mixin.dart';
-import '../core/widget_modifier.dart';
 import '../core/style.dart';
+import '../core/widget_modifier.dart';
 import '../properties/layout/edge_insets_geometry_mix.dart';
 import '../properties/painting/border_radius_mix.dart';
 import '../properties/painting/shadow_mix.dart';
@@ -138,18 +138,45 @@ final class WidgetModifierConfig with Equatable {
   }
 
   /// Scale using transform.
-  factory WidgetModifierConfig.scale(
-    double scale, {
+  factory WidgetModifierConfig.scale({
+    required double x,
+    required double y,
     Alignment alignment = Alignment.center,
   }) {
-    return WidgetModifierConfig.transform(
-      transform: Matrix4.diagonal3Values(scale, scale, 1.0),
-      alignment: alignment,
+    return WidgetModifierConfig.modifier(
+      ScaleModifierMix(x: x, y: y, alignment: alignment),
+    );
+  }
+
+  factory WidgetModifierConfig.rotate({
+    required double radians,
+    Alignment alignment = Alignment.center,
+  }) {
+    return WidgetModifierConfig.modifier(
+      RotateModifierMix(radians: radians, alignment: alignment),
+    );
+  }
+
+  factory WidgetModifierConfig.translate({
+    required double x,
+    required double y,
+  }) {
+    return WidgetModifierConfig.modifier(TranslateModifierMix(x: x, y: y));
+  }
+  factory WidgetModifierConfig.skew({
+    required double skewX,
+    required double skewY,
+    Alignment alignment = Alignment.center,
+  }) {
+    return WidgetModifierConfig.modifier(
+      SkewModifierMix(skewX: skewX, skewY: skewY, alignment: alignment),
     );
   }
 
   factory WidgetModifierConfig.visibility(bool visible) {
-    return WidgetModifierConfig.modifier(VisibilityModifierMix(visible: visible));
+    return WidgetModifierConfig.modifier(
+      VisibilityModifierMix(visible: visible),
+    );
   }
 
   factory WidgetModifierConfig.align({
@@ -177,7 +204,9 @@ final class WidgetModifierConfig with Equatable {
   }
 
   factory WidgetModifierConfig.flexible({int? flex, FlexFit? fit}) {
-    return WidgetModifierConfig.modifier(FlexibleModifierMix(flex: flex, fit: fit));
+    return WidgetModifierConfig.modifier(
+      FlexibleModifierMix(flex: flex, fit: fit),
+    );
   }
 
   factory WidgetModifierConfig.rotatedBox(int quarterTurns) {
@@ -344,8 +373,12 @@ final class WidgetModifierConfig with Equatable {
     );
   }
 
-  WidgetModifierConfig scale(double scale, {Alignment alignment = Alignment.center}) {
-    return merge(WidgetModifierConfig.scale(scale, alignment: alignment));
+  WidgetModifierConfig scale(
+    double x,
+    double y, {
+    Alignment alignment = Alignment.center,
+  }) {
+    return merge(WidgetModifierConfig.scale(x: x, y: y, alignment: alignment));
   }
 
   WidgetModifierConfig opacity(double value) {
@@ -356,15 +389,27 @@ final class WidgetModifierConfig with Equatable {
     return merge(WidgetModifierConfig.aspectRatio(value));
   }
 
-  WidgetModifierConfig clipOval({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipOval({
+    CustomClipper<Rect>? clipper,
+    Clip? clipBehavior,
+  }) {
     return merge(
-      WidgetModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipOval(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
-  WidgetModifierConfig clipRect({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipRect({
+    CustomClipper<Rect>? clipper,
+    Clip? clipBehavior,
+  }) {
     return merge(
-      WidgetModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipRect(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
@@ -386,9 +431,15 @@ final class WidgetModifierConfig with Equatable {
     );
   }
 
-  WidgetModifierConfig clipPath({CustomClipper<Path>? clipper, Clip? clipBehavior}) {
+  WidgetModifierConfig clipPath({
+    CustomClipper<Path>? clipper,
+    Clip? clipBehavior,
+  }) {
     return merge(
-      WidgetModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipPath(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
@@ -401,7 +452,10 @@ final class WidgetModifierConfig with Equatable {
     Alignment alignment = Alignment.center,
   }) {
     return merge(
-      WidgetModifierConfig.transform(transform: transform, alignment: alignment),
+      WidgetModifierConfig.transform(
+        transform: transform,
+        alignment: alignment,
+      ),
     );
   }
 
@@ -609,6 +663,10 @@ const _defaultOrder = [
   // 13. TransformModifier: Applies visual transformations (scale, rotate, translate).
   // IMPORTANT: Visual-only - doesn't affect layout space, unlike RotatedBoxModifier.
   TransformModifier,
+  ScaleModifier,
+  RotateModifier,
+  TranslateModifier,
+  SkewModifier,
 
   // 14. Clip Modifiers: Applies visual clipping in various shapes.
   // Applied near the end to clip the widget's final visual appearance.
@@ -641,6 +699,10 @@ final defaultModifier = {
   AlignModifier: AlignModifier(),
   PaddingModifier: PaddingModifier(),
   TransformModifier: TransformModifier(),
+  ScaleModifier: ScaleModifier(),
+  RotateModifier: RotateModifier(),
+  TranslateModifier: TranslateModifier(),
+  SkewModifier: SkewModifier(),
   ClipOvalModifier: ClipOvalModifier(),
   ClipRRectModifier: ClipRRectModifier(),
   ClipPathModifier: ClipPathModifier(),
@@ -669,12 +731,14 @@ class ModifierListTween extends Tween<List<WidgetModifier>?> {
       lerpedModifiers = [];
       for (final modifier in otherModifiers) {
         WidgetModifier? thisModifier = thisModifierMap[modifier.runtimeType];
-        thisModifier ??= defaultModifier[modifier.runtimeType] as WidgetModifier?;
+        thisModifier ??=
+            defaultModifier[modifier.runtimeType] as WidgetModifier?;
 
         if (thisModifier != null) {
           // Both have this modifier type, lerp them
           // We need to use dynamic dispatch here since lerp is type-specific
-          final lerpedModifier = thisModifier.lerp(modifier, t) as WidgetModifier;
+          final lerpedModifier =
+              thisModifier.lerp(modifier, t) as WidgetModifier;
           lerpedModifiers.add(lerpedModifier);
         } else {
           // Only this has the modifier, fade it out if t > 0.5

--- a/packages/mix/lib/src/style/mixins/widget_modifier_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/widget_modifier_style_mixin.dart
@@ -2,15 +2,16 @@ import 'package:flutter/widgets.dart';
 
 import '../../core/spec.dart';
 import '../../core/style.dart';
-import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/mouse_cursor_modifier.dart';
+import '../../modifiers/widget_modifier_config.dart';
 import '../../properties/layout/edge_insets_geometry_mix.dart';
 import '../../properties/painting/border_radius_mix.dart';
 import '../../properties/typography/text_style_mix.dart';
 import '../../specs/box/box_style.dart';
 
 /// Provides convenient widget modifier styling methods for spec attributes.
-mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
+mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>>
+    on Style<S> {
   /// Applies the given [value] widget modifier configuration.
   T wrap(WidgetModifierConfig value);
 
@@ -27,21 +28,30 @@ mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S
   /// Wraps the widget with a clip oval modifier.
   T wrapClipOval({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return wrap(
-      WidgetModifierConfig.clipOval(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipOval(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
   /// Wraps the widget with a clip rect modifier.
   T wrapClipRect({CustomClipper<Rect>? clipper, Clip? clipBehavior}) {
     return wrap(
-      WidgetModifierConfig.clipRect(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipRect(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
   /// Wraps the widget with a clip path modifier.
   T wrapClipPath({CustomClipper<Path>? clipper, Clip? clipBehavior}) {
     return wrap(
-      WidgetModifierConfig.clipPath(clipper: clipper, clipBehavior: clipBehavior),
+      WidgetModifierConfig.clipPath(
+        clipper: clipper,
+        clipBehavior: clipBehavior,
+      ),
     );
   }
 
@@ -86,36 +96,48 @@ mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S
   }
 
   /// Wraps the widget with a scale transform modifier.
-  T wrapScale(double scale, {Alignment alignment = Alignment.center}) {
+  T wrapScale({
+    required double x,
+    required double y,
+    Alignment alignment = Alignment.center,
+  }) {
+    return wrap(WidgetModifierConfig.scale(x: x, y: y, alignment: alignment));
+  }
+
+  /// Wraps the widget with a skew transform modifier.
+  T wrapSkew(
+    double skewX,
+    double skewY, {
+    Alignment alignment = Alignment.center,
+  }) {
     return wrap(
-      WidgetModifierConfig.transform(
-        transform: Matrix4.diagonal3Values(scale, scale, 1.0),
+      WidgetModifierConfig.skew(
+        skewX: skewX,
+        skewY: skewY,
         alignment: alignment,
       ),
     );
   }
 
   /// Wraps the widget with a rotate transform modifier.
-  T wrapRotate(double angle, {Alignment alignment = Alignment.center}) {
+  T wrapRotate(double radians, {Alignment alignment = Alignment.center}) {
     return wrap(
-      WidgetModifierConfig.transform(
-        transform: Matrix4.rotationZ(angle),
-        alignment: alignment,
-      ),
+      WidgetModifierConfig.rotate(radians: radians, alignment: alignment),
     );
   }
 
   /// Wraps the widget with a translate transform modifier.
-  T wrapTranslate(double x, double y, [double z = 0.0]) {
-    return wrap(
-      WidgetModifierConfig.transform(transform: Matrix4.translationValues(x, y, z)),
-    );
+  T wrapTranslate({required double x, required double y}) {
+    return wrap(WidgetModifierConfig.translate(x: x, y: y));
   }
 
   /// Wraps the widget with a transform modifier.
   T wrapTransform(Matrix4 transform, {Alignment alignment = Alignment.center}) {
     return wrap(
-      WidgetModifierConfig.transform(transform: transform, alignment: alignment),
+      WidgetModifierConfig.transform(
+        transform: transform,
+        alignment: alignment,
+      ),
     );
   }
 
@@ -179,7 +201,9 @@ mixin WidgetModifierStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S
   T wrapMouseCursor(MouseCursor cursor) {
     // Note: MouseCursorModifierMix needs to be wrapped in WidgetModifierConfig
     return wrap(
-      WidgetModifierConfig.modifier(MouseCursorModifierMix(mouseCursor: cursor)),
+      WidgetModifierConfig.modifier(
+        MouseCursorModifierMix(mouseCursor: cursor),
+      ),
     );
   }
 

--- a/packages/mix/test/src/modifiers/transform_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/transform_modifier_test.dart
@@ -1,0 +1,602 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers/testing_utils.dart';
+
+void main() {
+  group('TransformModifier', () {
+    group('Constructor', () {
+      test(
+        'creates with identity transform and center alignment by default',
+        () {
+          final modifier = TransformModifier();
+
+          expect(modifier.transform, Matrix4.identity());
+          expect(modifier.alignment, Alignment.center);
+        },
+      );
+
+      test('assigns transform and alignment correctly', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        const alignment = Alignment.topLeft;
+        final modifier = TransformModifier(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        expect(modifier.transform, transform);
+        expect(modifier.alignment, alignment);
+      });
+
+      test('uses identity transform when null is provided', () {
+        final modifier = TransformModifier(transform: null);
+
+        expect(modifier.transform, Matrix4.identity());
+        expect(modifier.alignment, Alignment.center);
+      });
+    });
+
+    group('copyWith', () {
+      test('returns new instance with updated transform', () {
+        final original = TransformModifier(
+          transform: Matrix4.identity(),
+          alignment: Alignment.center,
+        );
+        final newTransform = Matrix4.rotationZ(math.pi / 2);
+        final updated = original.copyWith(transform: newTransform);
+
+        expect(updated.transform, newTransform);
+        expect(updated.alignment, Alignment.center);
+        expect(updated, isNot(same(original)));
+      });
+
+      test('returns new instance with updated alignment', () {
+        final original = TransformModifier();
+        final updated = original.copyWith(alignment: Alignment.topRight);
+
+        expect(updated.transform, Matrix4.identity());
+        expect(updated.alignment, Alignment.topRight);
+        expect(updated, isNot(same(original)));
+      });
+
+      test('preserves original values when parameters are null', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        final original = TransformModifier(
+          transform: transform,
+          alignment: Alignment.bottomLeft,
+        );
+        final updated = original.copyWith();
+
+        expect(updated.transform, transform);
+        expect(updated.alignment, Alignment.bottomLeft);
+        expect(updated, isNot(same(original)));
+      });
+    });
+
+    group('lerp', () {
+      test('interpolates transform matrices correctly', () {
+        final start = TransformModifier(transform: Matrix4.identity());
+        final end = TransformModifier(transform: Matrix4.rotationZ(math.pi));
+        final result = start.lerp(end, 0.5);
+
+        // The result should be approximately halfway between identity and pi rotation
+        expect(result.transform, isA<Matrix4>());
+        expect(result.alignment, Alignment.center);
+      });
+
+      test('interpolates alignment correctly', () {
+        final start = TransformModifier(alignment: Alignment.topLeft);
+        final end = TransformModifier(alignment: Alignment.bottomRight);
+        final result = start.lerp(end, 0.5);
+
+        expect(result.alignment, const Alignment(0.0, 0.0)); // Center point
+      });
+
+      test('handles null other parameter', () {
+        final start = TransformModifier(
+          transform: Matrix4.rotationZ(math.pi / 4),
+          alignment: Alignment.center,
+        );
+        final result = start.lerp(null, 0.5);
+
+        expect(result, same(start));
+      });
+
+      test('handles extreme t values', () {
+        final start = TransformModifier(alignment: Alignment.topLeft);
+        final end = TransformModifier(alignment: Alignment.bottomRight);
+
+        final result0 = start.lerp(end, 0.0);
+        expect(result0.alignment, Alignment.topLeft);
+
+        final result1 = start.lerp(end, 1.0);
+        expect(result1.alignment, Alignment.bottomRight);
+      });
+    });
+
+    group('equality and hashCode', () {
+      test('equal when transform and alignment match', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        final modifier1 = TransformModifier(
+          transform: transform,
+          alignment: Alignment.center,
+        );
+        final modifier2 = TransformModifier(
+          transform: transform,
+          alignment: Alignment.center,
+        );
+
+        expect(modifier1, equals(modifier2));
+        expect(modifier1.hashCode, equals(modifier2.hashCode));
+      });
+
+      test('not equal when transform differs', () {
+        final modifier1 = TransformModifier(transform: Matrix4.identity());
+        final modifier2 = TransformModifier(
+          transform: Matrix4.rotationZ(math.pi / 4),
+        );
+
+        expect(modifier1, isNot(equals(modifier2)));
+      });
+
+      test('not equal when alignment differs', () {
+        final modifier1 = TransformModifier(alignment: Alignment.center);
+        final modifier2 = TransformModifier(alignment: Alignment.topLeft);
+
+        expect(modifier1, isNot(equals(modifier2)));
+      });
+    });
+
+    group('props', () {
+      test('contains transform and alignment', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        const alignment = Alignment.topRight;
+        final modifier = TransformModifier(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        expect(modifier.props, [transform, alignment]);
+      });
+    });
+
+    group('build', () {
+      testWidgets('creates Transform widget with correct properties', (
+        WidgetTester tester,
+      ) async {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        const alignment = Alignment.topLeft;
+        final modifier = TransformModifier(
+          transform: transform,
+          alignment: alignment,
+        );
+        const child = SizedBox(width: 50, height: 50);
+
+        await tester.pumpWidget(modifier.build(child));
+
+        final transformWidget = tester.widget<Transform>(
+          find.byType(Transform),
+        );
+        expect(transformWidget.transform, transform);
+        expect(transformWidget.alignment, alignment);
+        expect(transformWidget.child, same(child));
+      });
+
+      testWidgets('creates Transform widget with default values', (
+        WidgetTester tester,
+      ) async {
+        final modifier = TransformModifier();
+        const child = SizedBox(width: 50, height: 50);
+
+        await tester.pumpWidget(modifier.build(child));
+
+        final transformWidget = tester.widget<Transform>(
+          find.byType(Transform),
+        );
+        expect(transformWidget.transform, Matrix4.identity());
+        expect(transformWidget.alignment, Alignment.center);
+        expect(transformWidget.child, same(child));
+      });
+    });
+  });
+
+  group('TransformModifierMix', () {
+    group('Constructor', () {
+      test('creates with null values by default', () {
+        final attribute = TransformModifierMix();
+
+        expect(attribute.transform, isNull);
+        expect(attribute.alignment, isNull);
+      });
+
+      test('creates with provided Prop values', () {
+        final transform = Prop.value(Matrix4.rotationZ(math.pi / 4));
+        final alignment = Prop.value(Alignment.center);
+        final attribute = TransformModifierMix.create(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        expect(attribute.transform, same(transform));
+        expect(attribute.alignment, same(alignment));
+      });
+    });
+
+    group('only constructor', () {
+      test('creates Prop values from direct values', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        const alignment = Alignment.topLeft;
+        final attribute = TransformModifierMix(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        expect(attribute.transform!, resolvesTo(transform));
+        expect(attribute.alignment!, resolvesTo(alignment));
+      });
+
+      test('handles null values correctly', () {
+        final attribute = TransformModifierMix();
+
+        expect(attribute.transform, isNull);
+        expect(attribute.alignment, isNull);
+      });
+    });
+
+    group('resolve', () {
+      test('resolves to TransformModifier with resolved values', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        const alignment = Alignment.topRight;
+        final attribute = TransformModifierMix(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        final expectedModifier = TransformModifier(
+          transform: transform,
+          alignment: alignment,
+        );
+
+        expect(attribute, resolvesTo(expectedModifier));
+      });
+
+      test('resolves with null values to defaults', () {
+        final attribute = TransformModifierMix();
+
+        final expectedModifier = TransformModifier(
+          transform: null, // Will become Matrix4.identity()
+          alignment: Alignment.center, // Default from resolve method
+        );
+
+        expect(attribute, resolvesTo(expectedModifier));
+      });
+    });
+
+    group('merge', () {
+      test('merges with other TransformModifierMix', () {
+        final attribute1 = TransformModifierMix(
+          transform: Matrix4.identity(),
+          alignment: Alignment.center,
+        );
+        final attribute2 = TransformModifierMix(
+          transform: Matrix4.rotationZ(math.pi / 4),
+          alignment: Alignment.topLeft,
+        );
+
+        final merged = attribute1.merge(attribute2);
+
+        expect(
+          merged.transform!,
+          resolvesTo(Matrix4.rotationZ(math.pi / 4)),
+        ); // overridden
+        expect(merged.alignment!, resolvesTo(Alignment.topLeft)); // overridden
+      });
+
+      test('returns original when other is null', () {
+        final attribute = TransformModifierMix(transform: Matrix4.identity());
+
+        final merged = attribute.merge(null);
+
+        expect(merged, same(attribute));
+      });
+
+      test('merges with null values', () {
+        final attribute1 = TransformModifierMix();
+        final attribute2 = TransformModifierMix(
+          transform: Matrix4.rotationZ(math.pi / 2),
+        );
+
+        final merged = attribute1.merge(attribute2);
+
+        expect(merged.transform!, resolvesTo(Matrix4.rotationZ(math.pi / 2)));
+        expect(merged.alignment, isNull);
+      });
+    });
+
+    group('equality and props', () {
+      test('equal when all Prop values match', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        final attribute1 = TransformModifierMix(
+          transform: transform,
+          alignment: Alignment.center,
+        );
+        final attribute2 = TransformModifierMix(
+          transform: transform,
+          alignment: Alignment.center,
+        );
+
+        expect(attribute1, equals(attribute2));
+      });
+
+      test('not equal when values differ', () {
+        final attribute1 = TransformModifierMix(transform: Matrix4.identity());
+        final attribute2 = TransformModifierMix(
+          transform: Matrix4.rotationZ(math.pi / 4),
+        );
+
+        expect(attribute1, isNot(equals(attribute2)));
+      });
+
+      test('props contains all Prop values', () {
+        final transform = Matrix4.rotationZ(math.pi / 4);
+        final attribute = TransformModifierMix(
+          transform: transform,
+          alignment: Alignment.center,
+        );
+
+        final props = attribute.props;
+        expect(props.length, 2);
+        expect(props[0], attribute.transform);
+        expect(props[1], attribute.alignment);
+      });
+    });
+  });
+
+  group('TransformModifierUtility', () {
+    late TransformModifierUtility<MockStyle<TransformModifierMix>> utility;
+
+    setUp(() {
+      utility = TransformModifierUtility((attribute) => MockStyle(attribute));
+    });
+
+    test('call() creates attribute with specified transform', () {
+      final transform = Matrix4.rotationZ(math.pi / 4);
+      final result = utility.call(transform);
+      final attribute = result.value;
+
+      expect(attribute.transform!, resolvesTo(transform));
+    });
+
+    test('scale() creates scaling transform', () {
+      final result = utility.scale(2.0);
+      final attribute = result.value;
+
+      expect(
+        attribute,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.diagonal3Values(2.0, 2.0, 1.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+    });
+
+    test('translate() creates translation transform', () {
+      final result = utility.translate(10.0, 20.0);
+      final attribute = result.value;
+
+      expect(
+        attribute,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.translationValues(10.0, 20.0, 0.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+    });
+
+    test('flipX() creates horizontal flip transform', () {
+      final result = utility.flipX();
+      final attribute = result.value;
+
+      expect(
+        attribute,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.diagonal3Values(-1.0, 1.0, 1.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+    });
+
+    test('flipY() creates vertical flip transform', () {
+      final result = utility.flipY();
+      final attribute = result.value;
+
+      expect(
+        attribute,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.diagonal3Values(1.0, -1.0, 1.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+    });
+
+    group('rotate utility', () {
+      test('d90() creates 90 degree rotation', () {
+        final result = utility.rotate.d90();
+        final attribute = result.value;
+
+        expect(
+          attribute,
+          resolvesTo(
+            TransformModifier(
+              transform: Matrix4.rotationZ(math.pi / 2),
+              alignment: Alignment.center,
+            ),
+          ),
+        );
+      });
+
+      test('d180() creates 180 degree rotation', () {
+        final result = utility.rotate.d180();
+        final attribute = result.value;
+
+        expect(
+          attribute,
+          resolvesTo(
+            TransformModifier(
+              transform: Matrix4.rotationZ(math.pi),
+              alignment: Alignment.center,
+            ),
+          ),
+        );
+      });
+
+      test('d270() creates 270 degree rotation', () {
+        final result = utility.rotate.d270();
+        final attribute = result.value;
+
+        expect(
+          attribute,
+          resolvesTo(
+            TransformModifier(
+              transform: Matrix4.rotationZ(3 * math.pi / 2),
+              alignment: Alignment.center,
+            ),
+          ),
+        );
+      });
+
+      test('call() creates custom rotation', () {
+        final result = utility.rotate.call(math.pi / 3);
+        final attribute = result.value;
+
+        expect(
+          attribute,
+          resolvesTo(
+            TransformModifier(
+              transform: Matrix4.rotationZ(math.pi / 3),
+              alignment: Alignment.center,
+            ),
+          ),
+        );
+      });
+    });
+  });
+
+  group('Integration tests', () {
+    testWidgets('TransformModifierMix resolves and builds correctly', (
+      WidgetTester tester,
+    ) async {
+      final transform = Matrix4.rotationZ(math.pi / 6);
+      final attribute = TransformModifierMix(
+        transform: transform,
+        alignment: Alignment.topRight,
+      );
+
+      final modifier = attribute.resolve(MockBuildContext());
+      const child = SizedBox(width: 100, height: 100);
+
+      await tester.pumpWidget(modifier.build(child));
+
+      final transformWidget = tester.widget<Transform>(find.byType(Transform));
+      expect(transformWidget.transform, transform);
+      expect(transformWidget.alignment, Alignment.topRight);
+      expect(transformWidget.child, same(child));
+    });
+
+    test('merge scenario preserves and overrides correctly', () {
+      final base = TransformModifierMix(
+        transform: Matrix4.identity(),
+        alignment: Alignment.center,
+      );
+
+      final override1 = TransformModifierMix(
+        transform: Matrix4.rotationZ(math.pi / 4),
+      );
+
+      final override2 = TransformModifierMix(alignment: Alignment.topLeft);
+
+      final result = base.merge(override1).merge(override2);
+
+      expect(result.transform!, resolvesTo(Matrix4.rotationZ(math.pi / 4)));
+      expect(result.alignment!, resolvesTo(Alignment.topLeft));
+    });
+
+    test('Lerp produces expected intermediate values', () {
+      final start = TransformModifier(
+        transform: Matrix4.identity(),
+        alignment: Alignment.topLeft,
+      );
+      final end = TransformModifier(
+        transform: Matrix4.rotationZ(math.pi),
+        alignment: Alignment.bottomRight,
+      );
+
+      final quarter = start.lerp(end, 0.25);
+      final half = start.lerp(end, 0.5);
+      final threeQuarter = start.lerp(end, 0.75);
+
+      // Check alignment interpolation
+      expect(quarter.alignment, const Alignment(-0.5, -0.5));
+      expect(half.alignment, const Alignment(0.0, 0.0));
+      expect(threeQuarter.alignment, const Alignment(0.5, 0.5));
+
+      // Transform matrices should be interpolated (exact values depend on Matrix4.lerp implementation)
+      expect(quarter.transform, isA<Matrix4>());
+      expect(half.transform, isA<Matrix4>());
+      expect(threeQuarter.transform, isA<Matrix4>());
+    });
+
+    test('Utility methods create expected transforms', () {
+      final utility = TransformModifierUtility<MockStyle<TransformModifierMix>>(
+        (attribute) => MockStyle(attribute),
+      );
+
+      // Test scale
+      final scaleResult = utility.scale(1.5);
+      expect(
+        scaleResult.value,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.diagonal3Values(1.5, 1.5, 1.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+
+      // Test translate
+      final translateResult = utility.translate(5.0, -10.0);
+      expect(
+        translateResult.value,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.translationValues(5.0, -10.0, 0.0),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+
+      // Test rotation
+      final rotateResult = utility.rotate.d90();
+      expect(
+        rotateResult.value,
+        resolvesTo(
+          TransformModifier(
+            transform: Matrix4.rotationZ(math.pi / 2),
+            alignment: Alignment.center,
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR implements multi-transform support by decomposing the existing single TransformModifier into specialized modifiers for different transformation types (scale, rotate, translate, and skew).

- Refactors TransformModifier hierarchy with specialized subclasses
- Adds new specialized transform methods with clearer parameter naming
- Updates existing transform utility methods to use the new specialized APIs
