### PR TITLE
feat: add applyVariants method for NamedVariant application

### DIFF
--- a/packages/mix/lib/src/core/internal/applied_variants_style.dart
+++ b/packages/mix/lib/src/core/internal/applied_variants_style.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/widgets.dart';
+
+import '../../animation/animation_config.dart';
+import '../../modifiers/widget_modifier_config.dart';
+import '../../variants/variant.dart';
+import '../spec.dart';
+import '../style.dart';
+import '../style_spec.dart';
+
+/// Internal wrapper that carries pre-applied named variants.
+///
+/// When [build] is called, the stored variants are passed to the
+/// base style's build method for resolution.
+class AppliedVariantsStyle<S extends Spec<S>> extends Style<S> {
+  final Style<S> _baseStyle;
+  final Set<NamedVariant> _appliedVariants;
+
+  const AppliedVariantsStyle(this._baseStyle, this._appliedVariants)
+      : super(variants: null, modifier: null, animation: null);
+
+  @override
+  List<Object?> get props => [_baseStyle, _appliedVariants];
+
+  @override
+  List<VariantStyle<S>>? get $variants => _baseStyle.$variants;
+
+  @override
+  WidgetModifierConfig? get $modifier => _baseStyle.$modifier;
+
+  @override
+  AnimationConfig? get $animation => _baseStyle.$animation;
+
+  @override
+  Set<WidgetState> get widgetStates => _baseStyle.widgetStates;
+
+  @override
+  StyleSpec<S> resolve(BuildContext context) => _baseStyle.resolve(context);
+
+  @override
+  Style<S> merge(covariant Style<S>? other) {
+    if (other == null) return this;
+
+    if (other is AppliedVariantsStyle<S>) {
+      return AppliedVariantsStyle(
+        _baseStyle.merge(other._baseStyle),
+        {..._appliedVariants, ...other._appliedVariants},
+      );
+    }
+
+    return AppliedVariantsStyle(_baseStyle.merge(other), _appliedVariants);
+  }
+
+  @override
+  StyleSpec<S> build(
+    BuildContext context, {
+    Set<NamedVariant> namedVariants = const {},
+  }) {
+    final combined = {..._appliedVariants, ...namedVariants};
+
+    return _baseStyle.build(context, namedVariants: combined);
+  }
+}

--- a/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/breakpoint.dart';
+import '../../core/internal/applied_variants_style.dart';
 import '../../core/spec.dart';
 import '../../core/style.dart';
 import '../../variants/variant.dart';
@@ -17,6 +18,25 @@ mixin VariantStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
 
   /// Sets the list of variant styles. Must be implemented by the class using this mixin.
   T variants(List<VariantStyle<S>> value);
