### PR TITLE
fix: widget state tracking logic in StyleBuilder

### DIFF
--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -94,9 +94,12 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
       // If we need interactivity and no MixWidgetStateModel is present,
       // wrap in MixInteractionDetector
       current = MixInteractionDetector(controller: _controller, child: current);
-    } else if (widget.controller?.value case final widgetStates?) {
-      // If we have a controller, wrap with WidgetStateProvider
-      current = WidgetStateProvider(states: widgetStates, child: current);
+    } else if (widget.controller != null) {
+      // If we have an external controller, wrap with _ExternalControllerProvider
+      current = _ExternalControllerProvider(
+        controller: _controller,
+        child: current,
+      );
     }
 
     // If inheritable is true, wrap with StyleProvider to pass the merged style down
@@ -166,6 +169,26 @@ class StyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
         }
 
         return animatedChild;
+      },
+    );
+  }
+}
+
+class _ExternalControllerProvider extends StatelessWidget {
+  const _ExternalControllerProvider({
+    required this.controller,
+    required this.child,
+  });
+
+  final WidgetStatesController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (_, _) {
+        return WidgetStateProvider(states: controller.value, child: child);
       },
     );
   }


### PR DESCRIPTION
### Description

Updates the condition for tracking widget state to handle cases where a controller is provided. Adds a test to verify that StyleBuilder correctly uses the controller to track widget state and update styles.

### Changes

List specific changes made in this PR.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
