### PR TITLE
PoC: BoxStylerWrapper for variant-aware resolution

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -116,6 +116,9 @@ export 'src/specs/box/box_spec.dart';
 
 /// SPECS
 export 'src/specs/box/box_style.dart';
+
+/// SPECS
+export 'src/specs/box/box_styler_wrapper.dart';
 export 'src/specs/box/box_widget.dart';
 export 'src/specs/flex/flex_mutable_style.dart';
 export 'src/specs/flex/flex_spec.dart';

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -79,7 +79,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
   /// 1. ContextVariant and NamedVariant (applied first)
   /// 2. StyleVariation (applied second)
   /// 3. WidgetStateVariant (applied last, highest priority)
-  @visibleForTesting
+  @internal
   Style<S> mergeActiveVariants(
     BuildContext context, {
     required Set<NamedVariant> namedVariants,

--- a/packages/mix/lib/src/specs/box/box_styler_wrapper.dart
+++ b/packages/mix/lib/src/specs/box/box_styler_wrapper.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/widgets.dart';
+
+import '../../core/prop.dart';
+import 'box_style.dart';
+
+/// A wrapper that holds a list of [BoxStyler] layers and resolves them
+/// into a single [BoxStyler] with all variants applied and tokens resolved.
+///
+/// Unlike [BoxStyler.merge], which combines styles eagerly,
+/// [BoxStylerWrapper] preserves each layer independently until
+/// [resolve] is called with a [BuildContext].
+///
+/// The [resolve] method:
+/// 1. Merges all layers into one [BoxStyler]
+/// 2. Applies active variants (context, named, widget-state)
+/// 3. Resolves all token references to concrete values
+///
+/// The result is a [BoxStyler] with no unresolved tokens or pending variants.
+class BoxStylerWrapper {
+  final List<BoxStyler> _styles;
+
+  BoxStylerWrapper([BoxStyler? initial])
+      : _styles = [?initial];
+
+  BoxStylerWrapper._(this._styles);
+
+  /// Adds a [BoxStyler] layer to the wrapper.
+  BoxStylerWrapper wrap(BoxStyler styler) {
+    return BoxStylerWrapper._([..._styles, styler]);
+  }
+
+  /// Resolves all layers into a single [BoxStyler] with concrete values.
+  ///
+  /// Merges all layers, applies active variants, and resolves all
+  /// token references using the provided [context].
+  BoxStyler resolve(BuildContext context) {
+    // 1. Resolve variants per layer, then merge resolved layers
+    BoxStyler merged = const BoxStyler.create();
+    for (final style in _styles) {
+      final resolved =
+          style.mergeActiveVariants(context, namedVariants: {}) as BoxStyler;
+      merged = merged.merge(resolved);
+    }
+
+    // 2. Resolve each Prop's tokens to concrete values
+    return BoxStyler.create(
+      alignment: _resolveProp(context, merged.$alignment),
+      padding: _resolveProp(context, merged.$padding),
+      margin: _resolveProp(context, merged.$margin),
+      constraints: _resolveProp(context, merged.$constraints),
+      decoration: _resolveProp(context, merged.$decoration),
+      foregroundDecoration:
+          _resolveProp(context, merged.$foregroundDecoration),
+      transform: _resolveProp(context, merged.$transform),
+      transformAlignment:
+          _resolveProp(context, merged.$transformAlignment),
+      clipBehavior: _resolveProp(context, merged.$clipBehavior),
+      animation: merged.$animation,
+      modifier: merged.$modifier,
+    );
+  }
+
+  static Prop<V>? _resolveProp<V>(BuildContext context, Prop<V>? prop) {
+    if (prop == null) return null;
+    return Prop.value(prop.resolveProp(context));
+  }
+}

--- a/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/variant_style_mixin.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../core/breakpoint.dart';
-import '../../core/spec.dart';
-import '../../core/style.dart';
-import '../../variants/variant.dart';
+import '../../../mix.dart';
 
 /// Mixin that provides convenient variant styling methods for spec attributes.
 ///
@@ -68,6 +65,10 @@ mixin VariantStyleMixin<T extends Style<S>, S extends Spec<S>> on Style<S> {
     // Create a VariantStyle with ContextVariantBuilder that will be resolved at runtime
     // Use this style as a placeholder; the actual style comes from the builder function
     return variants([VariantStyle<S>(ContextVariantBuilder<T>(fn), this)]);
+  }
+
+  T useToken<V>(MixToken<V> token, T Function(V) fn) {
+    return onBuilder((context) => fn(token.resolve(context)));
   }
 
   /// Creates a variant based on the specified breakpoint.

--- a/packages/mix_docs_preview/lib/guides/design_token/theme_tokens.dart
+++ b/packages/mix_docs_preview/lib/guides/design_token/theme_tokens.dart
@@ -13,7 +13,6 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
-
 import 'package:mix_docs_preview/helpers.dart';
 
 void main() {
@@ -44,23 +43,27 @@ class _Example extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = BoxStyler()
-        .borderRadiusTopLeft($pill())
-        .color($primaryColor())
-        .height(100)
-        .width(100)
-        .paddingAll(16.0);
+    // final style = BoxStyler()
+    //     .borderRadiusTopLeft($pill())
+    //     .useToken($primaryColor, BoxStyler.color)
+    //     .color($primaryColor())
+    //     .height(100)
+    //     .width(100)
+    //     .paddingAll(16.0);
+
+    final wrapper = BoxStylerWrapper()
+        .wrap(BoxStyler().useToken($pill, BoxStyler().borderRadiusTopLeft))
+        .wrap(BoxStyler().useToken($primaryColor, BoxStyler().color))
+        .wrap(.color(Colors.red))
+        .wrap(.height(100))
+        .wrap(.width(100))
+        .wrap(BoxStyler().paddingAll(16.0));
 
     return Box(
-      style: style,
+      style: wrapper.resolve(context),
       child: MixScope(
         colors: {$primaryColor: Colors.red},
-        child: StyledText(
-          'Hello, World!',
-          style: TextStyler.color(
-            $primaryColor(),
-          ).wrap(.new().padding(.all($spacing()))),
-        ),
+        child: StyledText('Hello, World!'),
       ),
     );
   }

--- a/packages/mix_docs_preview/pubspec.yaml
+++ b/packages/mix_docs_preview/pubspec.yaml
@@ -7,6 +7,12 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
   flutter: ">=3.41.0"
 
+dependency_overrides:
+  mix:
+    path: ../mix
+  mix_tailwinds:
+    path: ../mix_tailwinds
+
 dependencies:
   cupertino_icons: ^1.0.8
   flutter:


### PR DESCRIPTION
## Summary

**This is a Proof of Concept** that changes the way a Styler is resolved.

### Problem

Currently, variants live in a separate list inside the Styler. During resolution, they are merged only among themselves and applied at the end, after all other properties. This means context variants (like `useToken`) don't participate at the same level as regular properties — tokens work with reference values before the real resolved ones are available.

### Approach

`BoxStylerWrapper` introduces an intermediate resolution layer that:

- Holds a list of `BoxStyler` layers independently (wrapping instead of merging)
- Resolves variants **per layer** before merging layers together
- Resolves all token references to concrete values

This guarantees that context variants like `useToken` are resolved at the same time as other properties, ensuring tokens work with actual resolved values rather than references.

### Changes

- **`BoxStylerWrapper`** — new class in `specs/box/` that wraps a list of `BoxStyler` and resolves them into a single `BoxStyler` with concrete values
- **`useToken`** — new method on `VariantStyleMixin` that resolves a token and passes the concrete value to a builder
- **`mergeActiveVariants`** — changed from `@visibleForTesting` to `@internal` for package-level access
- **`theme_tokens.dart`** — updated example demonstrating the wrapper + `useToken` pattern

## Test plan

- [ ] Validate that tokens resolve correctly through `BoxStylerWrapper.resolve()`
- [ ] Validate that context variants are applied per layer before merging
- [ ] Validate that `useToken` resolves token values eagerly

🤖 Generated with [Claude Code](https://claude.com/claude-code)