### PR TITLE
refactor: normalize mixin type parameter order for consistency

### DIFF
--- a/packages/mix/lib/src/core/spec_utility.dart
+++ b/packages/mix/lib/src/core/spec_utility.dart
@@ -57,7 +57,7 @@ abstract class StyleMutableBuilder<S extends Spec<S>> extends Style<S>
 
   /// Internal mutable wrapper
   @protected
-  Mutable<S, Style<S>> get mutable;
+  Mutable<Style<S>, S> get mutable;
 
   /// Access to the actual accumulated style
   @visibleForTesting
@@ -91,7 +91,7 @@ abstract class StyleMutableBuilder<S extends Spec<S>> extends Style<S>
 ///
 /// Enables styles to accumulate merge operations into an internal value,
 /// providing error handling and type safety for merge operations.
-mixin Mutable<S extends Spec<S>, T extends Style<S>> on Style<S> {
+mixin Mutable<T extends Style<S>, S extends Spec<S>> on Style<S> {
   late T value;
 
   // Intercept merge calls
@@ -100,7 +100,7 @@ mixin Mutable<S extends Spec<S>, T extends Style<S>> on Style<S> {
     if (other == null) return this as T;
 
     try {
-      final otherValue = other is Mutable<S, T> ? other.value : other;
+      final otherValue = other is Mutable<T, S> ? other.value : other;
       // Accumulate merges - use super.merge to avoid recursion
       value = value.merge(otherValue) as T;
 

--- a/packages/mix/lib/src/core/utility_variant_mixin.dart
+++ b/packages/mix/lib/src/core/utility_variant_mixin.dart
@@ -9,7 +9,7 @@ import 'style.dart';
 /// This mixin provides variant methods for styling utilities with a simple
 /// delegation approach. All methods return Style types for consistency
 /// with other utility methods like animate().
-mixin UtilityVariantMixin<S extends Spec<S>, T extends Style<S>> {
+mixin UtilityVariantMixin<T extends Style<S>, S extends Spec<S>> {
   /// Must be implemented by utilities to apply a variant to a style.
   T withVariant(Variant variant, T style);
 

--- a/packages/mix/lib/src/specs/box/box_mutable_style.dart
+++ b/packages/mix/lib/src/specs/box/box_mutable_style.dart
@@ -22,7 +22,7 @@ import 'box_style.dart';
 /// Supports the same API as [BoxStyler] but maintains mutable internal state
 /// enabling fluid styling: `$box..color.red()..width(100)`.
 class BoxMutableStyler extends StyleMutableBuilder<BoxSpec>
-    with UtilityVariantMixin<BoxSpec, BoxStyler> {
+    with UtilityVariantMixin<BoxStyler, BoxSpec> {
   late final padding = EdgeInsetsGeometryUtility<BoxStyler>(
     (prop) => mutable.merge(BoxStyler.create(padding: Prop.mix(prop))),
   );
@@ -125,7 +125,7 @@ class BoxMutableStyler extends StyleMutableBuilder<BoxSpec>
 ///
 /// Used internally by [BoxMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
-class BoxMutableState extends BoxStyler with Mutable<BoxSpec, BoxStyler> {
+class BoxMutableState extends BoxStyler with Mutable<BoxStyler, BoxSpec> {
   BoxMutableState(BoxStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -45,7 +45,7 @@ class BoxStyler extends Style<BoxSpec>
         SpacingStyleMixin<BoxStyler>,
         TransformStyleMixin<BoxStyler>,
         ConstraintStyleMixin<BoxStyler>,
-        AnimationStyleMixin<BoxSpec, BoxStyler> {
+        AnimationStyleMixin<BoxStyler, BoxSpec> {
   final Prop<AlignmentGeometry>? $alignment;
   final Prop<EdgeInsetsGeometry>? $padding;
   final Prop<EdgeInsetsGeometry>? $margin;

--- a/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
@@ -18,7 +18,7 @@ import 'flex_style.dart';
 /// Supports the same API as [FlexStyler] but maintains mutable internal state
 /// enabling fluid styling: `$flex..direction(Axis.horizontal)..spacing(8)`.
 class FlexMutableStyler extends StyleMutableBuilder<FlexSpec>
-    with UtilityVariantMixin<FlexSpec, FlexStyler> {
+    with UtilityVariantMixin<FlexStyler, FlexSpec> {
   late final direction = MixUtility(mutable.direction);
 
   late final mainAxisAlignment = MixUtility(mutable.mainAxisAlignment);
@@ -116,7 +116,7 @@ class FlexMutableStyler extends StyleMutableBuilder<FlexSpec>
 ///
 /// Used internally by [FlexMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
-class FlexMutableState extends FlexStyler with Mutable<FlexSpec, FlexStyler> {
+class FlexMutableState extends FlexStyler with Mutable<FlexStyler, FlexSpec> {
   FlexMutableState(FlexStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/flex/flex_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.dart
@@ -31,7 +31,7 @@ class FlexStyler extends Style<FlexSpec>
         WidgetModifierStyleMixin<FlexStyler, FlexSpec>,
         VariantStyleMixin<FlexStyler, FlexSpec>,
         FlexStyleMixin<FlexStyler>,
-        AnimationStyleMixin<FlexSpec, FlexStyler> {
+        AnimationStyleMixin<FlexStyler, FlexSpec> {
   final Prop<Axis>? $direction;
   final Prop<MainAxisAlignment>? $mainAxisAlignment;
   final Prop<CrossAxisAlignment>? $crossAxisAlignment;

--- a/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
@@ -22,7 +22,7 @@ import 'flexbox_style.dart';
 /// Combines box and flex styling capabilities. Supports the same API as [FlexBoxStyler]
 /// but maintains mutable internal state enabling fluid styling: `$flexbox..color.red()..width(100)`.
 class FlexBoxMutableStyler extends StyleMutableBuilder<FlexBoxSpec>
-    with UtilityVariantMixin<FlexBoxSpec, FlexBoxStyler> {
+    with UtilityVariantMixin<FlexBoxStyler, FlexBoxSpec> {
   late final padding = EdgeInsetsGeometryUtility<FlexBoxStyler>(
     (prop) => mutable.merge(FlexBoxStyler(padding: prop)),
   );
@@ -180,7 +180,7 @@ class FlexBoxMutableStyler extends StyleMutableBuilder<FlexBoxSpec>
 /// Used internally by [FlexBoxMutableStyler] to accumulate styling changes
 /// without creating new instances for each modification.
 class FlexBoxMutableState extends FlexBoxStyler
-    with Mutable<FlexBoxSpec, FlexBoxStyler> {
+    with Mutable<FlexBoxStyler, FlexBoxSpec> {
   FlexBoxMutableState(FlexBoxStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
@@ -21,7 +21,7 @@ import 'icon_style.dart';
 /// Supports the same API as [IconStyler] but maintains mutable internal state
 /// enabling fluid styling: `$icon..color(Colors.blue)..size(24)..weight(400)`.
 class IconMutableStyler extends StyleMutableBuilder<IconSpec>
-    with UtilityVariantMixin<IconSpec, IconStyler> {
+    with UtilityVariantMixin<IconStyler, IconSpec> {
   late final color = ColorUtility<IconStyler>(
     (prop) => mutable.merge(IconStyler.create(color: prop)),
   );
@@ -106,7 +106,7 @@ class IconMutableStyler extends StyleMutableBuilder<IconSpec>
   IconStyler get value => mutable.value;
 }
 
-class IconMutableState extends IconStyler with Mutable<IconSpec, IconStyler> {
+class IconMutableState extends IconStyler with Mutable<IconStyler, IconSpec> {
   IconMutableState(IconStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/icon/icon_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.dart
@@ -22,7 +22,7 @@ class IconStyler extends Style<IconSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<IconStyler, IconSpec>,
         VariantStyleMixin<IconStyler, IconSpec>,
-        AnimationStyleMixin<IconSpec, IconStyler> {
+        AnimationStyleMixin<IconStyler, IconSpec> {
   final Prop<Color>? $color;
   final Prop<double>? $size;
   final Prop<double>? $weight;

--- a/packages/mix/lib/src/specs/image/image_mutable_style.dart
+++ b/packages/mix/lib/src/specs/image/image_mutable_style.dart
@@ -19,7 +19,7 @@ import 'image_style.dart';
 /// Supports the same API as [ImageStyler] but maintains mutable internal state
 /// enabling fluid styling: `$image..width(100)..height(100)..fit(BoxFit.cover)`.
 class ImageMutableStyler extends StyleMutableBuilder<ImageSpec>
-    with UtilityVariantMixin<ImageSpec, ImageStyler> {
+    with UtilityVariantMixin<ImageStyler, ImageSpec> {
   late final color = ColorUtility(
     (prop) => mutable.merge(ImageStyler.create(color: prop)),
   );
@@ -110,7 +110,7 @@ class ImageMutableStyler extends StyleMutableBuilder<ImageSpec>
 }
 
 class ImageMutableState extends ImageStyler
-    with Mutable<ImageSpec, ImageStyler> {
+    with Mutable<ImageStyler, ImageSpec> {
   ImageMutableState(ImageStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
@@ -19,7 +19,7 @@ import 'stack_style.dart';
 /// Supports the same API as [StackStyler] but maintains mutable internal state
 /// enabling fluid styling: `$stack..alignment(Alignment.center)..fit(StackFit.expand)`.
 class StackMutableStyler extends StyleMutableBuilder<StackSpec>
-    with UtilityVariantMixin<StackSpec, StackStyler> {
+    with UtilityVariantMixin<StackStyler, StackSpec> {
   late final alignment = MixUtility(mutable.alignment);
 
   late final fit = MixUtility(mutable.fit);
@@ -90,7 +90,7 @@ class StackMutableStyler extends StyleMutableBuilder<StackSpec>
 }
 
 class StackMutableState extends StackStyler
-    with Mutable<StackSpec, StackStyler> {
+    with Mutable<StackStyler, StackSpec> {
   StackMutableState(StackStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/stack/stack_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.dart
@@ -27,7 +27,7 @@ class StackStyler extends Style<StackSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<StackStyler, StackSpec>,
         VariantStyleMixin<StackStyler, StackSpec>,
-        AnimationStyleMixin<StackSpec, StackStyler> {
+        AnimationStyleMixin<StackStyler, StackSpec> {
   final Prop<AlignmentGeometry>? $alignment;
   final Prop<StackFit>? $fit;
   final Prop<TextDirection>? $textDirection;

--- a/packages/mix/lib/src/specs/text/text_mutable_style.dart
+++ b/packages/mix/lib/src/specs/text/text_mutable_style.dart
@@ -22,7 +22,7 @@ import 'text_style.dart';
 /// Supports the same API as [TextStyler] but maintains mutable internal state
 /// enabling fluid styling: `$text..color.red()..fontSize(16)`.
 class TextMutableStyler extends StyleMutableBuilder<TextSpec>
-    with UtilityVariantMixin<TextSpec, TextStyler> {
+    with UtilityVariantMixin<TextStyler, TextSpec> {
   late final textOverflow = MixUtility(mutable.overflow);
 
   late final strutStyle = StrutStyleUtility(mutable.strutStyle);
@@ -138,7 +138,7 @@ class TextMutableStyler extends StyleMutableBuilder<TextSpec>
   TextStyler get value => mutable.value;
 }
 
-class TextMutableState extends TextStyler with Mutable<TextSpec, TextStyler> {
+class TextMutableState extends TextStyler with Mutable<TextStyler, TextSpec> {
   TextMutableState(TextStyler style) {
     value = style;
   }

--- a/packages/mix/lib/src/specs/text/text_style.dart
+++ b/packages/mix/lib/src/specs/text/text_style.dart
@@ -34,7 +34,7 @@ class TextStyler extends Style<TextSpec>
         WidgetModifierStyleMixin<TextStyler, TextSpec>,
         VariantStyleMixin<TextStyler, TextSpec>,
         TextStyleMixin<TextStyler>,
-        AnimationStyleMixin<TextSpec, TextStyler> {
+        AnimationStyleMixin<TextStyler, TextSpec> {
   final Prop<TextOverflow>? $overflow;
   final Prop<StrutStyle>? $strutStyle;
   final Prop<TextAlign>? $textAlign;

--- a/packages/mix/lib/src/style/mixins/animation_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/animation_style_mixin.dart
@@ -4,7 +4,7 @@ import '../../animation/animation_config.dart';
 import '../../core/spec.dart';
 import '../../core/style.dart';
 
-mixin AnimationStyleMixin<S extends Spec<S>, T extends Style<S>> on Style<S> {
+mixin AnimationStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
   @protected
   T animate(AnimationConfig config);
 


### PR DESCRIPTION
## Summary
- Standardizes all two-type-parameter mixins to use consistent `<StylerType, SpecType>` ordering
- Updates mixin definitions: AnimationStyleMixin, UtilityVariantMixin, and Mutable
- Updates all usage sites across 15 files to match new signatures

## Changes Made
**Mixin Definitions Updated:**
- `AnimationStyleMixin<S extends Spec<S>, T extends Style<S>>` → `AnimationStyleMixin<T extends Style<S>, S extends Spec<S>>`
- `UtilityVariantMixin<S extends Spec<S>, T extends Style<S>>` → `UtilityVariantMixin<T extends Style<S>, S extends Spec<S>>`
- `Mutable<S extends Spec<S>, T extends Style<S>>` → `Mutable<T extends Style<S>, S extends Spec<S>>`

**Usage Sites Updated:**
- 5 AnimationStyleMixin usages in main style files
- 7 UtilityVariantMixin usages in mutable style files
- 7 Mutable usages in mutable style files

## Benefits
- **Predictable API**: First type parameter is always StylerType, second is always SpecType
- **Consistency**: Matches established pattern of WidgetModifierStyleMixin and VariantStyleMixin
- **Developer Experience**: Easier to remember and use mixin signatures

## Test Plan
- [ ] Verify all mixin signatures follow consistent pattern
- [ ] Ensure no compilation errors in affected files
- [ ] Run existing tests to confirm functionality preserved
- [ ] Check that IDE autocomplete and type inference work correctly