### PR TITLE
fix: Add default styles to Mix widgets

### DIFF
--- a/packages/mix/lib/src/core/style_widget.dart
+++ b/packages/mix/lib/src/core/style_widget.dart
@@ -10,14 +10,10 @@ import 'style_builder.dart';
 /// Type [S] must extend [Spec<S>] for type-safe styling.
 abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
   /// Creates a [StyleWidget] with either [style] or [spec].
-  const StyleWidget({this.style, this.spec, super.key})
-    : assert(
-        (style != null) != (spec != null),
-        'Provide either style or spec, not both',
-      );
+  const StyleWidget({required this.style, this.spec, super.key});
 
   /// Style to apply to this widget.
-  final Style<S>? style;
+  final Style<S> style;
 
   /// Direct spec to apply to this widget.
   final S? spec;
@@ -32,11 +28,12 @@ abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
 class _StyleWidgetState<S extends Spec<S>> extends State<StyleWidget<S>> {
   @override
   Widget build(BuildContext context) {
-    if (widget.spec != null) {
+    final spec = widget.spec;
+    if (spec != null) {
       // Direct spec usage - no style resolution needed
-      return widget.build(context, widget.spec!);
+      return widget.build(context, spec);
     } // Style resolution path (current behavior)
 
-    return StyleBuilder<S>(style: widget.style!, builder: widget.build);
+    return StyleBuilder<S>(style: widget.style, builder: widget.build);
   }
 }

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -4,12 +4,18 @@ import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'box_spec.dart';
+import 'box_style.dart';
 
 /// A styled box widget using Mix framework.
 ///
 /// Applies [BoxSpec] styling to create a customized [Container].
 class Box extends StyleWidget<BoxSpec> {
-  const Box({super.style, super.spec, super.key, this.child});
+  const Box({
+    super.style = const BoxStyler.create(),
+    super.spec,
+    super.key,
+    this.child,
+  });
 
   /// Builder pattern for `StyleSpec<BoxSpec>` with custom builder function.
   static Widget builder(

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -8,6 +8,7 @@ import '../../core/style_widget.dart';
 import '../box/box_widget.dart';
 import '../flex/flex_spec.dart';
 import 'flexbox_spec.dart';
+import 'flexbox_style.dart';
 
 @Deprecated('Use ColumnBox instead')
 typedef VBox = ColumnBox;
@@ -21,7 +22,7 @@ typedef HBox = RowBox;
 /// providing decoration, constraints, and flex layout in one widget.
 class FlexBox extends StyleWidget<FlexBoxSpec> {
   const FlexBox({
-    super.style,
+    super.style = const FlexBoxStyler.create(),
     super.spec,
     super.key,
     this.children = const <Widget>[],

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -4,6 +4,7 @@ import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'icon_spec.dart';
+import 'icon_style.dart';
 
 /// Displays an icon with Mix styling.
 ///
@@ -12,7 +13,7 @@ class StyledIcon extends StyleWidget<IconSpec> {
   const StyledIcon({
     this.icon,
     this.semanticLabel,
-    super.style,
+    super.style = const IconStyler.create(),
     super.spec,
     super.key,
   });

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -4,6 +4,7 @@ import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'image_spec.dart';
+import 'image_style.dart';
 
 /// A styled image widget using Mix framework.
 ///
@@ -11,7 +12,7 @@ import 'image_spec.dart';
 class StyledImage extends StyleWidget<ImageSpec> {
   const StyledImage({
     super.key,
-    super.style,
+    super.style = const ImageStyler.create(),
     super.spec,
     this.frameBuilder,
     this.loadingBuilder,

--- a/packages/mix/lib/src/specs/stack/stack_widget.dart
+++ b/packages/mix/lib/src/specs/stack/stack_widget.dart
@@ -5,6 +5,7 @@ import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import '../box/box_widget.dart';
 import 'stack_box_spec.dart';
+import 'stack_box_style.dart';
 import 'stack_spec.dart';
 
 /// Combines [Container] and [Stack] with Mix styling.
@@ -12,7 +13,7 @@ import 'stack_spec.dart';
 /// Creates a stacked layout with box styling capabilities.
 class ZBox extends StyleWidget<ZBoxSpec> {
   const ZBox({
-    super.style,
+    super.style = const StackBoxStyler.create(),
     super.spec,
     this.children = const <Widget>[],
     super.key,

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -5,13 +5,19 @@ import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'text_spec.dart';
+import 'text_style.dart';
 
 /// Displays text with Mix styling.
 ///
 /// Applies [TextSpec] for custom text appearance.
 class StyledText extends StyleWidget<TextSpec> {
   /// Creates a [StyledText] with required [text] and optional [style] or [spec].
-  const StyledText(this.text, {super.style, super.spec, super.key});
+  const StyledText(
+    this.text, {
+    super.style = const TextStyler.create(),
+    super.spec,
+    super.key,
+  });
 
   /// Builder pattern for `StyleSpec<TextSpec>` with custom builder function.
   static Widget builder(


### PR DESCRIPTION
## Summary

- Make style parameter required in StyleWidget base class
- Add default styles to all styled widgets (Box, FlexBox, StyledIcon, StyledImage, ZBox, StyledText) 
- Remove style/spec mutual exclusion assertion
- Simplify widget constructor signatures while maintaining backward compatibility

## Changes

This PR ensures all Mix widgets have sensible default styling behavior without requiring explicit style parameters. The changes include:

1. **StyleWidget base class**: Made `style` parameter required and removed the assertion that enforced mutual exclusion between `style` and `spec`
2. **Widget constructors**: Added default style values using the respective styler classes
3. **Backward compatibility**: Maintained support for both style and spec parameters

## Benefits

- Improved developer experience with sensible defaults
- Reduced boilerplate when using Mix widgets
- Maintains existing functionality while adding convenience

## Test plan

- [ ] Verify all widgets compile with default styles
- [ ] Test that existing code using explicit styles continues to work
- [ ] Confirm spec parameter still works as expected
- [ ] Run existing test suite to ensure no regressions