### PR TITLE
Fix SessionStart hook by adding required matcher field

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
The SessionStart hook was not triggering because it was missing
the required "matcher": "startup" field in the hook configuration.