### PR TITLE
refactor: extract widget state variant mixins into separate files

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -48,6 +48,7 @@ export 'src/core/style_spec.dart';
 export 'src/core/style_widget.dart';
 export 'src/core/utility.dart';
 export 'src/core/utility_variant_mixin.dart';
+export 'src/core/utility_widget_state_variant_mixin.dart';
 export 'src/core/widget_modifier.dart';
 export 'src/modifiers/align_modifier.dart';
 export 'src/modifiers/aspect_ratio_modifier.dart';
@@ -155,6 +156,7 @@ export 'src/style/mixins/spacing_style_mixin.dart';
 export 'src/style/mixins/text_style_mixin.dart';
 export 'src/style/mixins/transform_style_mixin.dart';
 export 'src/style/mixins/variant_style_mixin.dart';
+export 'src/style/mixins/widget_state_variant_mixin.dart';
 export 'src/style/mixins/widget_modifier_style_mixin.dart';
 
 /// THEME

--- a/packages/mix/lib/src/core/utility_variant_mixin.dart
+++ b/packages/mix/lib/src/core/utility_variant_mixin.dart
@@ -19,26 +19,6 @@ mixin UtilityVariantMixin<T extends Style<S>, S extends Spec<S>> {
   /// Gets the current utility value as a style.
   T get currentValue;
 
-  /// Creates a variant for hover state.
-  ///
-  /// Example:
-  /// ```dart
-  /// $box.onHovered($box.color.red())
-  /// ```
-  T onHovered(T style) {
-    return withVariant(ContextVariant.widgetState(WidgetState.hovered), style);
-  }
-
-  /// Creates a variant for pressed state.
-  ///
-  /// Example:
-  /// ```dart
-  /// $box.onPressed($box.color.blue())
-  /// ```
-  T onPressed(T style) {
-    return withVariant(ContextVariant.widgetState(WidgetState.pressed), style);
-  }
-
   /// Creates a variant for dark mode.
   ///
   /// Example:

--- a/packages/mix/lib/src/core/utility_widget_state_variant_mixin.dart
+++ b/packages/mix/lib/src/core/utility_widget_state_variant_mixin.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../variants/variant.dart';
+import 'spec.dart';
+import 'style.dart';
+
+/// Mixin providing widget state variant methods for utility classes.
+///
+/// This mixin provides widget state variant methods for styling utilities with
+/// a simple delegation approach. All methods return Style types for consistency
+/// with other utility methods like animate().
+mixin UtilityWidgetStateVariantMixin<T extends Style<S>, S extends Spec<S>> {
+  /// Must be implemented by utilities to apply a variant to a style.
+  T withVariant(Variant variant, T style);
+
+  /// Creates a variant for hover state.
+  ///
+  /// Example:
+  /// ```dart
+  /// $box.onHovered($box.color.red())
+  /// ```
+  T onHovered(T style) {
+    return withVariant(ContextVariant.widgetState(WidgetState.hovered), style);
+  }
+
+  /// Creates a variant for pressed state.
+  ///
+  /// Example:
+  /// ```dart
+  /// $box.onPressed($box.color.blue())
+  /// ```
+  T onPressed(T style) {
+    return withVariant(ContextVariant.widgetState(WidgetState.pressed), style);
+  }
+
+  /// Creates a variant for focused state.
+  ///
+  /// Example:
+  /// ```dart
+  /// $box.onFocused($box.color.green())
+  /// ```
+  T onFocused(T style) {
+    return withVariant(ContextVariant.widgetState(WidgetState.focused), style);
+  }
+
+  /// Creates a variant for disabled state.
+  ///
+  /// Example:
+  /// ```dart
+  /// $box.onDisabled($box.color.grey())
+  /// ```
+  T onDisabled(T style) {
+    return withVariant(ContextVariant.widgetState(WidgetState.disabled), style);
+  }
+
+  /// Creates a variant for enabled state (opposite of disabled).
+  ///
+  /// Example:
+  /// ```dart
+  /// $box.onEnabled($box.color.blue())
+  /// ```
+  T onEnabled(T style) {
+    return withVariant(
+      ContextVariant.not(ContextVariant.widgetState(WidgetState.disabled)),
+      style,
+    );
+  }
+}

--- a/packages/mix/lib/src/specs/box/box_mutable_style.dart
+++ b/packages/mix/lib/src/specs/box/box_mutable_style.dart
@@ -7,6 +7,7 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/layout/constraints_util.dart';
@@ -22,7 +23,9 @@ import 'box_style.dart';
 /// Supports the same API as [BoxStyler] but maintains mutable internal state
 /// enabling fluid styling: `$box..color.red()..width(100)`.
 class BoxMutableStyler extends StyleMutableBuilder<BoxSpec>
-    with UtilityVariantMixin<BoxStyler, BoxSpec> {
+    with
+        UtilityVariantMixin<BoxStyler, BoxSpec>,
+        UtilityWidgetStateVariantMixin<BoxStyler, BoxSpec> {
   late final padding = EdgeInsetsGeometryUtility<BoxStyler>(
     (prop) => mutable.merge(BoxStyler.create(padding: Prop.mix(prop))),
   );

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -22,6 +22,7 @@ import '../../style/mixins/shadow_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'box_spec.dart';
 import 'box_mutable_style.dart';
 import 'box_widget.dart';
@@ -38,6 +39,7 @@ class BoxStyler extends Style<BoxSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<BoxStyler, BoxSpec>,
         VariantStyleMixin<BoxStyler, BoxSpec>,
+        WidgetStateVariantMixin<BoxStyler, BoxSpec>,
         BorderStyleMixin<BoxStyler>,
         BorderRadiusStyleMixin<BoxStyler>,
         ShadowStyleMixin<BoxStyler>,

--- a/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_mutable_style.dart
@@ -6,6 +6,7 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../variants/variant.dart';
@@ -18,7 +19,9 @@ import 'flex_style.dart';
 /// Supports the same API as [FlexStyler] but maintains mutable internal state
 /// enabling fluid styling: `$flex..direction(Axis.horizontal)..spacing(8)`.
 class FlexMutableStyler extends StyleMutableBuilder<FlexSpec>
-    with UtilityVariantMixin<FlexStyler, FlexSpec> {
+    with
+        UtilityVariantMixin<FlexStyler, FlexSpec>,
+        UtilityWidgetStateVariantMixin<FlexStyler, FlexSpec> {
   late final direction = MixUtility(mutable.direction);
 
   late final mainAxisAlignment = MixUtility(mutable.mainAxisAlignment);

--- a/packages/mix/lib/src/specs/flex/flex_style.dart
+++ b/packages/mix/lib/src/specs/flex/flex_style.dart
@@ -12,6 +12,7 @@ import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/flex_style_mixin.dart';
 import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'flex_spec.dart';
 import 'flex_mutable_style.dart';
 
@@ -30,6 +31,7 @@ class FlexStyler extends Style<FlexSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<FlexStyler, FlexSpec>,
         VariantStyleMixin<FlexStyler, FlexSpec>,
+        WidgetStateVariantMixin<FlexStyler, FlexSpec>,
         FlexStyleMixin<FlexStyler>,
         AnimationStyleMixin<FlexStyler, FlexSpec> {
   final Prop<Axis>? $direction;

--- a/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_mutable_style.dart
@@ -7,6 +7,7 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/layout/constraints_util.dart';
@@ -22,7 +23,9 @@ import 'flexbox_style.dart';
 /// Combines box and flex styling capabilities. Supports the same API as [FlexBoxStyler]
 /// but maintains mutable internal state enabling fluid styling: `$flexbox..color.red()..width(100)`.
 class FlexBoxMutableStyler extends StyleMutableBuilder<FlexBoxSpec>
-    with UtilityVariantMixin<FlexBoxStyler, FlexBoxSpec> {
+    with
+        UtilityVariantMixin<FlexBoxStyler, FlexBoxSpec>,
+        UtilityWidgetStateVariantMixin<FlexBoxStyler, FlexBoxSpec> {
   late final padding = EdgeInsetsGeometryUtility<FlexBoxStyler>(
     (prop) => mutable.merge(FlexBoxStyler(padding: prop)),
   );

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -22,6 +22,7 @@ import '../../style/mixins/shadow_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import '../box/box_spec.dart';
 import '../box/box_style.dart';
 import '../flex/flex_spec.dart';
@@ -43,6 +44,7 @@ class FlexBoxStyler extends Style<FlexBoxSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<FlexBoxStyler, FlexBoxSpec>,
         VariantStyleMixin<FlexBoxStyler, FlexBoxSpec>,
+        WidgetStateVariantMixin<FlexBoxStyler, FlexBoxSpec>,
         BorderStyleMixin<FlexBoxStyler>,
         BorderRadiusStyleMixin<FlexBoxStyler>,
         ShadowStyleMixin<FlexBoxStyler>,

--- a/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_mutable_style.dart
@@ -6,6 +6,7 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
@@ -21,7 +22,9 @@ import 'icon_style.dart';
 /// Supports the same API as [IconStyler] but maintains mutable internal state
 /// enabling fluid styling: `$icon..color(Colors.blue)..size(24)..weight(400)`.
 class IconMutableStyler extends StyleMutableBuilder<IconSpec>
-    with UtilityVariantMixin<IconStyler, IconSpec> {
+    with
+        UtilityVariantMixin<IconStyler, IconSpec>,
+        UtilityWidgetStateVariantMixin<IconStyler, IconSpec> {
   late final color = ColorUtility<IconStyler>(
     (prop) => mutable.merge(IconStyler.create(color: prop)),
   );

--- a/packages/mix/lib/src/specs/icon/icon_style.dart
+++ b/packages/mix/lib/src/specs/icon/icon_style.dart
@@ -11,6 +11,7 @@ import '../../properties/painting/shadow_mix.dart';
 import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
 import '../../style/mixins/widget_modifier_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'icon_mutable_style.dart';
 import 'icon_spec.dart';
 import 'icon_widget.dart';
@@ -22,6 +23,7 @@ class IconStyler extends Style<IconSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<IconStyler, IconSpec>,
         VariantStyleMixin<IconStyler, IconSpec>,
+        WidgetStateVariantMixin<IconStyler, IconSpec>,
         AnimationStyleMixin<IconStyler, IconSpec> {
   final Prop<Color>? $color;
   final Prop<double>? $size;

--- a/packages/mix/lib/src/specs/image/image_mutable_style.dart
+++ b/packages/mix/lib/src/specs/image/image_mutable_style.dart
@@ -6,6 +6,7 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
@@ -19,7 +20,9 @@ import 'image_style.dart';
 /// Supports the same API as [ImageStyler] but maintains mutable internal state
 /// enabling fluid styling: `$image..width(100)..height(100)..fit(BoxFit.cover)`.
 class ImageMutableStyler extends StyleMutableBuilder<ImageSpec>
-    with UtilityVariantMixin<ImageStyler, ImageSpec> {
+    with
+        UtilityVariantMixin<ImageStyler, ImageSpec>,
+        UtilityWidgetStateVariantMixin<ImageStyler, ImageSpec> {
   late final color = ColorUtility(
     (prop) => mutable.merge(ImageStyler.create(color: prop)),
   );

--- a/packages/mix/lib/src/specs/image/image_style.dart
+++ b/packages/mix/lib/src/specs/image/image_style.dart
@@ -9,6 +9,7 @@ import '../../core/style_spec.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'image_spec.dart';
 import 'image_mutable_style.dart';
 import 'image_widget.dart';
@@ -19,7 +20,8 @@ class ImageStyler extends Style<ImageSpec>
     with
         Diagnosticable,
         WidgetModifierStyleMixin<ImageStyler, ImageSpec>,
-        VariantStyleMixin<ImageStyler, ImageSpec> {
+        VariantStyleMixin<ImageStyler, ImageSpec>,
+        WidgetStateVariantMixin<ImageStyler, ImageSpec> {
   final Prop<ImageProvider<Object>>? $image;
   final Prop<double>? $width;
   final Prop<double>? $height;

--- a/packages/mix/lib/src/specs/stack/stack_box_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_box_style.dart
@@ -17,6 +17,7 @@ import '../../style/mixins/decoration_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import '../box/box_spec.dart';
 import '../box/box_style.dart';
 import 'stack_box_spec.dart';
@@ -36,6 +37,7 @@ class StackBoxStyler extends Style<ZBoxSpec>
     with
         Diagnosticable,
         VariantStyleMixin<StackBoxStyler, ZBoxSpec>,
+        WidgetStateVariantMixin<StackBoxStyler, ZBoxSpec>,
         BorderRadiusStyleMixin<StackBoxStyler>,
         DecorationStyleMixin<StackBoxStyler>,
         SpacingStyleMixin<StackBoxStyler>,

--- a/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_mutable_style.dart
@@ -7,6 +7,7 @@ import '../../core/style.dart' show VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../variants/variant.dart';
@@ -19,7 +20,9 @@ import 'stack_style.dart';
 /// Supports the same API as [StackStyler] but maintains mutable internal state
 /// enabling fluid styling: `$stack..alignment(Alignment.center)..fit(StackFit.expand)`.
 class StackMutableStyler extends StyleMutableBuilder<StackSpec>
-    with UtilityVariantMixin<StackStyler, StackSpec> {
+    with
+        UtilityVariantMixin<StackStyler, StackSpec>,
+        UtilityWidgetStateVariantMixin<StackStyler, StackSpec> {
   late final alignment = MixUtility(mutable.alignment);
 
   late final fit = MixUtility(mutable.fit);

--- a/packages/mix/lib/src/specs/stack/stack_style.dart
+++ b/packages/mix/lib/src/specs/stack/stack_style.dart
@@ -10,6 +10,7 @@ import '../../modifiers/widget_modifier_config.dart';
 import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'stack_spec.dart';
 import 'stack_mutable_style.dart';
 
@@ -27,6 +28,7 @@ class StackStyler extends Style<StackSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<StackStyler, StackSpec>,
         VariantStyleMixin<StackStyler, StackSpec>,
+        WidgetStateVariantMixin<StackStyler, StackSpec>,
         AnimationStyleMixin<StackStyler, StackSpec> {
   final Prop<AlignmentGeometry>? $alignment;
   final Prop<StackFit>? $fit;

--- a/packages/mix/lib/src/specs/text/text_mutable_style.dart
+++ b/packages/mix/lib/src/specs/text/text_mutable_style.dart
@@ -6,6 +6,7 @@ import '../../core/style.dart' show Style, VariantStyle;
 import '../../core/style_spec.dart';
 import '../../core/utility.dart';
 import '../../core/utility_variant_mixin.dart';
+import '../../core/utility_widget_state_variant_mixin.dart';
 import '../../modifiers/widget_modifier_config.dart';
 import '../../modifiers/widget_modifier_util.dart';
 import '../../properties/painting/color_util.dart';
@@ -22,7 +23,9 @@ import 'text_style.dart';
 /// Supports the same API as [TextStyler] but maintains mutable internal state
 /// enabling fluid styling: `$text..color.red()..fontSize(16)`.
 class TextMutableStyler extends StyleMutableBuilder<TextSpec>
-    with UtilityVariantMixin<TextStyler, TextSpec> {
+    with
+        UtilityVariantMixin<TextStyler, TextSpec>,
+        UtilityWidgetStateVariantMixin<TextStyler, TextSpec> {
   late final textOverflow = MixUtility(mutable.overflow);
 
   late final strutStyle = StrutStyleUtility(mutable.strutStyle);

--- a/packages/mix/lib/src/specs/text/text_style.dart
+++ b/packages/mix/lib/src/specs/text/text_style.dart
@@ -15,6 +15,7 @@ import '../../style/mixins/animation_style_mixin.dart';
 import '../../style/mixins/widget_modifier_style_mixin.dart';
 import '../../style/mixins/text_style_mixin.dart';
 import '../../style/mixins/variant_style_mixin.dart';
+import '../../style/mixins/widget_state_variant_mixin.dart';
 import 'text_spec.dart';
 import 'text_mutable_style.dart';
 import 'text_widget.dart';
@@ -33,6 +34,7 @@ class TextStyler extends Style<TextSpec>
         Diagnosticable,
         WidgetModifierStyleMixin<TextStyler, TextSpec>,
         VariantStyleMixin<TextStyler, TextSpec>,
+        WidgetStateVariantMixin<TextStyler, TextSpec>,
         TextStyleMixin<TextStyler>,
         AnimationStyleMixin<TextStyler, TextSpec> {
   final Prop<TextOverflow>? $overflow;

--- a/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
@@ -31,11 +31,6 @@ mixin VariantStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
     return variant(ContextVariant.brightness(Brightness.light), style);
   }
 
-  /// Creates a variant for hover state
-  T onHovered(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.hovered), style);
-  }
-
   /// Creates a variant that applies styling based on the build context.
   ///
   /// The provided builder function receives a [BuildContext] and should return
@@ -59,29 +54,6 @@ mixin VariantStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
   )
   T builder(T Function(BuildContext context) fn) {
     return onBuilder(fn);
-  }
-
-  /// Creates a variant for pressed state
-  T onPressed(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.pressed), style);
-  }
-
-  /// Creates a variant for focused state
-  T onFocused(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.focused), style);
-  }
-
-  /// Creates a variant for disabled state
-  T onDisabled(T style) {
-    return variant(ContextVariant.widgetState(WidgetState.disabled), style);
-  }
-
-  /// Creates a variant for enabled state (opposite of disabled)
-  T onEnabled(T style) {
-    return variant(
-      ContextVariant.not(ContextVariant.widgetState(WidgetState.disabled)),
-      style,
-    );
   }
 
   /// Creates a variant based on breakpoint

--- a/packages/mix/lib/src/style/mixins/widget_state_variant_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/widget_state_variant_mixin.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../../core/spec.dart';
+import '../../core/style.dart';
+import '../../variants/variant.dart';
+
+/// Mixin that provides widget state variant styling methods for spec attributes.
+///
+/// This mixin provides convenient methods for applying widget state variants
+/// (hover, press, focus, disabled/enabled) to style attributes.
+mixin WidgetStateVariantMixin<T extends Style<S>, S extends Spec<S>>
+    on Style<S> {
+  /// Must be implemented by the class using this mixin
+  T variant(Variant variant, T style);
+
+  /// Creates a variant for hover state
+  T onHovered(T style) {
+    return variant(ContextVariant.widgetState(WidgetState.hovered), style);
+  }
+
+  /// Creates a variant for pressed state
+  T onPressed(T style) {
+    return variant(ContextVariant.widgetState(WidgetState.pressed), style);
+  }
+
+  /// Creates a variant for focused state
+  T onFocused(T style) {
+    return variant(ContextVariant.widgetState(WidgetState.focused), style);
+  }
+
+  /// Creates a variant for disabled state
+  T onDisabled(T style) {
+    return variant(ContextVariant.widgetState(WidgetState.disabled), style);
+  }
+
+  /// Creates a variant for enabled state (opposite of disabled)
+  T onEnabled(T style) {
+    return variant(
+      ContextVariant.not(ContextVariant.widgetState(WidgetState.disabled)),
+      style,
+    );
+  }
+}

--- a/packages/mix/test/src/variants/variant_mixin_test.dart
+++ b/packages/mix/test/src/variants/variant_mixin_test.dart
@@ -6,7 +6,9 @@ import '../../helpers/testing_utils.dart';
 
 // Test implementation of VariantMixin
 class TestVariantAttribute extends Style<BoxSpec>
-    with VariantStyleMixin<TestVariantAttribute, BoxSpec> {
+    with
+        VariantStyleMixin<TestVariantAttribute, BoxSpec>,
+        WidgetStateVariantMixin<TestVariantAttribute, BoxSpec> {
   const TestVariantAttribute({super.variants, super.modifier, super.animation});
 
   @override


### PR DESCRIPTION
## Summary

This PR refactors the widget state variant functionality by extracting it into dedicated mixin files for better separation of concerns and code organization.

**Changes:**
- Created `UtilityWidgetStateVariantMixin` for utility classes with widget state variant methods
- Created `WidgetStateVariantMixin` for style classes with widget state variant methods  
- Applied these new mixins to all relevant style and utility classes (Box, Flex, FlexBox, Icon, Image, Stack, Text)
- Removed widget state variant methods from base `UtilityVariantMixin` and `VariantStyleMixin`
- Updated exports in `mix.dart`

**Benefits:**
- Clearer mixin hierarchy and separation of concerns
- Widget state variant functionality is now isolated and easier to maintain
- Improved code organization without changing public API

**Test Plan:**
- [ ] Verify existing tests pass
- [ ] Verify widget state variants still work correctly (onHovered, onPressed, onFocused, onDisabled, onEnabled)
- [ ] Check that all affected style and utility classes properly implement the new mixins