### PR TITLE
refactor: migrate StyleWidget to use styleSpec parameter for improved consistency

### DIFF
--- a/packages/mix/lib/src/core/style_widget.dart
+++ b/packages/mix/lib/src/core/style_widget.dart
@@ -3,20 +3,21 @@ import 'package:flutter/widgets.dart';
 import 'spec.dart';
 import 'style.dart';
 import 'style_builder.dart';
+import 'style_spec.dart';
 
 /// Base widget for applying Mix styles to Flutter widgets.
 ///
 /// Provides style application and inheritance through the Mix framework.
 /// Type [S] must extend [Spec<S>] for type-safe styling.
 abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
-  /// Creates a [StyleWidget] with either [style] or [spec].
-  const StyleWidget({required this.style, this.spec, super.key});
+  /// Creates a [StyleWidget] with either [style] or [styleSpec].
+  const StyleWidget({required this.style, this.styleSpec, super.key});
 
   /// Style to apply to this widget.
   final Style<S> style;
 
   /// Direct spec to apply to this widget.
-  final S? spec;
+  final StyleSpec<S>? styleSpec;
 
   @override
   State<StyleWidget<S>> createState() => _StyleWidgetState<S>();
@@ -28,10 +29,10 @@ abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
 class _StyleWidgetState<S extends Spec<S>> extends State<StyleWidget<S>> {
   @override
   Widget build(BuildContext context) {
-    final spec = widget.spec;
-    if (spec != null) {
+    final styleSpec = widget.styleSpec;
+    if (styleSpec != null) {
       // Direct spec usage - no style resolution needed
-      return widget.build(context, spec);
+      return StyleSpecBuilder(builder: widget.build, styleSpec: styleSpec);
     } // Style resolution path (current behavior)
 
     return StyleBuilder<S>(style: widget.style, builder: widget.build);

--- a/packages/mix/lib/src/modifiers/box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/box_modifier.dart
@@ -44,10 +44,7 @@ final class BoxModifier extends WidgetModifier<BoxModifier>
 
   @override
   Widget build(Widget child) {
-    return Box(
-      styleSpec: StyleSpec(spec: spec),
-      child: child,
-    );
+    return Box(styleSpec: StyleSpec(spec: spec), child: child);
   }
 }
 

--- a/packages/mix/lib/src/modifiers/box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/box_modifier.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../../mix.dart';
+import '../core/helpers.dart';
+import '../core/style.dart';
+import '../core/style_spec.dart';
+import '../core/utility.dart';
+import '../core/widget_modifier.dart';
+import '../specs/box/box_spec.dart';
+import '../specs/box/box_style.dart';
+import '../specs/box/box_widget.dart';
+import '../properties/painting/decoration_mix.dart';
+import '../properties/layout/edge_insets_geometry_mix.dart';
 
 /// Modifier that wraps its child in a styled Container using BoxSpec styling.
 ///

--- a/packages/mix/lib/src/modifiers/box_modifier.dart
+++ b/packages/mix/lib/src/modifiers/box_modifier.dart
@@ -1,15 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import '../core/helpers.dart';
-import '../core/widget_modifier.dart';
-import '../core/style.dart';
-import '../core/utility.dart';
-import '../properties/layout/edge_insets_geometry_mix.dart';
-import '../properties/painting/decoration_mix.dart';
-import '../specs/box/box_spec.dart';
-import '../specs/box/box_style.dart';
-import '../specs/box/box_widget.dart';
+import '../../mix.dart';
 
 /// Modifier that wraps its child in a styled Container using BoxSpec styling.
 ///
@@ -43,7 +35,10 @@ final class BoxModifier extends WidgetModifier<BoxModifier>
 
   @override
   Widget build(Widget child) {
-    return Box(spec: spec, child: child);
+    return Box(
+      styleSpec: StyleSpec(spec: spec),
+      child: child,
+    );
   }
 }
 

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'box_spec.dart';
@@ -16,7 +15,6 @@ class Box extends StyleWidget<BoxSpec> {
     super.key,
     this.child,
   });
