### PR TITLE
Ensure that widgets are visible until the end of animations

### DIFF
--- a/packages/mix/lib/src/modifiers/visibility_modifier.dart
+++ b/packages/mix/lib/src/modifiers/visibility_modifier.dart
@@ -23,10 +23,12 @@ final class VisibilityModifier extends WidgetModifier<VisibilityModifier>
   }
 
   @override
-  VisibilityModifier lerp(VisibilityModifier? other, double t) {
+  VisibilityModifier lerp(_VisibilityModifier? other, double t) {
     if (other == null) return this;
-
-    return VisibilityModifier(MixOps.lerpSnap(visible, other.visible, t));
+    if (visible == other.visible) return this;
+    if (t == 0) return this;
+    if (t == 1) return other;
+    return _VisibilityModifier(true);
   }
 
   @override

--- a/packages/mix/lib/src/modifiers/visibility_modifier.dart
+++ b/packages/mix/lib/src/modifiers/visibility_modifier.dart
@@ -23,7 +23,7 @@ final class VisibilityModifier extends WidgetModifier<VisibilityModifier>
   }
 
   @override
-  VisibilityModifier lerp(_VisibilityModifier? other, double t) {
+  VisibilityModifier lerp(VisibilityModifier? other, double t) {
     if (other == null) return this;
     if (visible == other.visible) return this;
     if (t == 0) return this;


### PR DESCRIPTION
#### Related issue

https://github.com/btwld/mix/issues/770

### Description

Adjust lerp of visibility to show the widget, unless there is a definite requirement for the widget to be invisible.

This will allow users to animate a widget offscreen with transform and upon completion will be wrapped in invisible.

Previously, the widget would disappear halfway through the animation

### Changes

replace lerp implementation with one that ensures that widget is visible

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [x] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