+
+  /// Applies the specified named variants to this style.
+  ///
+  /// Returns a new style that will have these variants activated
+  /// when resolved. Use this to select which named variants should
+  /// be active for a particular widget.
+  ///
+  /// Example:
+  /// ```dart
+  /// final sizeStyle = BoxStyler()
+  ///   .variant(small, BoxStyler().width(100).height(100))
+  ///   .variant(large, BoxStyler().width(200).height(200));
+  ///
+  /// // Apply the small variant
+  /// Box(style: sizeStyle.applyVariants([small]))
+  /// ```
+  Style<S> applyVariants(Iterable<NamedVariant> variantsToApply) {
+    return AppliedVariantsStyle<S>(this, variantsToApply.toSet());
+  }
 
   /// Creates a variant for dark mode.
   T onDark(T style) {

--- a/packages/mix/test/src/style/mixins/variant_style_mixin_test.dart
+++ b/packages/mix/test/src/style/mixins/variant_style_mixin_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../../helpers/testing_utils.dart';
+
+void main() {
+  group('VariantStyleMixin.applyVariants', () {
+    const small = NamedVariant('small');
+    const large = NamedVariant('large');
+    const primary = NamedVariant('primary');
+
+    test('applies single named variant', () {
+      final style = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50))
+          .variant(large, BoxStyler().width(200));
+
+      final appliedStyle = style.applyVariants([small]);
+
+      final context = MockBuildContext();
+      final result = appliedStyle.build(context);
+
+      expect(result.spec.constraints?.maxWidth, 50);
+    });
+
+    test('applies multiple named variants', () {
+      final style = BoxStyler()
+          .color(Colors.grey)
+          .variant(small, BoxStyler().width(50))
+          .variant(primary, BoxStyler().color(Colors.blue));
+
+      final appliedStyle = style.applyVariants([small, primary]);
+
+      final context = MockBuildContext();
+      final result = appliedStyle.build(context);
+
+      expect(result.spec.constraints?.maxWidth, 50);
+      final boxDecoration = result.spec.decoration as BoxDecoration?;
+      expect(boxDecoration?.color, Colors.blue);
+    });
+
+    test('non-applied variants remain inactive', () {
+      final style = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50))
+          .variant(large, BoxStyler().width(200));
+
+      final appliedStyle = style.applyVariants([small]);
+
+      final context = MockBuildContext();
+      final result = appliedStyle.build(context);
+
+      // Should apply small (50), not large (200)
+      expect(result.spec.constraints?.maxWidth, 50);
+    });
+
+    test('empty variants list has no effect', () {
+      final style = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50));
+
+      final appliedStyle = style.applyVariants([]);
+
+      final context = MockBuildContext();
+      final result = appliedStyle.build(context);
+
+      expect(result.spec.constraints?.maxWidth, 100);
+    });
+
+    test('merging styles with applied variants preserves variants', () {
+      final style1 = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50));
+
+      final style2 = BoxStyler()
+          .height(200)
+          .variant(primary, BoxStyler().color(Colors.blue));
+
+      final applied1 = style1.applyVariants([small]);
+      final applied2 = style2.applyVariants([primary]);
+      final merged = applied1.merge(applied2);
+
+      final context = MockBuildContext();
+      final result = merged.build(context);
+
+      expect(result.spec.constraints?.maxWidth, 50);
+      expect(result.spec.constraints?.maxHeight, 200);
+      final boxDecoration = result.spec.decoration as BoxDecoration?;
+      expect(boxDecoration?.color, Colors.blue);
+    });
+
+    test('applied variants combine with directly passed namedVariants', () {
+      final style = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50))
+          .variant(large, BoxStyler().height(300));
+
+      // Apply small via applyVariants
+      final appliedStyle = style.applyVariants([small]);
+
+      final context = MockBuildContext();
+      // Also pass large directly to build
+      final result = appliedStyle.build(context, namedVariants: {large});
+
+      // Both should be applied
+      expect(result.spec.constraints?.maxWidth, 50);
+      expect(result.spec.constraints?.maxHeight, 300);
+    });
+
+    testWidgets('works with widget tree', (tester) async {
+      final style = BoxStyler()
+          .width(100)
+          .variant(small, BoxStyler().width(50));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Box(style: style.applyVariants([small])),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final constraints = container.constraints;
+
+      expect(constraints?.maxWidth, 50);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `applyVariants()` method to `VariantStyleMixin` for applying named variants to styles
- Creates internal `AppliedVariantsStyle` wrapper class to carry pre-applied variants

## Problem
Users could create `NamedVariant` and add them to styles via `.variant()`, but there was no API to activate them (issue #794).

## Solution
Adds a simple `applyVariants()` method that returns a wrapped style which passes the specified variants to `build()` during resolution.

## Usage
```dart
final style = BoxStyler()
  .variant(small, BoxStyler().width(50))
  .variant(large, BoxStyler().width(200));

// Apply the small variant
Box(style: style.applyVariants([small]))
```

## Test plan
- [x] Added unit tests for `applyVariants` covering single/multiple variants, merging, and widget tree integration

Closes #794