### PR TITLE
Refactor gradient color handling to use color tokens

### DIFF
--- a/packages/mix/example/lib/api/gradients/gradient_linear.dart
+++ b/packages/mix/example/lib/api/gradients/gradient_linear.dart
@@ -1,9 +1,18 @@
-import '../../helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 
+import '../../helpers.dart';
+
+final $primaryColor = ColorToken('primary');
+final $secondaryColor = ColorToken('secondary');
+
 void main() {
-  runMixApp(Example());
+  runMixApp(
+    MixScope(
+      colors: {$primaryColor: Colors.red, $secondaryColor: Colors.blue},
+      child: Example(),
+    ),
+  );
 }
 
 class Example extends StatelessWidget {
@@ -15,13 +24,14 @@ class Example extends StatelessWidget {
         .height(100)
         .width(200)
         .borderRounded(16)
+        .color($primaryColor())
         .shadowOnly(
-          color: Colors.purple.shade200,
+          color: $primaryColor(),
           offset: Offset(0, 8),
           blurRadius: 20,
         )
         .linearGradient(
-          colors: [Colors.purple.shade400, Colors.pink.shade300],
+          colors: [$primaryColor(), $secondaryColor()],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         );

--- a/packages/mix/lib/src/properties/painting/gradient_mix.dart
+++ b/packages/mix/lib/src/properties/painting/gradient_mix.dart
@@ -12,11 +12,11 @@ import '../../core/prop.dart';
 sealed class GradientMix<T extends Gradient> extends Mix<T>
     with DefaultValue<T> {
   final Prop<List<double>>? $stops;
-  final Prop<List<Color>>? $colors;
+  final List<Prop<Color>>? $colors;
   final Prop<GradientTransform>? $transform;
   const GradientMix({
     Prop<List<double>>? stops,
-    Prop<List<Color>>? colors,
+    List<Prop<Color>>? colors,
     Prop<GradientTransform>? transform,
   }) : $stops = stops,
        $colors = colors,
@@ -66,7 +66,7 @@ sealed class GradientMix<T extends Gradient> extends Mix<T>
   Map<String, dynamic> mergeCommonProperties(GradientMix? other) {
     return {
       'transform': MixOps.merge($transform, other?.$transform),
-      'colors': MixOps.merge($colors, other?.$colors),
+      'colors': MixOps.mergeList($colors, other?.$colors),
       'stops': MixOps.merge($stops, other?.$stops),
     };
   }
@@ -95,7 +95,7 @@ final class LinearGradientMix extends GradientMix<LinearGradient>
          end: Prop.maybe(end),
          tileMode: Prop.maybe(tileMode),
          transform: Prop.maybe(transform),
-         colors: Prop.maybe(colors),
+         colors: colors?.map(Prop.value).toList(),
          stops: Prop.maybe(stops),
        );
 
@@ -188,10 +188,14 @@ final class LinearGradientMix extends GradientMix<LinearGradient>
 
   @override
   LinearGradient resolve(BuildContext context) {
+    final colors =
+        $colors?.map((e) => MixOps.resolve(context, e)!).toList() ??
+        defaultValue.colors;
+
     return LinearGradient(
       begin: MixOps.resolve(context, $begin) ?? defaultValue.begin,
       end: MixOps.resolve(context, $end) ?? defaultValue.end,
-      colors: MixOps.resolve(context, $colors) ?? defaultValue.colors,
+      colors: colors,
       stops: MixOps.resolve(context, $stops) ?? defaultValue.stops,
       tileMode: MixOps.resolve(context, $tileMode) ?? defaultValue.tileMode,
       transform: MixOps.resolve(context, $transform) ?? defaultValue.transform,
@@ -263,7 +267,7 @@ final class RadialGradientMix extends GradientMix<RadialGradient>
          focal: Prop.maybe(focal),
          focalRadius: Prop.maybe(focalRadius),
          transform: Prop.maybe(transform),
-         colors: Prop.maybe(colors),
+         colors: colors?.map(Prop.value).toList(),
          stops: Prop.maybe(stops),
        );
 
@@ -384,10 +388,14 @@ final class RadialGradientMix extends GradientMix<RadialGradient>
 
   @override
   RadialGradient resolve(BuildContext context) {
+    final colors =
+        $colors?.map((e) => MixOps.resolve(context, e)!).toList() ??
+        defaultValue.colors;
+
     return RadialGradient(
       center: MixOps.resolve(context, $center) ?? defaultValue.center,
       radius: MixOps.resolve(context, $radius) ?? defaultValue.radius,
-      colors: MixOps.resolve(context, $colors) ?? defaultValue.colors,
+      colors: colors,
       stops: MixOps.resolve(context, $stops) ?? defaultValue.stops,
       tileMode: MixOps.resolve(context, $tileMode) ?? defaultValue.tileMode,
       focal: MixOps.resolve(context, $focal) ?? defaultValue.focal,
@@ -466,7 +474,7 @@ final class SweepGradientMix extends GradientMix<SweepGradient>
          endAngle: Prop.maybe(endAngle),
          tileMode: Prop.maybe(tileMode),
          transform: Prop.maybe(transform),
-         colors: Prop.maybe(colors),
+         colors: colors?.map(Prop.value).toList(),
          stops: Prop.maybe(stops),
        );
 
@@ -572,12 +580,16 @@ final class SweepGradientMix extends GradientMix<SweepGradient>
 
   @override
   SweepGradient resolve(BuildContext context) {
+    final colors =
+        $colors?.map((e) => MixOps.resolve(context, e)!).toList() ??
+        defaultValue.colors;
+
     return SweepGradient(
       center: MixOps.resolve(context, $center) ?? defaultValue.center,
       startAngle:
           MixOps.resolve(context, $startAngle) ?? defaultValue.startAngle,
       endAngle: MixOps.resolve(context, $endAngle) ?? defaultValue.endAngle,
-      colors: MixOps.resolve(context, $colors) ?? defaultValue.colors,
+      colors: colors,
       stops: MixOps.resolve(context, $stops) ?? defaultValue.stops,
       tileMode: MixOps.resolve(context, $tileMode) ?? defaultValue.tileMode,
       transform: MixOps.resolve(context, $transform) ?? defaultValue.transform,

--- a/packages/mix/test/src/properties/painting/gradient_mix_test.dart
+++ b/packages/mix/test/src/properties/painting/gradient_mix_test.dart
@@ -21,7 +21,7 @@ void main() {
         expect(linearGradientMix.$tileMode, resolvesTo(TileMode.repeated));
         expect(
           linearGradientMix.$colors,
-          resolvesTo(equals([Colors.red, Colors.blue])),
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
         );
         expect(linearGradientMix.$stops, resolvesTo(equals([0.0, 1.0])));
       });
@@ -48,7 +48,11 @@ void main() {
 
         expect(
           linearGradientMix.$colors,
-          resolvesTo(equals([Colors.green, Colors.yellow, Colors.red])),
+          equals([
+            resolvesTo(Colors.green),
+            resolvesTo(Colors.yellow),
+            resolvesTo(Colors.red),
+          ]),
         );
 
         expect(linearGradientMix.$stops, resolvesTo(equals([0.0, 0.5, 1.0])));
@@ -66,7 +70,10 @@ void main() {
         final result = LinearGradientMix.maybeValue(linearGradient);
 
         expect(result, isNotNull);
-        expect(result!.$colors, resolvesTo(hasLength(2)));
+        expect(
+          result!.$colors,
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
+        );
       });
     });
 
@@ -120,7 +127,14 @@ void main() {
         final colors = [Colors.red, Colors.green, Colors.blue];
         final gradientMix = LinearGradientMix.colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(3)));
+        expect(
+          gradientMix.$colors,
+          equals([
+            resolvesTo(Colors.red),
+            resolvesTo(Colors.green),
+            resolvesTo(Colors.blue),
+          ]),
+        );
         expect(gradientMix.$begin, isNull);
         expect(gradientMix.$end, isNull);
         expect(gradientMix.$tileMode, isNull);
@@ -171,7 +185,10 @@ void main() {
         final colors = [Colors.yellow, Colors.purple];
         final gradientMix = LinearGradientMix().colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(2)));
+        expect(
+          gradientMix.$colors,
+          equals([resolvesTo(Colors.yellow), resolvesTo(Colors.purple)]),
+        );
       });
 
       test('stops utility works correctly', () {
@@ -247,7 +264,7 @@ void main() {
         expect(merged.$tileMode, resolvesTo(TileMode.repeated));
         expect(
           merged.$colors,
-          resolvesTo(equals([Colors.green, Colors.yellow])),
+          equals([resolvesTo(Colors.green), resolvesTo(Colors.yellow)]),
         );
       });
     });