-
 
   /// Child widget to display inside the box.
   final Widget? child;

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -12,7 +12,7 @@ import 'box_style.dart';
 class Box extends StyleWidget<BoxSpec> {
   const Box({
     super.style = const BoxStyler.create(),
-    super.spec,
+    super.styleSpec,
     super.key,
     this.child,
   });
@@ -48,35 +48,17 @@ class Box extends StyleWidget<BoxSpec> {
 /// Alias for [Box] widget for backward compatibility.
 typedef StyledContainer = Box;
 
-/// Extension to convert [BoxSpec] directly to a [Box] widget.
-extension BoxSpecWidget on BoxSpec {
-  /// Creates a [Box] widget from this [BoxSpec].
-  @Deprecated('Use Box(spec: this, child: child) instead')
-  Widget createWidget({Widget? child}) {
-    return Box(spec: this, child: child);
-  }
-
-  @Deprecated('Use Box(spec: this, child: child) instead')
-  Widget call({Widget? child}) {
-    return Box(spec: this, child: child);
-  }
-}
-
 extension BoxSpecWrappedWidget on StyleSpec<BoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<BoxSpec>] with context.
   @Deprecated(
     'Use Box.builder(styleSpec, builder) for custom logic, or styleSpec(child: child) for simple cases',
   )
   Widget createWidget({Widget? child}) {
-    return Box.builder(this, (context, spec) {
-      return Box(spec: spec, child: child);
-    });
+    return call(child: child);
   }
 
   /// Convenient shorthand for creating a Box widget with this StyleSpec.
   Widget call({Widget? child}) {
-    return Box.builder(this, (context, spec) {
-      return Box(spec: spec, child: child);
-    });
+    return Box(styleSpec: this, child: child);
   }
 }

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -50,14 +50,13 @@ typedef StyledContainer = Box;
 
 extension BoxSpecWrappedWidget on StyleSpec<BoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<BoxSpec>] with context.
-  @Deprecated(
-    'Use Box.builder(styleSpec, builder) for custom logic, or styleSpec(child: child) for simple cases',
-  )
+  @Deprecated('Use Box(styleSpec: styleSpec, child: child) instead')
   Widget createWidget({Widget? child}) {
     return call(child: child);
   }
 
   /// Convenient shorthand for creating a Box widget with this StyleSpec.
+  @Deprecated('Use Box(styleSpec: styleSpec, child: child) instead')
   Widget call({Widget? child}) {
     return Box(styleSpec: this, child: child);
   }

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -146,13 +146,10 @@ Flex _createFlexSpecWidget({
   );
 }
 
