### PR TITLE
feat: Add DefaultStyledText and DefaultStyledIcon typedefs

### DIFF
--- a/packages/mix/example/lib/api/default_widgets/default_styled_text.dart
+++ b/packages/mix/example/lib/api/default_widgets/default_styled_text.dart
@@ -26,8 +26,8 @@ class Example extends StatelessWidget {
       child: DefaultStyledText(
         style: baseStyle,
         child: Column(
-          spacing: 16,
           mainAxisSize: MainAxisSize.min,
+          spacing: 16,
           children: [
             StyledText('hello world'),
             StyledText(

--- a/packages/mix/example/lib/api/default_widgets/default_styled_text.dart
+++ b/packages/mix/example/lib/api/default_widgets/default_styled_text.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers.dart';
+
+void main() {
+  runMixApp(Example());
+}
+
+class Example extends StatelessWidget {
+  const Example({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final baseStyle = TextStyler()
+        .fontSize(50)
+        .fontWeight(FontWeight.w600)
+        .color(Colors.blue.shade700)
+        .onHovered(TextStyler().color(Colors.red))
+        .animate(AnimationConfig.easeInOut(1.s));
+
+    final iconStyle = IconStyler().size(20).color(Colors.blueAccent);
+
+    return DefaultStyledIcon(
+      style: iconStyle,
+      child: DefaultStyledText(
+        style: baseStyle,
+        child: Column(
+          spacing: 16,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            StyledText('hello world'),
+            StyledText(
+              'Mix is awesome',
+              style: TextStyler().onHovered(
+                TextStyler().color(Colors.deepPurple),
+              ),
+            ),
+            StyledIcon(icon: Icons.ac_unit),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/mix/lib/src/core/providers/style_provider.dart
+++ b/packages/mix/lib/src/core/providers/style_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 
+import '../../specs/icon/icon_spec.dart';
+import '../../specs/text/text_spec.dart';
 import '../spec.dart';
 import '../style.dart';
 
@@ -22,3 +24,17 @@ class StyleProvider<S extends Spec<S>> extends InheritedWidget {
     return style != oldWidget.style;
   }
 }
+
+/// Provides [TextStyler] to descendant [StyledText].
+///
+/// This is a convenience typedef for [StyleProvider<TextSpec>] that makes it
+/// easier to provide [TextStyler] (font, color, size, etc.) to descendant
+/// [StyledText] widgets through the widget tree.
+typedef DefaultStyledText = StyleProvider<TextSpec>;
+
+/// Provides [IconStyler] to descendant [StyledIcon] widgets.
+///
+/// This is a convenience typedef for [StyleProvider<IconSpec>] that makes it
+/// easier to provide [IconStyler] (size, color, theme, etc.) to descendant
+/// [StyledIcon] widgets through the widget tree.
+typedef DefaultStyledIcon = StyleProvider<IconSpec>;

--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -56,6 +56,12 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
     _controller = widget.controller ?? WidgetStatesController();
   }
 
+  Style<S> _buildStyle(BuildContext context) {
+    final inheritedStyle = StyleProvider.maybeOf<S>(context);
+
+    return inheritedStyle?.merge(widget.style) ?? widget.style;
+  }
+
   @override
   void dispose() {
     // Only dispose controllers we created internally
@@ -68,20 +74,17 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
 
   @override
   Widget build(BuildContext context) {
-    final widgetStates = widget.style.widgetStates;
+    final style = _buildStyle(context);
 
     // Calculate interactivity need early
     final needsToTrackWidgetState =
-        widget.controller == null && widgetStates.isNotEmpty;
+        widget.controller == null && style.widgetStates.isNotEmpty;
 
     final alreadyHasWidgetStateScope = WidgetStateProvider.of(context) != null;
 
-    final inheritedStyle = StyleProvider.maybeOf<S>(context);
-    final mergedStyle = inheritedStyle?.merge(widget.style) ?? widget.style;
-
     Widget current = Builder(
       builder: (context) {
-        final wrappedSpec = mergedStyle.build(context);
+        final wrappedSpec = style.build(context);
 
         return StyleSpecBuilder(
           builder: widget.builder,
@@ -104,7 +107,7 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
 
     // If inheritable is true, wrap with StyleProvider to pass the merged style down
     if (widget.inheritable) {
-      current = StyleProvider<S>(style: mergedStyle, child: current);
+      current = StyleProvider<S>(style: style, child: current);
     }
 
     return current;

--- a/packages/mix/test/src/core/style_builder_test.dart
+++ b/packages/mix/test/src/core/style_builder_test.dart
@@ -732,7 +732,7 @@ void main() {
       });
 
       testWidgets(
-        'Should track widgetState when the style on the provider has context variants',
+        'Should create MixInteractionDetector when StyleProvider\'s style contains widget state variants',
         (tester) async {
           // Parent style provides a variant for hovered state
           final parentStyle = BoxStyler()


### PR DESCRIPTION
### Description
Introduces `DefaultStyledText` and `DefaultStyledIcon` as convenience typedefs for `StyleProvider`, simplifying the provision of text and icon styles to descendant widgets. Adds an example demonstrating their usage and updates StyleBuilder to properly merge inherited styles. Includes new tests to verify widget state tracking with context variants.

### Changes
- add `DefaultStyledText` and `DefaultStyledIcon`
- fix StyleProvider logic

List specific changes made in this PR.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