@@ -323,7 +340,10 @@ void main() {
         expect(radialGradientMix.$center, resolvesTo(Alignment.center));
         expect(radialGradientMix.$radius, resolvesTo(0.5));
         expect(radialGradientMix.$tileMode, resolvesTo(TileMode.mirror));
-        expect(radialGradientMix.$colors, resolvesTo(hasLength(2)));
+        expect(
+          radialGradientMix.$colors,
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
+        );
         expect(radialGradientMix.$stops, resolvesTo(hasLength(2)));
       });
 
@@ -353,7 +373,11 @@ void main() {
 
         expect(
           radialGradientMix.$colors,
-          resolvesTo(equals([Colors.purple, Colors.orange, Colors.cyan])),
+          equals([
+            resolvesTo(Colors.purple),
+            resolvesTo(Colors.orange),
+            resolvesTo(Colors.cyan),
+          ]),
         );
 
         expect(radialGradientMix.$stops, resolvesTo(equals([0.1, 0.6, 0.9])));
@@ -371,7 +395,10 @@ void main() {
         final result = RadialGradientMix.maybeValue(radialGradient);
 
         expect(result, isNotNull);
-        expect(result!.$colors, resolvesTo(hasLength(2)));
+        expect(
+          result!.$colors,
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
+        );
       });
     });
 
