### PR TITLE
refactor: remove unsupported widget state variants

### DIFF
--- a/packages/mix/example/lib/api/context_variants/selected.dart
+++ b/packages/mix/example/lib/api/context_variants/selected.dart
@@ -30,7 +30,10 @@ class _ExampleState extends State<Example> {
         .height(100)
         .width(100)
         .borderRounded(10)
-        .onSelected(BoxStyler().color(Colors.blue));
+        .variant(
+          ContextVariant.widgetState(WidgetState.selected),
+          BoxStyler().color(Colors.blue),
+        );
 
     return Pressable(
       onPress: () {

--- a/packages/mix/example/lib/api/context_variants/selected_toggle.dart
+++ b/packages/mix/example/lib/api/context_variants/selected_toggle.dart
@@ -31,7 +31,8 @@ class _ExampleState extends State<Example> {
         .color(Colors.grey.shade200)
         .borderAll(color: Colors.grey.shade300, width: 2)
         .animate(AnimationConfig.spring(300.ms))
-        .onSelected(
+        .variant(
+          ContextVariant.widgetState(WidgetState.selected),
           BoxStyler()
               .color(Colors.blue.shade500)
               .borderAll(color: Colors.blue.shade600, width: 2)
@@ -46,7 +47,10 @@ class _ExampleState extends State<Example> {
         .fontSize(16)
         .fontWeight(FontWeight.w600)
         .color(Colors.grey.shade700)
-        .onSelected(TextStyler().color(Colors.white));
+        .variant(
+          ContextVariant.widgetState(WidgetState.selected),
+          TextStyler().color(Colors.white),
+        );
 
     return Pressable(
       onPress: () {

--- a/packages/mix/example/lib/components/chip_button.dart
+++ b/packages/mix/example/lib/components/chip_button.dart
@@ -17,7 +17,10 @@ final chipButtonContainer = BoxStyler()
     .color(Colors.blue)
     .borderRounded(20)
     .onHovered(BoxStyler().color(Colors.blue.shade700))
-    .onSelected(BoxStyler().color(Colors.black))
+    .variant(
+      ContextVariant.widgetState(WidgetState.selected),
+      BoxStyler().color(Colors.black),
+    )
     .alignment(Alignment.center)
     .wrap(WidgetModifierConfig.defaultText(chipButtonLabel))
     .animate(AnimationConfig.easeInOut(300.ms));

--- a/packages/mix/lib/src/specs/box/box_style_api.md
+++ b/packages/mix/lib/src/specs/box/box_style_api.md
@@ -335,7 +335,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(BoxStyler style)** → BoxStyler - Applies style when pressed
 - **onFocused(BoxStyler style)** → BoxStyler - Applies style when focused
 - **onDisabled(BoxStyler style)** → BoxStyler - Applies style when disabled
-- **onSelected(BoxStyler style)** → BoxStyler - Applies style when selected
+- **onEnabled(BoxStyler style)** → BoxStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, BoxStyler style)** → BoxStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/flex/flex_style_api.md
+++ b/packages/mix/lib/src/specs/flex/flex_style_api.md
@@ -276,7 +276,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(FlexStyler style)** → FlexStyler - Applies style when pressed
 - **onFocused(FlexStyler style)** → FlexStyler - Applies style when focused
 - **onDisabled(FlexStyler style)** → FlexStyler - Applies style when disabled
-- **onSelected(FlexStyler style)** → FlexStyler - Applies style when selected
+- **onEnabled(FlexStyler style)** → FlexStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, FlexStyler style)** → FlexStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style_api.md
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style_api.md
@@ -352,7 +352,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(FlexBoxStyler style)** → FlexBoxStyler - Applies style when pressed
 - **onFocused(FlexBoxStyler style)** → FlexBoxStyler - Applies style when focused
 - **onDisabled(FlexBoxStyler style)** → FlexBoxStyler - Applies style when disabled
-- **onSelected(FlexBoxStyler style)** → FlexBoxStyler - Applies style when selected
+- **onEnabled(FlexBoxStyler style)** → FlexBoxStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, FlexBoxStyler style)** → FlexBoxStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/icon/icon_style_api.md
+++ b/packages/mix/lib/src/specs/icon/icon_style_api.md
@@ -277,7 +277,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(IconStyler style)** → IconStyler - Applies style when pressed
 - **onFocused(IconStyler style)** → IconStyler - Applies style when focused
 - **onDisabled(IconStyler style)** → IconStyler - Applies style when disabled
-- **onSelected(IconStyler style)** → IconStyler - Applies style when selected
+- **onEnabled(IconStyler style)** → IconStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, IconStyler style)** → IconStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/image/image_style_api.md
+++ b/packages/mix/lib/src/specs/image/image_style_api.md
@@ -318,7 +318,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(ImageStyler style)** → ImageStyler - Applies style when pressed
 - **onFocused(ImageStyler style)** → ImageStyler - Applies style when focused
 - **onDisabled(ImageStyler style)** → ImageStyler - Applies style when disabled
-- **onSelected(ImageStyler style)** → ImageStyler - Applies style when selected
+- **onEnabled(ImageStyler style)** → ImageStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, ImageStyler style)** → ImageStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/stack/stack_box_style_api.md
+++ b/packages/mix/lib/src/specs/stack/stack_box_style_api.md
@@ -248,7 +248,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(StackBoxStyler style)** → StackBoxStyler - Applies style when pressed
 - **onFocused(StackBoxStyler style)** → StackBoxStyler - Applies style when focused
 - **onDisabled(StackBoxStyler style)** → StackBoxStyler - Applies style when disabled
-- **onSelected(StackBoxStyler style)** → StackBoxStyler - Applies style when selected
+- **onEnabled(StackBoxStyler style)** → StackBoxStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, StackBoxStyler style)** → StackBoxStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/stack/stack_style_api.md
+++ b/packages/mix/lib/src/specs/stack/stack_style_api.md
@@ -200,7 +200,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(StackStyler style)** → StackStyler - Applies style when pressed
 - **onFocused(StackStyler style)** → StackStyler - Applies style when focused
 - **onDisabled(StackStyler style)** → StackStyler - Applies style when disabled
-- **onSelected(StackStyler style)** → StackStyler - Applies style when selected
+- **onEnabled(StackStyler style)** → StackStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, StackStyler style)** → StackStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/specs/text/text_style_api.md
+++ b/packages/mix/lib/src/specs/text/text_style_api.md
@@ -301,7 +301,7 @@ Adds a single variant with the given variant condition and style.
 - **onPressed(TextStyler style)** → TextStyler - Applies style when pressed
 - **onFocused(TextStyler style)** → TextStyler - Applies style when focused
 - **onDisabled(TextStyler style)** → TextStyler - Applies style when disabled
-- **onSelected(TextStyler style)** → TextStyler - Applies style when selected
+- **onEnabled(TextStyler style)** → TextStyler - Applies style when enabled
 
 #### Responsive Variants
 - **onBreakpoint(Breakpoint breakpoint, TextStyler style)** → TextStyler - Applies style at specific breakpoint

--- a/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
@@ -76,29 +76,6 @@ mixin VariantStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
     return variant(ContextVariant.widgetState(WidgetState.disabled), style);
   }
 
-  /// Creates a variant for selected state
-  T onSelected(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.selected), style);
-  }
-
-  /// Creates a variant for error state
-  T onError(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.error), style);
-  }
-
-  /// Creates a variant for scrolled under state
-  T onScrolledUnder(T style) {
-    return variant(
-      ContextVariant.widgetState(WidgetState.scrolledUnder),
-      style,
-    );
-  }
-
-  /// Creates a variant for dragged state
-  T onDragged(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.dragged), style);
-  }
-
   /// Creates a variant for enabled state (opposite of disabled)
   T onEnabled(T style) {
     return variant(

--- a/packages/mix/test/src/variants/variant_mixin_test.dart
+++ b/packages/mix/test/src/variants/variant_mixin_test.dart
@@ -104,16 +104,6 @@ void main() {
       expect(result.$variants!.first.variant, isA<ContextVariant>());
     });
 
-    test('onSelected creates correct variant', () {
-      const attribute = TestVariantAttribute();
-      const style = TestVariantAttribute();
-      final result = attribute.onSelected(style);
-
-      expect(result.$variants, isNotNull);
-      expect(result.$variants!.length, 1);
-      expect(result.$variants!.first.variant, isA<ContextVariant>());
-    });
-
     test('onMobile creates correct variant', () {
       const attribute = TestVariantAttribute();
       const style = TestVariantAttribute();
@@ -178,36 +168,6 @@ void main() {
 
       expect(result.$variants!.first.value, equals(darkStyle));
       expect(result.$variants!.last.value, equals(hoverStyle));
-    });
-
-    test('onError creates correct variant', () {
-      const attribute = TestVariantAttribute();
-      const style = TestVariantAttribute();
-      final result = attribute.onError(style);
-
-      expect(result.$variants, isNotNull);
-      expect(result.$variants!.length, 1);
-      expect(result.$variants!.first.variant, isA<ContextVariant>());
-    });
-
-    test('onScrolledUnder creates correct variant', () {
-      const attribute = TestVariantAttribute();
-      const style = TestVariantAttribute();
-      final result = attribute.onScrolledUnder(style);
-
-      expect(result.$variants, isNotNull);
-      expect(result.$variants!.length, 1);
-      expect(result.$variants!.first.variant, isA<ContextVariant>());
-    });
-
-    test('onDragged creates correct variant', () {
-      const attribute = TestVariantAttribute();
-      const style = TestVariantAttribute();
-      final result = attribute.onDragged(style);
-
-      expect(result.$variants, isNotNull);
-      expect(result.$variants!.length, 1);
-      expect(result.$variants!.first.variant, isA<ContextVariant>());
     });
 
     test('onEnabled creates correct variant', () {


### PR DESCRIPTION
## Summary
Removes variant convenience methods that are not automatically managed by Mix's core widgets (Pressable, Box, etc.). This cleanup improves API clarity and prevents confusion about which states are actually supported.

## Motivation
The default Mix widgets (Pressable, Box, etc.) do not react to certain widget states because they are not automatically managed by the framework. Providing convenience methods for these states created confusion and implied functionality that wasn't present.

## Changes

### Removed Variants
- **`onSelected`** - Not automatically managed by Pressable; requires manual state tracking
- **`onError`** - Not managed by Mix widgets
- **`onDragged`** - Not managed by Mix widgets  
- **`onScrolledUnder`** - Not managed by Mix widgets

### Kept Variants (Fully Supported)
- **`onHovered`** ✅ - Managed by Pressable via MixInteractionDetector
- **`onPressed`** ✅ - Managed by Pressable
- **`onFocused`** ✅ - Managed by Pressable
- **`onDisabled`** ✅ - Managed by Pressable via enabled flag
- **`onEnabled`** ✅ - Inverse of onDisabled, useful for styling enabled states

## Migration Guide

For removed states that still need manual state management, use the direct variant API:

**Before:**
```dart
BoxStyler().onSelected(BoxStyler().color(Colors.blue))
```

**After:**
```dart
BoxStyler().variant(
  ContextVariant.widgetState(WidgetState.selected),
  BoxStyler().color(Colors.blue),
)
```

## Files Changed
- Updated `VariantStyleMixin` to remove unsupported methods
- Updated all API documentation files
- Updated test files to remove tests for removed variants
- Updated example files demonstrating manual state management

## Testing
- ✅ All tests pass
- ✅ `dart analyze` - no new issues
- ✅ `dcm analyze` - no issues found
- ✅ Examples build successfully