-
-
-
 extension FlexBoxSpecWrappedWidget on StyleSpec<FlexBoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<FlexBoxSpec>] with context.
   @Deprecated(
-    'Use FlexBox.builder(styleSpec, builder), RowBox.builder(styleSpec, builder), or ColumnBox.builder(styleSpec, builder) for custom logic, or styleSpec(direction: direction, children: children) for simple cases',
+    'Use RowBox(children: children, styleSpec: styleSpec) for horizontal or ColumnBox(children: children, styleSpec: styleSpec) for vertical instead',
   )
   Widget createWidget({
     required Axis direction,
@@ -162,6 +159,9 @@ extension FlexBoxSpecWrappedWidget on StyleSpec<FlexBoxSpec> {
   }
 
   /// Convenient shorthand for creating a FlexBox widget with this StyleSpec.
+  @Deprecated(
+    'Use RowBox(children: children, styleSpec: styleSpec) for horizontal or ColumnBox(children: children, styleSpec: styleSpec) for vertical instead',
+  )
   Widget call({required Axis direction, List<Widget> children = const []}) {
     switch (direction) {
       case Axis.horizontal:

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/widgets.dart';
 
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import '../box/box_widget.dart';

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -23,7 +23,7 @@ typedef HBox = RowBox;
 class FlexBox extends StyleWidget<FlexBoxSpec> {
   const FlexBox({
     super.style = const FlexBoxStyler.create(),
-    super.spec,
+    super.styleSpec,
     super.key,
     this.children = const <Widget>[],
   });
@@ -55,7 +55,7 @@ class FlexBox extends StyleWidget<FlexBoxSpec> {
     );
 
     if (spec.box != null) {
-      return Box(spec: spec.box!.spec, child: flexWidget);
+      return Box(styleSpec: spec.box!, child: flexWidget);
     }
 
     return flexWidget;
@@ -68,7 +68,7 @@ class FlexBox extends StyleWidget<FlexBoxSpec> {
 class RowBox extends FlexBox {
   const RowBox({
     super.style,
-    super.spec,
+    super.styleSpec,
     super.key,
     super.children = const <Widget>[],
   });
@@ -94,7 +94,7 @@ class RowBox extends FlexBox {
 class ColumnBox extends FlexBox {
   const ColumnBox({
     super.style,
-    super.spec,
+    super.styleSpec,
     super.key,
     super.children = const <Widget>[],
   });
@@ -146,96 +146,8 @@ Flex _createFlexSpecWidget({
   );
 }
 
-/// Extension to convert [FlexSpec] directly to a [Flex] widget.
-extension FlexSpecWidget on FlexSpec {
-  /// Creates a [Flex] widget from this [FlexSpec].
-  @Deprecated(
-    'FlexSpec is a component spec. Use FlexBox, RowBox, or ColumnBox for complete widgets',
-  )
-  Flex createWidget({Axis? direction, List<Widget> children = const []}) {
-    return _createFlexSpecWidget(
-      spec: this,
-      forcedDirection: direction,
-      children: children,
-    );
-  }
 
-  @Deprecated(
-    'FlexSpec is a component spec. Use FlexBox, RowBox, or ColumnBox for complete widgets',
-  )
-  Flex call({Axis? direction, List<Widget> children = const []}) {
-    return _createFlexSpecWidget(
-      spec: this,
-      forcedDirection: direction,
-      children: children,
-    );
-  }
-}
 
-/// Extension to convert [FlexBoxSpec] directly to a [FlexBox] widget.
-extension FlexBoxSpecWidget on FlexBoxSpec {
-  /// Creates a [FlexBox] widget from this [FlexBoxSpec].
-  @Deprecated(
-    'Use FlexBox(spec: this, children: children), RowBox(spec: this, children: children), or ColumnBox(spec: this, children: children) instead',
-  )
-  Widget createWidget({
-    required Axis direction,
-    List<Widget> children = const [],
-  }) {
-    if (direction == Axis.horizontal) {
-      return RowBox(spec: this, children: children);
-    }
-
-    return ColumnBox(spec: this, children: children);
-  }
-
-  @Deprecated(
-    'Use FlexBox(spec: this, children: children), RowBox(spec: this, children: children), or ColumnBox(spec: this, children: children) instead',
-  )
-  Widget call({required Axis direction, List<Widget> children = const []}) {
-    switch (direction) {
-      case Axis.horizontal:
-        return RowBox(spec: this, children: children);
-      case Axis.vertical:
-        return ColumnBox(spec: this, children: children);
-    }
-  }
-}
-
-extension FlexSpecWrappedWidget on StyleSpec<FlexSpec> {
-  /// Creates a widget that resolves this [StyleSpec<FlexSpec>] with context.
-  @Deprecated(
-    'FlexSpec is a component spec. Use FlexBox.builder(), RowBox.builder(), or ColumnBox.builder() with FlexBoxSpec instead',
-  )
-  Widget createWidget({Axis? direction, List<Widget> children = const []}) {
-    return StyleSpecBuilder(
-      builder: (context, spec) {
-        return _createFlexSpecWidget(
-          spec: spec,
-          forcedDirection: direction,
-          children: children,
-        );
-      },
-      styleSpec: this,
-    );
-  }
-
-  @Deprecated(
-    'FlexSpec is a component spec. Use FlexBox.builder(), RowBox.builder(), or ColumnBox.builder() with FlexBoxSpec instead',
-  )
-  Widget call({Axis? direction, List<Widget> children = const []}) {
-    return StyleSpecBuilder(
-      builder: (context, spec) {
-        return _createFlexSpecWidget(
-          spec: spec,
-          forcedDirection: direction,
-          children: children,
-        );
-      },
-      styleSpec: this,
-    );
-  }
-}
 
 extension FlexBoxSpecWrappedWidget on StyleSpec<FlexBoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<FlexBoxSpec>] with context.
@@ -246,26 +158,16 @@ extension FlexBoxSpecWrappedWidget on StyleSpec<FlexBoxSpec> {
     required Axis direction,
     List<Widget> children = const [],
   }) {
-    return FlexBox.builder(this, (context, spec) {
-      if (direction == Axis.horizontal) {
-        return RowBox(spec: spec, children: children);
-      }
-
-      return ColumnBox(spec: spec, children: children);
-    });
+    return call(direction: direction, children: children);
   }
 
   /// Convenient shorthand for creating a FlexBox widget with this StyleSpec.
   Widget call({required Axis direction, List<Widget> children = const []}) {
     switch (direction) {
       case Axis.horizontal:
-        return RowBox.builder(this, (context, spec) {
-          return RowBox(spec: spec, children: children);
-        });
+        return RowBox(styleSpec: this, children: children);
       case Axis.vertical:
-        return ColumnBox.builder(this, (context, spec) {
-          return ColumnBox(spec: spec, children: children);
-        });
+        return ColumnBox(styleSpec: this, children: children);
     }
   }
 }

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -14,7 +14,7 @@ class StyledIcon extends StyleWidget<IconSpec> {
     this.icon,
     this.semanticLabel,
     super.style = const IconStyler.create(),
-    super.spec,
+    super.styleSpec,
     super.key,
   });
 
@@ -51,23 +51,6 @@ class StyledIcon extends StyleWidget<IconSpec> {
   }
 }
 
-/// Extension to convert [IconSpec] directly to a [StyledIcon] widget.
-extension IconSpecWidget on IconSpec {
-  /// Creates a [StyledIcon] widget from this [IconSpec].
-  @Deprecated(
-    'Use StyledIcon(spec: this, icon: icon, semanticLabel: semanticLabel) instead',
-  )
-  Widget createWidget({IconData? icon, String? semanticLabel}) {
-    return StyledIcon(spec: this, icon: icon, semanticLabel: semanticLabel);
-  }
-
-  @Deprecated(
-    'Use StyledIcon(spec: this, icon: icon, semanticLabel: semanticLabel) instead',
-  )
-  Widget call({IconData? icon, String? semanticLabel}) {
-    return StyledIcon(spec: this, icon: icon, semanticLabel: semanticLabel);
-  }
-}
 
 extension IconSpecWrappedWidget on StyleSpec<IconSpec> {
   /// Creates a widget that resolves this [StyleSpec<IconSpec>] with context.
@@ -75,15 +58,15 @@ extension IconSpecWrappedWidget on StyleSpec<IconSpec> {
     'Use StyledIcon.builder(styleSpec, builder) for custom logic, or styleSpec(icon: icon, semanticLabel: semanticLabel) for simple cases',
   )
   Widget createWidget({IconData? icon, String? semanticLabel}) {
-    return StyledIcon.builder(this, (context, spec) {
-      return StyledIcon(spec: spec, icon: icon, semanticLabel: semanticLabel);
-    });
+    return call(icon: icon, semanticLabel: semanticLabel);
   }
 
   /// Convenient shorthand for creating a StyledIcon widget with this StyleSpec.
   Widget call({IconData? icon, String? semanticLabel}) {
-    return StyledIcon.builder(this, (context, spec) {
-      return StyledIcon(spec: spec, icon: icon, semanticLabel: semanticLabel);
-    });
+    return StyledIcon(
+      icon: icon,
+      semanticLabel: semanticLabel,
+      styleSpec: this,
+    );
   }
 }

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -51,17 +51,19 @@ class StyledIcon extends StyleWidget<IconSpec> {
   }
 }
 
-
 extension IconSpecWrappedWidget on StyleSpec<IconSpec> {
   /// Creates a widget that resolves this [StyleSpec<IconSpec>] with context.
   @Deprecated(
-    'Use StyledIcon.builder(styleSpec, builder) for custom logic, or styleSpec(icon: icon, semanticLabel: semanticLabel) for simple cases',
+    'Use StyledIcon(icon: icon, semanticLabel: semanticLabel, styleSpec: styleSpec) instead',
   )
   Widget createWidget({IconData? icon, String? semanticLabel}) {
     return call(icon: icon, semanticLabel: semanticLabel);
   }
 
   /// Convenient shorthand for creating a StyledIcon widget with this StyleSpec.
+  @Deprecated(
+    'Use StyledIcon(icon: icon, semanticLabel: semanticLabel, styleSpec: styleSpec) instead',
+  )
   Widget call({IconData? icon, String? semanticLabel}) {
     return StyledIcon(
       icon: icon,

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'icon_spec.dart';

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -13,7 +13,7 @@ class StyledImage extends StyleWidget<ImageSpec> {
   const StyledImage({
     super.key,
     super.style = const ImageStyler.create(),
-    super.spec,
+    super.styleSpec,
     this.frameBuilder,
     this.loadingBuilder,
     this.errorBuilder,
@@ -98,49 +98,6 @@ ImageProvider<Object> _resolveImage(
   return imageProvider;
 }
 
-/// Extension to convert [ImageSpec] directly to a [StyledImage] widget.
-extension ImageSpecWidget on ImageSpec {
-  /// Creates a [StyledImage] widget from this [ImageSpec].
-  @Deprecated(
-    'Use StyledImage(spec: this, image: image, frameBuilder: frameBuilder, loadingBuilder: loadingBuilder, errorBuilder: errorBuilder, opacity: opacity) instead',
-  )
-  Widget createWidget({
-    ImageProvider<Object>? image,
-    ImageFrameBuilder? frameBuilder,
-    ImageLoadingBuilder? loadingBuilder,
-    ImageErrorWidgetBuilder? errorBuilder,
-    Animation<double>? opacity,
-  }) {
-    return StyledImage(
-      spec: this,
-      frameBuilder: frameBuilder,
-      loadingBuilder: loadingBuilder,
-      errorBuilder: errorBuilder,
-      image: image,
-      opacity: opacity,
-    );
-  }
-
-  @Deprecated(
-    'Use StyledImage(spec: this, image: image, frameBuilder: frameBuilder, loadingBuilder: loadingBuilder, errorBuilder: errorBuilder, opacity: opacity) instead',
-  )
-  Widget call({
-    ImageProvider<Object>? image,
-    ImageFrameBuilder? frameBuilder,
-    ImageLoadingBuilder? loadingBuilder,
-    ImageErrorWidgetBuilder? errorBuilder,
-    Animation<double>? opacity,
-  }) {
-    return StyledImage(
-      spec: this,
-      frameBuilder: frameBuilder,
-      loadingBuilder: loadingBuilder,
-      errorBuilder: errorBuilder,
-      image: image,
-      opacity: opacity,
-    );
-  }
-}
 
 extension ImageSpecWrappedWidget on StyleSpec<ImageSpec> {
   /// Creates a widget that resolves this [StyleSpec<ImageSpec>] with context.
@@ -154,16 +111,13 @@ extension ImageSpecWrappedWidget on StyleSpec<ImageSpec> {
     ImageErrorWidgetBuilder? errorBuilder,
     Animation<double>? opacity,
   }) {
-    return StyledImage.builder(this, (context, spec) {
-      return StyledImage(
-        spec: spec,
-        frameBuilder: frameBuilder,
-        loadingBuilder: loadingBuilder,
-        errorBuilder: errorBuilder,
-        image: image,
-        opacity: opacity,
-      );
-    });
+    return call(
+      image: image,
+      frameBuilder: frameBuilder,
+      loadingBuilder: loadingBuilder,
+      errorBuilder: errorBuilder,
+      opacity: opacity,
+    );
   }
 
   /// Convenient shorthand for creating a StyledImage widget with this StyleSpec.
@@ -174,15 +128,13 @@ extension ImageSpecWrappedWidget on StyleSpec<ImageSpec> {
     ImageErrorWidgetBuilder? errorBuilder,
     Animation<double>? opacity,
   }) {
-    return StyledImage.builder(this, (context, spec) {
-      return StyledImage(
-        spec: spec,
-        frameBuilder: frameBuilder,
-        loadingBuilder: loadingBuilder,
-        errorBuilder: errorBuilder,
-        image: image,
-        opacity: opacity,
-      );
-    });
+    return StyledImage(
+      styleSpec: this,
+      frameBuilder: frameBuilder,
+      loadingBuilder: loadingBuilder,
+      errorBuilder: errorBuilder,
+      image: image,
+      opacity: opacity,
+    );
   }
 }

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -98,11 +98,10 @@ ImageProvider<Object> _resolveImage(
   return imageProvider;
 }
 
-
 extension ImageSpecWrappedWidget on StyleSpec<ImageSpec> {
   /// Creates a widget that resolves this [StyleSpec<ImageSpec>] with context.
   @Deprecated(
-    'Use StyledImage.builder(styleSpec, builder) for custom logic, or styleSpec(image: image, frameBuilder: frameBuilder, loadingBuilder: loadingBuilder, errorBuilder: errorBuilder, opacity: opacity) for simple cases',
+    'Use StyledImage(image: image, frameBuilder: frameBuilder, loadingBuilder: loadingBuilder, errorBuilder: errorBuilder, opacity: opacity, styleSpec: styleSpec) instead',
   )
   Widget createWidget({
     ImageProvider<Object>? image,
@@ -121,6 +120,9 @@ extension ImageSpecWrappedWidget on StyleSpec<ImageSpec> {
   }
 
   /// Convenient shorthand for creating a StyledImage widget with this StyleSpec.
+  @Deprecated(
+    'Use StyledImage(image: image, frameBuilder: frameBuilder, loadingBuilder: loadingBuilder, errorBuilder: errorBuilder, opacity: opacity, styleSpec: styleSpec) instead',
+  )
   Widget call({
     ImageProvider<Object>? image,
     ImageFrameBuilder? frameBuilder,

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'image_spec.dart';

--- a/packages/mix/lib/src/specs/stack/stack_widget.dart
+++ b/packages/mix/lib/src/specs/stack/stack_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import '../box/box_widget.dart';

--- a/packages/mix/lib/src/specs/stack/stack_widget.dart
+++ b/packages/mix/lib/src/specs/stack/stack_widget.dart
@@ -58,19 +58,15 @@ Stack _createStackSpecWidget({
   );
 }
 
-
-
-
 extension ZBoxSpecWrappedWidget on StyleSpec<ZBoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<ZBoxSpec>] with context.
-  @Deprecated(
-    'Use ZBox.builder(styleSpec, builder) for custom logic, or styleSpec(children: children) for simple cases',
-  )
+  @Deprecated('Use ZBox(children: children, styleSpec: styleSpec) instead')
   Widget createWidget({List<Widget> children = const []}) {
     return call(children: children);
   }
 
   /// Convenient shorthand for creating a ZBox widget with this StyleSpec.
+  @Deprecated('Use ZBox(children: children, styleSpec: styleSpec) instead')
   Widget call({List<Widget> children = const []}) {
     return ZBox(styleSpec: this, children: children);
   }

--- a/packages/mix/lib/src/specs/stack/stack_widget.dart
+++ b/packages/mix/lib/src/specs/stack/stack_widget.dart
@@ -14,7 +14,7 @@ import 'stack_spec.dart';
 class ZBox extends StyleWidget<ZBoxSpec> {
   const ZBox({
     super.style = const StackBoxStyler.create(),
-    super.spec,
+    super.styleSpec,
     this.children = const <Widget>[],
     super.key,
   });
@@ -37,7 +37,7 @@ class ZBox extends StyleWidget<ZBoxSpec> {
     final stack = _createStackSpecWidget(spec: stackSpec, children: children);
 
     if (boxStyleSpec != null) {
-      return Box(spec: boxStyleSpec.spec, child: stack);
+      return Box(styleSpec: boxStyleSpec, child: stack);
     }
 
     return stack;
@@ -58,55 +58,8 @@ Stack _createStackSpecWidget({
   );
 }
 
-/// Extension to convert [StackSpec] directly to a [Stack] widget.
-extension StackSpecWidget on StackSpec {
-  /// Creates a [Stack] widget from this [StackSpec].
-  @Deprecated('StackSpec is a component spec. Use ZBox for complete widgets')
-  Stack createWidget({List<Widget> children = const []}) {
-    return _createStackSpecWidget(spec: this, children: children);
-  }
 
-  @Deprecated('StackSpec is a component spec. Use ZBox for complete widgets')
-  Stack call({List<Widget> children = const []}) {
-    return _createStackSpecWidget(spec: this, children: children);
-  }
-}
 
-/// Extension to convert [ZBoxSpec] directly to a [ZBox] widget.
-extension ZBoxSpecWidget on ZBoxSpec {
-  /// Creates a [ZBox] widget from this [ZBoxSpec].
-  @Deprecated('Use ZBox(spec: this, children: children) instead')
-  Widget createWidget({List<Widget> children = const []}) {
-    return ZBox(spec: this, children: children);
-  }
-
-  @Deprecated('Use ZBox(spec: this, children: children) instead')
-  Widget call({List<Widget> children = const []}) {
-    return createWidget(children: children);
-  }
-}
-
-extension StackSpecWrappedWidget on StyleSpec<StackSpec> {
-  /// Creates a widget that resolves this [StyleSpec<StackSpec>] with context.
-  @Deprecated(
-    'StackSpec is a component spec. Use ZBox.builder() with ZBoxSpec instead',
-  )
-  Widget createWidget({List<Widget> children = const []}) {
-    return StyleSpecBuilder(
-      builder: (context, spec) {
-        return _createStackSpecWidget(spec: spec, children: children);
-      },
-      styleSpec: this,
-    );
-  }
-
-  @Deprecated(
-    'StackSpec is a component spec. Use ZBox.builder() with ZBoxSpec instead',
-  )
-  Widget call({List<Widget> children = const []}) {
-    return createWidget(children: children);
-  }
-}
 
 extension ZBoxSpecWrappedWidget on StyleSpec<ZBoxSpec> {
   /// Creates a widget that resolves this [StyleSpec<ZBoxSpec>] with context.
@@ -114,15 +67,11 @@ extension ZBoxSpecWrappedWidget on StyleSpec<ZBoxSpec> {
     'Use ZBox.builder(styleSpec, builder) for custom logic, or styleSpec(children: children) for simple cases',
   )
   Widget createWidget({List<Widget> children = const []}) {
-    return ZBox.builder(this, (context, spec) {
-      return ZBox(spec: spec, children: children);
-    });
+    return call(children: children);
   }
 
   /// Convenient shorthand for creating a ZBox widget with this StyleSpec.
   Widget call({List<Widget> children = const []}) {
-    return ZBox.builder(this, (context, spec) {
-      return ZBox(spec: spec, children: children);
-    });
+    return ZBox(styleSpec: this, children: children);
   }
 }

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -51,17 +51,15 @@ class StyledText extends StyleWidget<TextSpec> {
   }
 }
 
-
 extension TextSpecWrappedWidget on StyleSpec<TextSpec> {
   /// Creates a widget that resolves this [StyleSpec<TextSpec>] with context.
-  @Deprecated(
-    'Use StyledText.builder(styleSpec, builder) for custom logic, or styleSpec(text) for simple cases',
-  )
+  @Deprecated('Use StyledText(text, styleSpec: styleSpec) instead')
   Widget createWidget(String text) {
     return call(text);
   }
 
   /// Convenient shorthand for creating a StyledText widget with this StyleSpec.
+  @Deprecated('Use StyledText(text, styleSpec: styleSpec) instead')
   Widget call(String text) {
     return StyledText(text, styleSpec: this);
   }

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -15,7 +15,7 @@ class StyledText extends StyleWidget<TextSpec> {
   const StyledText(
     this.text, {
     super.style = const TextStyler.create(),
-    super.spec,
+    super.styleSpec,
     super.key,
   });
 
@@ -51,19 +51,6 @@ class StyledText extends StyleWidget<TextSpec> {
   }
 }
 
-/// Extension to convert [TextSpec] directly to a [StyledText] widget.
-extension TextSpecWidget on TextSpec {
-  /// Creates a [StyledText] widget from this [TextSpec].
-  @Deprecated('Use StyledText(text, spec: this) instead')
-  Widget createWidget(String text) {
-    return StyledText(text, spec: this);
-  }
-
-  @Deprecated('Use StyledText(text, spec: this) instead')
-  Widget call(String text) {
-    return StyledText(text, spec: this);
-  }
-}
 
 extension TextSpecWrappedWidget on StyleSpec<TextSpec> {
   /// Creates a widget that resolves this [StyleSpec<TextSpec>] with context.
@@ -71,15 +58,11 @@ extension TextSpecWrappedWidget on StyleSpec<TextSpec> {
     'Use StyledText.builder(styleSpec, builder) for custom logic, or styleSpec(text) for simple cases',
   )
   Widget createWidget(String text) {
-    return StyledText.builder(this, (context, spec) {
-      return StyledText(text, spec: spec);
-    });
+    return call(text);
   }
 
   /// Convenient shorthand for creating a StyledText widget with this StyleSpec.
   Widget call(String text) {
-    return StyledText.builder(this, (context, spec) {
-      return StyledText(text, spec: spec);
-    });
+    return StyledText(text, styleSpec: this);
   }
 }

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import '../../core/directive.dart';
-import '../../core/style_builder.dart';
 import '../../core/style_spec.dart';
 import '../../core/style_widget.dart';
 import 'text_spec.dart';

--- a/packages/mix/test/src/modifiers/box_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/box_modifier_test.dart
@@ -24,7 +24,8 @@ void main() {
       expect(result, isA<Box>());
       final box = result as Box;
       expect(box.child, equals(child));
-      expect(box.styleSpec, equals(spec));
+      expect(box.styleSpec, isA<StyleSpec<BoxSpec>>());
+      expect(box.styleSpec!.spec, equals(spec));
     });
 
     test('copyWith creates new instance with updated spec', () {

--- a/packages/mix/test/src/modifiers/box_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/box_modifier_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(result, isA<Box>());
       final box = result as Box;
       expect(box.child, equals(child));
-      expect(box.spec, equals(spec));
+      expect(box.styleSpec, equals(spec));
     });
 
     test('copyWith creates new instance with updated spec', () {

--- a/packages/mix/test/src/specs/box/box_widget_test.dart
+++ b/packages/mix/test/src/specs/box/box_widget_test.dart
@@ -13,7 +13,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                Box(spec: const BoxSpec(), key: boxKey),
+                Box(key: boxKey),
                 Container(key: containerKey),
               ],
             ),
@@ -105,7 +105,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                Box(spec: const BoxSpec(), key: boxKey),
+                Box(key: boxKey),
                 Container(key: containerKey),
               ],
             ),

--- a/packages/mix/test/src/specs/flexbox/flexbox_widget_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_widget_test.dart
@@ -81,7 +81,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                RowBox(spec: const FlexBoxSpec(), key: hBoxKey),
+                RowBox( key: hBoxKey),
                 Row(key: rowKey, children: const []),
               ],
             ),
@@ -121,7 +121,7 @@ void main() {
           home: Scaffold(
             body: Row(
               children: [
-                ColumnBox(spec: const FlexBoxSpec(), key: vBoxKey),
+                ColumnBox( key: vBoxKey),
                 Column(key: columnKey, children: const []),
               ],
             ),
@@ -161,7 +161,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                FlexBox(spec: const FlexBoxSpec(), key: flexBoxKey),
+                FlexBox( key: flexBoxKey),
                 Flex(
                   direction: Axis.horizontal,
                   key: flexKey,

--- a/packages/mix/test/src/specs/icon/icon_widget_test.dart
+++ b/packages/mix/test/src/specs/icon/icon_widget_test.dart
@@ -14,7 +14,10 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                StyledIcon(spec: const IconSpec(), icon: testIcon, key: styledIconKey),
+                StyledIcon(
+                  icon: testIcon,
+                  key: styledIconKey,
+                ),
                 Icon(testIcon, key: iconKey),
               ],
             ),

--- a/packages/mix/test/src/specs/image/image_widget_test.dart
+++ b/packages/mix/test/src/specs/image/image_widget_test.dart
@@ -15,7 +15,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                StyledImage(spec: const ImageSpec(), key: styledImageKey, image: imageProvider),
+                StyledImage(key: styledImageKey, image: imageProvider),
                 Image(key: imageKey, image: imageProvider),
               ],
             ),

--- a/packages/mix/test/src/specs/stack/stack_widget_test.dart
+++ b/packages/mix/test/src/specs/stack/stack_widget_test.dart
@@ -97,7 +97,10 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                ZBox(spec: const ZBoxSpec(), key: zBoxKey, children: const []),
+                ZBox(
+                  key: zBoxKey,
+                  children: const [],
+                ),
                 Stack(key: stackKey, children: const []),
               ],
             ),

--- a/packages/mix/test/src/specs/text/text_widget_test.dart
+++ b/packages/mix/test/src/specs/text/text_widget_test.dart
@@ -14,7 +14,7 @@ void main() {
           home: Scaffold(
             body: Column(
               children: [
-                StyledText(testText, spec: const TextSpec(), key: styledTextKey),
+                StyledText(testText, key: styledTextKey),
                 Text(testText, key: textKey),
               ],
             ),


### PR DESCRIPTION
## Summary
- Refactored `StyleWidget` to use `styleSpec` parameter instead of `spec` for better consistency
- Updated all Mix widget constructors to use unified `styleSpec` naming convention
- Deprecated StyleSpec extension methods with clear migration guidance
- Cleaned up redundant builder patterns and simplified widget creation
- Maintained backward compatibility through proper deprecation notices

## Key Changes

### StyleWidget API Migration
- Changed `StyleWidget.spec` parameter to `StyleWidget.styleSpec` with type `StyleSpec<S>?`
- Updated widget classes: Box, FlexBox, RowBox, ColumnBox, ZBox, StyledText, StyledIcon, StyledImage
- Modified StyleSpecBuilder integration to use new parameter structure

### Extension Method Improvements  
- Deprecated all StyleSpec extension `call()` and `createWidget()` methods
- Updated deprecation messages to guide users to direct widget constructors
- Simplified extension implementations by removing StyleSpecBuilder dependencies

### Code Cleanup
- Removed deprecated spec-based extensions (BoxSpecWidget, TextSpecWidget, etc.)
- Cleaned up redundant imports and unused builder patterns
- Updated all test files to reflect new parameter naming

## Migration Guide

### Before
```dart
// Old approach
Box(spec: boxSpec, child: widget)
styleSpec(child: widget)
```

### After  
```dart
// New approach
Box(styleSpec: boxSpec, child: widget)
Box(styleSpec: styleSpec, child: widget)
```

## Breaking Changes
- `StyleWidget.spec` parameter renamed to `StyleWidget.styleSpec`
- Widget constructors now expect `styleSpec` instead of `spec`
- Several extension methods marked as deprecated

## Test Plan
- [x] All widget tests updated for new parameter names
- [x] Extension method deprecations verified  
- [x] Widget construction patterns confirmed working
- [x] Backward compatibility maintained through deprecation notices