@@ -462,7 +489,14 @@ void main() {
         final colors = [Colors.red, Colors.green, Colors.blue];
         final gradientMix = RadialGradientMix.colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(3)));
+        expect(
+          gradientMix.$colors,
+          equals([
+            resolvesTo(Colors.red),
+            resolvesTo(Colors.green),
+            resolvesTo(Colors.blue),
+          ]),
+        );
         expect(gradientMix.$center, isNull);
         expect(gradientMix.$radius, isNull);
         expect(gradientMix.$tileMode, isNull);
@@ -529,7 +563,10 @@ void main() {
         final colors = [Colors.yellow, Colors.purple];
         final gradientMix = RadialGradientMix().colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(2)));
+        expect(
+          gradientMix.$colors,
+          equals([resolvesTo(Colors.yellow), resolvesTo(Colors.purple)]),
+        );
       });
 
       test('stops utility works correctly', () {
@@ -576,7 +613,7 @@ void main() {
         expect(merged.$radius, resolvesTo(0.8));
         expect(
           merged.$colors,
-          resolvesTo(equals([Colors.green, Colors.yellow])),
+          equals([resolvesTo(Colors.green), resolvesTo(Colors.yellow)]),
         );
       });
     });
@@ -630,7 +667,10 @@ void main() {
         expect(sweepGradientMix.$startAngle, resolvesTo(0.0));
         expect(sweepGradientMix.$endAngle, resolvesTo(3.14159));
         expect(sweepGradientMix.$tileMode, resolvesTo(TileMode.mirror));
-        expect(sweepGradientMix.$colors, resolvesTo(hasLength(2)));
+        expect(
+          sweepGradientMix.$colors,
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
+        );
       });
 
       test('value constructor extracts all properties from SweepGradient', () {
@@ -657,7 +697,11 @@ void main() {
 
         expect(
           sweepGradientMix.$colors,
-          resolvesTo(equals([Colors.cyan, Colors.pink, Colors.lime])),
+          equals([
+            resolvesTo(Colors.cyan),
+            resolvesTo(Colors.pink),
+            resolvesTo(Colors.lime),
+          ]),
         );
 
         expect(sweepGradientMix.$stops, resolvesTo(equals([0.2, 0.7, 1.0])));
@@ -673,7 +717,10 @@ void main() {
         final result = SweepGradientMix.maybeValue(sweepGradient);
 
         expect(result, isNotNull);
-        expect(result!.$colors, resolvesTo(hasLength(2)));
+        expect(
+          result!.$colors,
+          equals([resolvesTo(Colors.red), resolvesTo(Colors.blue)]),
+        );
       });
     });
 
@@ -743,7 +790,14 @@ void main() {
         final colors = [Colors.red, Colors.green, Colors.blue];
         final gradientMix = SweepGradientMix.colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(3)));
+        expect(
+          gradientMix.$colors,
+          equals([
+            resolvesTo(Colors.red),
+            resolvesTo(Colors.green),
+            resolvesTo(Colors.blue),
+          ]),
+        );
         expect(gradientMix.$center, isNull);
         expect(gradientMix.$startAngle, isNull);
         expect(gradientMix.$endAngle, isNull);
@@ -802,7 +856,10 @@ void main() {
         final colors = [Colors.yellow, Colors.purple];
         final gradientMix = SweepGradientMix().colors(colors);
 
-        expect(gradientMix.$colors, resolvesTo(hasLength(2)));
+        expect(
+          gradientMix.$colors,
+          equals([resolvesTo(Colors.yellow), resolvesTo(Colors.purple)]),
+        );
       });
 
       test('stops utility works correctly', () {
@@ -853,7 +910,7 @@ void main() {
         expect(merged.$endAngle, resolvesTo(3.14159));
         expect(
           merged.$colors,
-          resolvesTo(equals([Colors.green, Colors.yellow])),
+          equals([resolvesTo(Colors.green), resolvesTo(Colors.yellow)]),
         );
       });
     });


### PR DESCRIPTION
### Description

Updated gradient mix classes to accept lists of color property tokens instead of direct color lists, enabling dynamic color resolution. Example usage now demonstrates color tokens for primary and secondary colors, improving theme flexibility and consistency.

### Changes

List specific changes made in this PR.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Is there any additional context or documentation that might be helpful for reviewers?
