### PR TITLE
test(mix_generator): tighten generator validation

### DIFF
--- a/packages/mix/test/src/specs/text/text_style_factory_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_factory_test.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/mix/test/src/specs/text/text_style_factory_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_factory_test.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mix/mix.dart';

--- a/packages/mix_generator/build.yaml
+++ b/packages/mix_generator/build.yaml
@@ -5,20 +5,14 @@ targets:
         enabled: true
         generate_for:
           - lib/src/specs/**/*.dart  # Narrowed scope for specs only
-        options:
-          debug: false
       styler_generator:
         enabled: true
         generate_for:
           - lib/src/specs/**/*.dart  # Narrowed scope for specs only
-        options:
-          debug: false
       mixable_generator:
         enabled: true
         generate_for:
           - lib/src/properties/**/*.dart  # Mix property classes
-        options:
-          debug: false
 
 builders:
   mix_generator:

--- a/packages/mix_generator/lib/src/core/models/field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/field_model.dart
@@ -9,6 +9,7 @@ import 'package:analyzer/dart/element/type.dart';
 import '../curated/flag_descriptions.dart';
 import '../curated/type_mappings.dart';
 import '../registry/mix_type_registry.dart';
+import 'type_helpers.dart';
 
 /// Represents a Spec field with computed values for generation.
 class FieldModel {
@@ -98,7 +99,7 @@ class FieldModel {
     final isNullable = type.nullabilitySuffix == .question;
 
     // Get base type name
-    final typeName = _getBaseTypeName(type);
+    final typeName = getBaseTypeName(type);
 
     // Check if list
     final isList = _isList(type);
@@ -206,16 +207,6 @@ enum DiagnosticKind {
 
 // Helper functions
 
-String _getBaseTypeName(DartType type) {
-  final displayString = type.getDisplayString();
-  // Remove nullability suffix
-  if (displayString.endsWith('?')) {
-    return displayString.substring(0, displayString.length - 1);
-  }
-
-  return displayString;
-}
-
 bool _isList(DartType type) {
   if (type is! InterfaceType) return false;
 
@@ -227,7 +218,7 @@ String? _getListElementType(DartType type) {
   if (!type.isDartCoreList) return null;
   if (type.typeArguments.isEmpty) return null;
 
-  return _getBaseTypeName(type.typeArguments.first);
+  return getBaseTypeName(type.typeArguments.first);
 }
 
 String _getEffectiveSpecType(DartType type) {

--- a/packages/mix_generator/lib/src/core/models/mix_field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/mix_field_model.dart
@@ -6,6 +6,8 @@ library;
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 
+import 'type_helpers.dart' as type_helpers;
+
 /// Represents a Mix field with computed values for generation.
 class MixFieldModel {
   /// The field name (without $ prefix).
@@ -53,8 +55,8 @@ class MixFieldModel {
     final isNullable = type.nullabilitySuffix == .question;
 
     // Check if wrapped in Prop<>
-    final isWrappedInProp = _isWrappedInProp(type);
-    final innerTypeName = _getInnerTypeName(type, isWrappedInProp);
+    final wrappedInProp = type_helpers.isWrappedInProp(type);
+    final innerTypeName = type_helpers.getInnerTypeName(type, wrappedInProp);
 
     return MixFieldModel(
       name: name,
@@ -63,43 +65,10 @@ class MixFieldModel {
       element: element,
       isNullable: isNullable,
       innerTypeName: innerTypeName,
-      isWrappedInProp: isWrappedInProp,
+      isWrappedInProp: wrappedInProp,
     );
   }
 
   @override
   String toString() => 'MixFieldModel($name: $innerTypeName)';
-}
-
-// Helper functions
-
-bool _isWrappedInProp(DartType type) {
-  if (type is! InterfaceType) return false;
-
-  return type.element.name == 'Prop';
-}
-
-String _getInnerTypeName(DartType type, bool isWrappedInProp) {
-  if (!isWrappedInProp) {
-    return _getBaseTypeName(type);
-  }
-
-  if (type is! InterfaceType) return _getBaseTypeName(type);
-
-  // Get the type argument of Prop<T>
-  if (type.typeArguments.isNotEmpty) {
-    return _getBaseTypeName(type.typeArguments.first);
-  }
-
-  return _getBaseTypeName(type);
-}
-
-String _getBaseTypeName(DartType type) {
-  final displayString = type.getDisplayString();
-  // Remove nullability suffix
-  if (displayString.endsWith('?')) {
-    return displayString.substring(0, displayString.length - 1);
-  }
-
-  return displayString;
 }

--- a/packages/mix_generator/lib/src/core/models/styler_field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/styler_field_model.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
 
 import '../curated/type_mappings.dart';
+import 'type_helpers.dart' as type_helpers;
 
 const _mixableFieldChecker = TypeChecker.fromUrl(
   'package:mix_annotations/src/annotations.dart#MixableField',
@@ -91,8 +92,8 @@ class StylerFieldModel {
     final isNullable = type.nullabilitySuffix == .question;
 
     // Check if wrapped in Prop<>
-    final isWrappedInProp = _isWrappedInProp(type);
-    final innerTypeName = _getInnerTypeName(type, isWrappedInProp);
+    final wrappedInProp = type_helpers.isWrappedInProp(type);
+    final innerTypeName = type_helpers.getInnerTypeName(type, wrappedInProp);
 
     // Check if raw list
     final isRawList = rawListTypes.containsKey(name);
@@ -146,7 +147,7 @@ class StylerFieldModel {
       element: element,
       isNullable: isNullable,
       innerTypeName: innerTypeName,
-      isWrappedInProp: isWrappedInProp,
+      isWrappedInProp: wrappedInProp,
       isRawList: isRawList,
       rawListElementType: rawListElementType,
       effectivePublicParamType: effectivePublicParamType,
@@ -162,39 +163,6 @@ class StylerFieldModel {
 
   @override
   String toString() => 'StylerFieldModel($name: $innerTypeName)';
-}
-
-// Helper functions
-
-bool _isWrappedInProp(DartType type) {
-  if (type is! InterfaceType) return false;
-
-  return type.element.name == 'Prop';
-}
-
-String _getInnerTypeName(DartType type, bool isWrappedInProp) {
-  if (!isWrappedInProp) {
-    return _getBaseTypeName(type);
-  }
-
-  if (type is! InterfaceType) return _getBaseTypeName(type);
-
-  // Get the type argument of Prop<T>
-  if (type.typeArguments.isNotEmpty) {
-    return _getBaseTypeName(type.typeArguments.first);
-  }
-
-  return _getBaseTypeName(type);
-}
-
-String _getBaseTypeName(DartType type) {
-  final displayString = type.getDisplayString();
-  // Remove nullability suffix
-  if (displayString.endsWith('?')) {
-    return displayString.substring(0, displayString.length - 1);
-  }
-
-  return displayString;
 }
 
 String _getEffectivePublicParamType(

--- a/packages/mix_generator/lib/src/core/models/type_helpers.dart
+++ b/packages/mix_generator/lib/src/core/models/type_helpers.dart
@@ -1,0 +1,34 @@
+/// Shared type helpers for field models.
+library;
+
+import 'package:analyzer/dart/element/type.dart';
+
+String getBaseTypeName(DartType type) {
+  final displayString = type.getDisplayString();
+
+  if (displayString.endsWith('?')) {
+    return displayString.substring(0, displayString.length - 1);
+  }
+
+  return displayString;
+}
+
+bool isWrappedInProp(DartType type) {
+  if (type is! InterfaceType) return false;
+
+  return type.element.name == 'Prop';
+}
+
+String getInnerTypeName(DartType type, bool isWrapped) {
+  if (!isWrapped) {
+    return getBaseTypeName(type);
+  }
+
+  if (type is! InterfaceType) return getBaseTypeName(type);
+
+  if (type.typeArguments.isNotEmpty) {
+    return getBaseTypeName(type.typeArguments.first);
+  }
+
+  return getBaseTypeName(type);
+}

--- a/packages/mix_generator/lib/src/mix_generator.dart
+++ b/packages/mix_generator/lib/src/mix_generator.dart
@@ -45,7 +45,7 @@ class SpecGenerator extends GeneratorForAnnotation<MixableSpec> {
       final paramName = p.name!;
       final field = classElement.getField(paramName);
       if (field == null) {
-        throw InvalidGenerationSourceError(
+        throw InvalidGenerationSource(
           'Field $paramName not found in ${specName ?? 'unknown'}',
           element: classElement,
         );
@@ -84,7 +84,7 @@ class SpecGenerator extends GeneratorForAnnotation<MixableSpec> {
   ) {
     // Validate element is a class
     if (element is! ClassElement) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableSpec can only be applied to classes.',
         element: element,
       );
@@ -93,7 +93,7 @@ class SpecGenerator extends GeneratorForAnnotation<MixableSpec> {
     final classElement = element;
     final specName = classElement.name;
     if (specName == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableSpec class must have a name.',
         element: element,
       );
@@ -101,7 +101,7 @@ class SpecGenerator extends GeneratorForAnnotation<MixableSpec> {
 
     // Validate it's a Spec class
     if (!_isSpecClass(classElement)) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableSpec can only be applied to classes extending Spec<$specName>.',
         element: element,
       );
@@ -110,7 +110,7 @@ class SpecGenerator extends GeneratorForAnnotation<MixableSpec> {
     // Validate constructor exists
     final constructor = classElement.unnamedConstructor;
     if (constructor == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '$specName must have an unnamed constructor.',
         element: element,
       );

--- a/packages/mix_generator/lib/src/mixable_generator.dart
+++ b/packages/mix_generator/lib/src/mixable_generator.dart
@@ -135,7 +135,7 @@ class MixableGenerator extends GeneratorForAnnotation<Mixable> {
   ) {
     // Validate element is a class
     if (element is! ClassElement) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@Mixable can only be applied to classes.',
         element: element,
       );
@@ -144,7 +144,7 @@ class MixableGenerator extends GeneratorForAnnotation<Mixable> {
     final classElement = element;
     final mixName = classElement.name;
     if (mixName == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@Mixable class must have a name.',
         element: element,
       );
@@ -152,7 +152,7 @@ class MixableGenerator extends GeneratorForAnnotation<Mixable> {
 
     // Validate it's a Mix class
     if (!_isMixClass(classElement)) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@Mixable can only be applied to classes extending Mix<T> or its subclasses.',
         element: element,
       );
@@ -165,7 +165,7 @@ class MixableGenerator extends GeneratorForAnnotation<Mixable> {
     final resolveToType =
         config.resolveToType ?? _extractResolveToType(classElement);
     if (resolveToType == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         'Could not determine target type for resolve(). '
         'Specify resolveToType in @Mixable annotation or ensure class extends Mix<T>.',
         element: element,

--- a/packages/mix_generator/lib/src/styler_generator.dart
+++ b/packages/mix_generator/lib/src/styler_generator.dart
@@ -104,7 +104,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
   ) {
     // Validate element is a class
     if (element is! ClassElement) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableStyler can only be applied to classes.',
         element: element,
       );
@@ -113,7 +113,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
     final classElement = element;
     final stylerName = classElement.name;
     if (stylerName == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableStyler class must have a name.',
         element: element,
       );
@@ -121,7 +121,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
 
     // Validate it's a Style class
     if (!_isStyleClass(classElement)) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         '@MixableStyler can only be applied to classes extending Style<T>.',
         element: element,
       );
@@ -130,7 +130,7 @@ class StylerGenerator extends GeneratorForAnnotation<MixableStyler> {
     // Extract Spec name from Style<SpecName>
     final specName = _extractSpecName(classElement);
     if (specName == null) {
-      throw InvalidGenerationSourceError(
+      throw InvalidGenerationSource(
         'Could not determine Spec type from Style<T> supertype.',
         element: element,
       );

--- a/packages/mix_generator/test/core/builders/mix_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/mix_mixin_builder_test.dart
@@ -1,0 +1,386 @@
+import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix_generator/src/core/builders/mix_mixin_builder.dart';
+import 'package:mix_generator/src/core/models/annotation_config.dart';
+import 'package:test/test.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  const defaultConfig = MixableAnnotationConfig();
+
+  group('MixMixinBuilder', () {
+    group('generatedMixinName', () {
+      test('produces _\$XMixin', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        expect(builder.generatedMixinName, equals('_\$BoxConstraintsMixMixin'));
+      });
+    });
+
+    group('build', () {
+      test('generates mixin declaration with correct on clause', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        expect(
+          builder.build(),
+          contains(
+            'mixin _\$BoxConstraintsMixMixin on Mix<BoxConstraints>, Diagnosticable {',
+          ),
+        );
+      });
+
+      test('includes DefaultValue in the on clause when enabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: defaultConfig,
+          hasDefaultValue: true,
+        );
+
+        expect(
+          builder.build(),
+          contains(
+            'mixin _\$BoxConstraintsMixMixin on Mix<BoxConstraints>, DefaultValue<BoxConstraints>, Diagnosticable {',
+          ),
+        );
+      });
+
+      test('includes Diagnosticable when debugFillProperties is generated', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        expect(
+          builder.build(),
+          contains('on Mix<BoxConstraints>, Diagnosticable'),
+        );
+      });
+
+      test('generates merge method with MixOps.merge per field', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: [
+            createTestMixFieldModel(
+              name: 'minWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+            createTestMixFieldModel(
+              name: 'maxWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+          ],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(
+          code,
+          contains('BoxConstraintsMix merge(BoxConstraintsMix? other)'),
+        );
+        expect(
+          code,
+          contains('minWidth: MixOps.merge(\$minWidth, other?.\$minWidth),'),
+        );
+        expect(
+          code,
+          contains('maxWidth: MixOps.merge(\$maxWidth, other?.\$maxWidth),'),
+        );
+      });
+
+      test('generates abstract getters with declared names and types', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: [
+            createTestMixFieldModel(
+              name: 'minWidth',
+              dartTypeDisplayString: 'Prop<double>?',
+              declaredName: r'$minWidth',
+              isNullable: true,
+              innerTypeName: 'double',
+              isWrappedInProp: true,
+            ),
+            createTestMixFieldModel(
+              name: 'maxWidth',
+              dartTypeDisplayString: 'Prop<double>',
+              declaredName: r'$maxWidth',
+              innerTypeName: 'double',
+              isWrappedInProp: true,
+            ),
+          ],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains(r'Prop<double>? get $minWidth;'));
+        expect(code, contains(r'Prop<double> get $maxWidth;'));
+      });
+
+      test('generates resolve method with MixOps.resolve per field', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: [
+            createTestMixFieldModel(
+              name: 'minWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+            createTestMixFieldModel(
+              name: 'maxWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+          ],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(
+          code,
+          contains('minWidth: MixOps.resolve(context, \$minWidth),'),
+        );
+        expect(
+          code,
+          contains('maxWidth: MixOps.resolve(context, \$maxWidth),'),
+        );
+      });
+
+      test('uses defaultValue fallback in resolve when enabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: [
+            createTestMixFieldModel(
+              name: 'minWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+          ],
+          config: defaultConfig,
+          hasDefaultValue: true,
+        );
+
+        expect(
+          builder.build(),
+          contains(
+            'minWidth: MixOps.resolve(context, \$minWidth) ?? defaultValue.minWidth,',
+          ),
+        );
+      });
+
+      test('generates props with all declared field names', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: [
+            createTestMixFieldModel(
+              name: 'minWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+            createTestMixFieldModel(
+              name: 'maxWidth',
+              dartTypeDisplayString: 'double?',
+              isNullable: true,
+            ),
+          ],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains('List<Object?> get props => ['));
+        expect(code, contains('\$minWidth,'));
+        expect(code, contains('\$maxWidth,'));
+      });
+
+      test(
+        'generates debugFillProperties with DiagnosticsProperty per field',
+        () {
+          final builder = MixMixinBuilder(
+            mixName: 'BoxConstraintsMix',
+            resolveToType: 'BoxConstraints',
+            fields: [
+              createTestMixFieldModel(
+                name: 'minWidth',
+                dartTypeDisplayString: 'double?',
+                isNullable: true,
+              ),
+              createTestMixFieldModel(
+                name: 'maxWidth',
+                dartTypeDisplayString: 'double?',
+                isNullable: true,
+              ),
+            ],
+            config: defaultConfig,
+            hasDefaultValue: false,
+          );
+
+          final code = builder.build();
+
+          expect(
+            code,
+            contains("..add(DiagnosticsProperty('minWidth', \$minWidth))"),
+          );
+          expect(
+            code,
+            contains("..add(DiagnosticsProperty('maxWidth', \$maxWidth))"),
+          );
+        },
+      );
+    });
+
+    group('flag-controlled generation', () {
+      test('skips merge when flag is disabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: const MixableAnnotationConfig(
+            methods: GeneratedMixMethods.skipMerge,
+          ),
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, isNot(contains('BoxConstraintsMix merge(')));
+        expect(code, contains('BoxConstraints resolve(BuildContext context)'));
+        expect(code, contains('List<Object?> get props =>'));
+        expect(code, contains('void debugFillProperties('));
+      });
+
+      test('skips resolve when flag is disabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: const MixableAnnotationConfig(
+            methods: GeneratedMixMethods.skipResolve,
+          ),
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains('BoxConstraintsMix merge('));
+        expect(
+          code,
+          isNot(contains('BoxConstraints resolve(BuildContext context)')),
+        );
+        expect(code, contains('List<Object?> get props =>'));
+        expect(code, contains('void debugFillProperties('));
+      });
+
+      test('skips props when flag is disabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: const MixableAnnotationConfig(
+            methods: GeneratedMixMethods.skipProps,
+          ),
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains('BoxConstraintsMix merge('));
+        expect(code, contains('BoxConstraints resolve(BuildContext context)'));
+        expect(code, isNot(contains('List<Object?> get props =>')));
+        expect(code, contains('void debugFillProperties('));
+      });
+
+      test('skips debugFillProperties when flag is disabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: const MixableAnnotationConfig(
+            methods: GeneratedMixMethods.skipDebugFillProperties,
+          ),
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains('BoxConstraintsMix merge('));
+        expect(code, contains('BoxConstraints resolve(BuildContext context)'));
+        expect(code, contains('List<Object?> get props =>'));
+        expect(code, isNot(contains('void debugFillProperties(')));
+        expect(code, isNot(contains('Diagnosticable')));
+      });
+
+      test('generates no methods when all flags are disabled', () {
+        final builder = MixMixinBuilder(
+          mixName: 'BoxConstraintsMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: const MixableAnnotationConfig(
+            methods: GeneratedMixMethods.none,
+          ),
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(
+          code,
+          contains('mixin _\$BoxConstraintsMixMixin on Mix<BoxConstraints> {'),
+        );
+        expect(code, isNot(contains('BoxConstraintsMix merge(')));
+        expect(
+          code,
+          isNot(contains('BoxConstraints resolve(BuildContext context)')),
+        );
+        expect(code, isNot(contains('List<Object?> get props =>')));
+        expect(code, isNot(contains('void debugFillProperties(')));
+      });
+    });
+
+    group('empty fields', () {
+      test('generates empty props list', () {
+        final builder = MixMixinBuilder(
+          mixName: 'EmptyMix',
+          resolveToType: 'BoxConstraints',
+          fields: const [],
+          config: defaultConfig,
+          hasDefaultValue: false,
+        );
+
+        final code = builder.build();
+
+        expect(code, contains('List<Object?> get props => [];'));
+        expect(code, isNot(contains('get \$')));
+      });
+    });
+  });
+}

--- a/packages/mix_generator/test/core/builders/spec_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/spec_mixin_builder_test.dart
@@ -48,7 +48,11 @@ class _FakeDartType implements DartType {
       _isNullable ? NullabilitySuffix.question : NullabilitySuffix.none;
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => null;
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected DartType access in test: ${invocation.memberName}',
+    );
+  }
 }
 
 // Minimal fake FieldElement for testing
@@ -59,7 +63,11 @@ class _FakeFieldElement implements FieldElement {
   _FakeFieldElement(this.name);
 
   @override
-  dynamic noSuchMethod(Invocation invocation) => null;
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected FieldElement access in test: ${invocation.memberName}',
+    );
+  }
 }
 
 void main() {
@@ -100,6 +108,23 @@ void main() {
           code,
           contains('mixin _\$BoxSpecMethods on Spec<BoxSpec>, Diagnosticable'),
         );
+      });
+
+      test('generates abstract getters for fielded specs', () {
+        final builder = SpecMixinBuilder(
+          specName: 'BoxSpec',
+          fields: [
+            createTestFieldModel(
+              name: 'color',
+              effectiveSpecType: 'Color?',
+              isNullable: true,
+            ),
+          ],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(code, contains('Color? get color;'));
       });
 
       test('generates copyWith override', () {

--- a/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
+++ b/packages/mix_generator/test/core/builders/styler_mixin_builder_test.dart
@@ -1,7 +1,10 @@
 import 'package:mix_annotations/mix_annotations.dart';
 import 'package:mix_generator/src/core/builders/styler_mixin_builder.dart';
 import 'package:mix_generator/src/core/models/annotation_config.dart';
+import 'package:mix_generator/src/core/models/styler_field_model.dart';
 import 'package:test/test.dart';
+
+import '../test_helpers.dart';
 
 void main() {
   // Default config that generates all methods
@@ -44,6 +47,33 @@ void main() {
           code,
           contains('mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable'),
         );
+      });
+
+      test('generates abstract getters for fielded stylers', () {
+        final builder = StylerMixinBuilder(
+          stylerName: 'BoxStyler',
+          specName: 'BoxSpec',
+          fields: [
+            StylerFieldModel(
+              name: 'gap',
+              declaredName: r'$gap',
+              dartType: FakeDartType('double?', true),
+              element: FakeFieldElement('gap'),
+              isNullable: true,
+              innerTypeName: 'double',
+              isWrappedInProp: false,
+              isRawList: false,
+              effectivePublicParamType: 'double',
+              generateSetter: true,
+              setterName: 'gap',
+              hasMixType: false,
+            ),
+          ],
+          config: defaultConfig,
+        );
+        final code = builder.build();
+
+        expect(code, contains(r'double? get $gap;'));
       });
 
       test('generates merge override', () {

--- a/packages/mix_generator/test/core/resolvers/diagnostic_resolver_test.dart
+++ b/packages/mix_generator/test/core/resolvers/diagnostic_resolver_test.dart
@@ -1,69 +1,167 @@
+import 'package:mix_generator/src/core/models/field_model.dart';
 import 'package:mix_generator/src/core/resolvers/diagnostic_resolver.dart';
 import 'package:test/test.dart';
 
+import '../test_helpers.dart';
+
 void main() {
   group('DiagnosticResolver', () {
-    // Note: Full testing requires FieldModel which needs analyzer types.
-    // These tests validate the diagnostic pattern logic.
+    group('generateSpecDiagnosticCode', () {
+      test('generates ColorProperty for color fields', () {
+        final field = createTestFieldModel(
+          name: 'color',
+          typeName: 'Color',
+          diagnosticKind: DiagnosticKind.color,
+        );
 
-    group('Spec diagnostic patterns', () {
-      test('ColorProperty pattern for Color', () {
-        expect("ColorProperty('color', color)", contains('ColorProperty'));
-      });
-
-      test('DoubleProperty pattern for double', () {
-        expect("DoubleProperty('size', size)", contains('DoubleProperty'));
-      });
-
-      test('IntProperty pattern for int', () {
-        expect("IntProperty('maxLines', maxLines)", contains('IntProperty'));
-      });
-
-      test('StringProperty pattern for String', () {
-        expect("StringProperty('label', label)", contains('StringProperty'));
-      });
-
-      test('EnumProperty pattern for enums', () {
         expect(
-          "EnumProperty<Clip>('clipBehavior', clipBehavior)",
-          contains('EnumProperty'),
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("ColorProperty('color', color)"),
         );
       });
 
-      test('FlagProperty pattern for bool with description', () {
+      test('generates DoubleProperty for double fields', () {
+        final field = createTestFieldModel(
+          name: 'size',
+          typeName: 'double',
+          diagnosticKind: DiagnosticKind.doubleProperty,
+        );
+
         expect(
-          "FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at word boundaries')",
-          contains('FlagProperty'),
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("DoubleProperty('size', size)"),
         );
       });
 
-      test('IterableProperty pattern for List', () {
+      test('generates IntProperty for int fields', () {
+        final field = createTestFieldModel(
+          name: 'maxLines',
+          typeName: 'int',
+          diagnosticKind: DiagnosticKind.intProperty,
+        );
+
         expect(
-          "IterableProperty<Shadow>('shadows', shadows)",
-          contains('IterableProperty'),
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("IntProperty('maxLines', maxLines)"),
         );
       });
 
-      test('DiagnosticsProperty pattern for other types', () {
-        expect(
-          "DiagnosticsProperty('alignment', alignment)",
-          contains('DiagnosticsProperty'),
+      test('generates StringProperty for string fields', () {
+        final field = createTestFieldModel(
+          name: 'label',
+          typeName: 'String',
+          diagnosticKind: DiagnosticKind.stringProperty,
         );
-      });
-    });
 
-    group('Styler diagnostic patterns', () {
-      test('Always uses DiagnosticsProperty', () {
         expect(
-          "DiagnosticsProperty('padding', \$padding)",
-          contains('DiagnosticsProperty'),
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("StringProperty('label', label)"),
         );
       });
 
-      test('Uses \$-prefixed field name', () {
+      test('generates EnumProperty for enum fields', () {
+        final field = createTestFieldModel(
+          name: 'clipBehavior',
+          typeName: 'Clip',
+          diagnosticKind: DiagnosticKind.enumProperty,
+        );
+
         expect(
-          "DiagnosticsProperty('padding', \$padding)",
-          contains('\$padding'),
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("EnumProperty<Clip>('clipBehavior', clipBehavior)"),
+        );
+      });
+
+      test('generates FlagProperty when a flag description is available', () {
+        final field = createTestFieldModel(
+          name: 'softWrap',
+          typeName: 'bool',
+          diagnosticKind: DiagnosticKind.flagProperty,
+          flagDescription: 'wrapping at word boundaries',
+        );
+
+        expect(
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals(
+            "FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at word boundaries')",
+          ),
+        );
+      });
+
+      test(
+        'falls back to DiagnosticsProperty when a flag description is absent',
+        () {
+          final field = createTestFieldModel(
+            name: 'softWrap',
+            typeName: 'bool',
+            diagnosticKind: DiagnosticKind.flagProperty,
+          );
+
+          expect(
+            diagnosticResolver.generateSpecDiagnosticCode(field),
+            equals("DiagnosticsProperty('softWrap', softWrap)"),
+          );
+        },
+      );
+
+      test('generates IterableProperty with the list element type', () {
+        final field = createTestFieldModel(
+          name: 'shadows',
+          typeName: 'List<Shadow>',
+          isList: true,
+          listElementType: 'Shadow',
+          diagnosticKind: DiagnosticKind.iterableProperty,
+        );
+
+        expect(
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("IterableProperty<Shadow>('shadows', shadows)"),
+        );
+      });
+
+      test('uses diagnosticLabel as the display name when provided', () {
+        final field = createTestFieldModel(
+          name: 'textDirectives',
+          typeName: 'List<String>',
+          isList: true,
+          listElementType: 'String',
+          diagnosticKind: DiagnosticKind.iterableProperty,
+          diagnosticLabel: 'directives',
+        );
+
+        expect(
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("IterableProperty<String>('directives', textDirectives)"),
+        );
+      });
+
+      test(
+        'falls back to IterableProperty<Object> when element type is absent',
+        () {
+          final field = createTestFieldModel(
+            name: 'items',
+            typeName: 'List<Object>',
+            isList: true,
+            diagnosticKind: DiagnosticKind.iterableProperty,
+          );
+
+          expect(
+            diagnosticResolver.generateSpecDiagnosticCode(field),
+            equals("IterableProperty<Object>('items', items)"),
+          );
+        },
+      );
+
+      test('generates DiagnosticsProperty for unhandled diagnostic kinds', () {
+        final field = createTestFieldModel(
+          name: 'alignment',
+          typeName: 'AlignmentGeometry',
+          diagnosticKind: DiagnosticKind.diagnostics,
+        );
+
+        expect(
+          diagnosticResolver.generateSpecDiagnosticCode(field),
+          equals("DiagnosticsProperty('alignment', alignment)"),
         );
       });
     });

--- a/packages/mix_generator/test/core/resolvers/lerp_resolver_test.dart
+++ b/packages/mix_generator/test/core/resolvers/lerp_resolver_test.dart
@@ -1,6 +1,8 @@
 import 'package:mix_generator/src/core/resolvers/lerp_resolver.dart';
 import 'package:test/test.dart';
 
+import '../test_helpers.dart';
+
 void main() {
   group('LerpResolver', () {
     group('LerpStrategy', () {
@@ -17,33 +19,110 @@ void main() {
       });
     });
 
-    // Note: Full testing of resolveStrategy and generateLerpCode
-    // requires FieldModel which needs analyzer types.
-    // These tests validate the resolver logic with mock data.
+    group('resolveStrategy', () {
+      test('returns interpolate for lerpable fields', () {
+        final field = createTestFieldModel(
+          name: 'padding',
+          typeName: 'EdgeInsetsGeometry',
+          isLerpable: true,
+        );
 
-    group('generateLerpCode output patterns', () {
-      test('interpolate pattern uses MixOps.lerp', () {
-        // This tests the pattern generation logic
+        expect(lerpResolver.resolveStrategy(field), LerpStrategy.interpolate);
+      });
+
+      test('returns snap for non-lerpable fields', () {
+        final field = createTestFieldModel(
+          name: 'clipBehavior',
+          typeName: 'Clip',
+          isLerpable: false,
+        );
+
+        expect(lerpResolver.resolveStrategy(field), LerpStrategy.snap);
+      });
+
+      test('returns delegateToSpec for StyleSpec fields', () {
+        final field = createTestFieldModel(
+          name: 'box',
+          typeName: 'StyleSpec<BoxSpec>',
+          effectiveSpecType: 'StyleSpec<BoxSpec>?',
+          isNullable: true,
+        );
+
         expect(
-          'MixOps.lerp(padding, other?.padding, t)',
-          contains('MixOps.lerp'),
+          lerpResolver.resolveStrategy(field),
+          LerpStrategy.delegateToSpec,
         );
       });
 
-      test('snap pattern uses MixOps.lerpSnap', () {
+      test('prefers delegateToSpec over interpolate for StyleSpec fields', () {
+        final field = createTestFieldModel(
+          name: 'box',
+          typeName: 'StyleSpec<BoxSpec>',
+          effectiveSpecType: 'StyleSpec<BoxSpec>?',
+          isNullable: true,
+          isLerpable: true,
+        );
+
         expect(
-          'MixOps.lerpSnap(clipBehavior, other?.clipBehavior, t)',
-          contains('MixOps.lerpSnap'),
+          lerpResolver.resolveStrategy(field),
+          LerpStrategy.delegateToSpec,
+        );
+      });
+    });
+
+    group('generateLerpCode', () {
+      test('generates MixOps.lerp for interpolate strategy', () {
+        final field = createTestFieldModel(
+          name: 'padding',
+          typeName: 'EdgeInsetsGeometry',
+          isLerpable: true,
+        );
+
+        expect(
+          lerpResolver.generateLerpCode(field),
+          equals('MixOps.lerp(padding, other?.padding, t)'),
         );
       });
 
-      test('delegate pattern for nullable field uses ?. operator', () {
-        expect('box?.lerp(other?.box, t)', contains('?.lerp('));
+      test('generates MixOps.lerpSnap for snap strategy', () {
+        final field = createTestFieldModel(
+          name: 'clipBehavior',
+          typeName: 'Clip',
+          isLerpable: false,
+        );
+
+        expect(
+          lerpResolver.generateLerpCode(field),
+          equals('MixOps.lerpSnap(clipBehavior, other?.clipBehavior, t)'),
+        );
       });
 
-      test('delegate pattern for non-nullable field uses . operator', () {
-        expect('box.lerp(other?.box, t)', isNot(contains('?.lerp(')));
-        expect('box.lerp(other?.box, t)', contains('.lerp('));
+      test('uses ?. for nullable StyleSpec fields', () {
+        final field = createTestFieldModel(
+          name: 'box',
+          typeName: 'StyleSpec<BoxSpec>',
+          effectiveSpecType: 'StyleSpec<BoxSpec>?',
+          isNullable: true,
+        );
+
+        expect(
+          lerpResolver.generateLerpCode(field),
+          equals('box?.lerp(other?.box, t)'),
+        );
+      });
+
+      test('uses . for non-nullable StyleSpec fields', () {
+        final field = createTestFieldModel(
+          name: 'box',
+          typeName: 'StyleSpec<BoxSpec>',
+          effectiveSpecType: 'StyleSpec<BoxSpec>',
+          isNullable: false,
+        );
+
+        expect(
+          lerpResolver.generateLerpCode(field),
+          equals('box.lerp(other?.box, t)'),
+        );
       });
     });
   });

--- a/packages/mix_generator/test/core/test_helpers.dart
+++ b/packages/mix_generator/test/core/test_helpers.dart
@@ -1,0 +1,96 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:mix_generator/src/core/models/field_model.dart';
+import 'package:mix_generator/src/core/models/mix_field_model.dart';
+import 'package:mix_generator/src/core/registry/mix_type_registry.dart';
+
+FieldModel createTestFieldModel({
+  required String name,
+  required String typeName,
+  String? effectiveSpecType,
+  bool isNullable = false,
+  bool isList = false,
+  String? listElementType,
+  bool isLerpable = false,
+  DiagnosticKind diagnosticKind = DiagnosticKind.diagnostics,
+  String? diagnosticLabel,
+  String? flagDescription,
+}) {
+  final resolvedSpecType =
+      effectiveSpecType ?? '$typeName${isNullable ? '?' : ''}';
+
+  return FieldModel(
+    name: name,
+    dartType: FakeDartType(resolvedSpecType, isNullable),
+    element: FakeFieldElement(name),
+    isNullable: isNullable,
+    typeName: typeName,
+    isList: isList,
+    listElementType: listElementType,
+    effectiveSpecType: resolvedSpecType,
+    effectivePublicParamType: resolvedSpecType,
+    isLerpable: isLerpable,
+    propWrapperKind: PropWrapperKind.none,
+    isWrappedInProp: false,
+    diagnosticKind: diagnosticKind,
+    diagnosticLabel: diagnosticLabel,
+    generateSetter: true,
+    flagDescription: flagDescription,
+  );
+}
+
+MixFieldModel createTestMixFieldModel({
+  required String name,
+  String? declaredName,
+  required String dartTypeDisplayString,
+  bool isNullable = false,
+  String? innerTypeName,
+  bool isWrappedInProp = false,
+}) {
+  return MixFieldModel(
+    name: name,
+    declaredName: declaredName ?? '\$$name',
+    dartType: FakeDartType(dartTypeDisplayString, isNullable),
+    element: FakeFieldElement(name),
+    isNullable: isNullable,
+    innerTypeName:
+        innerTypeName ?? dartTypeDisplayString.replaceFirst(RegExp(r'\?$'), ''),
+    isWrappedInProp: isWrappedInProp,
+  );
+}
+
+class FakeDartType implements DartType {
+  final String _displayString;
+  final bool _isNullable;
+
+  FakeDartType(this._displayString, this._isNullable);
+
+  @override
+  String getDisplayString({bool withNullability = true}) => _displayString;
+
+  @override
+  NullabilitySuffix get nullabilitySuffix =>
+      _isNullable ? NullabilitySuffix.question : NullabilitySuffix.none;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected DartType access in test: ${invocation.memberName}',
+    );
+  }
+}
+
+class FakeFieldElement implements FieldElement {
+  @override
+  final String name;
+
+  FakeFieldElement(this.name);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw UnsupportedError(
+      'Unexpected FieldElement access in test: ${invocation.memberName}',
+    );
+  }
+}

--- a/packages/mix_generator/test/integration/generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/generator_smoke_test.dart
@@ -1,0 +1,229 @@
+import 'package:build/build.dart';
+import 'package:build_test/build_test.dart';
+import 'package:mix_generator/mix_generator.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+Builder _partBuilder(Generator generator) =>
+    PartBuilder([generator], '.g.dart');
+
+void main() {
+  group('generator smoke', () {
+    test('SpecGenerator handles nullable list fields end-to-end', () async {
+      const source = r'''
+library spec_case;
+
+part 'spec_case.g.dart';
+
+class MixableSpec {
+  final int methods;
+  final int components;
+
+  const MixableSpec({this.methods = 0x01 | 0x02 | 0x04, this.components = 0});
+}
+
+class Spec<T> {
+  const Spec();
+}
+
+class Shadow {}
+
+@MixableSpec()
+class BoxSpec extends Spec<BoxSpec> {
+  final List<Shadow>? shadows;
+
+  const BoxSpec({this.shadows});
+}
+''';
+
+      await testBuilder(
+        _partBuilder(const SpecGenerator()),
+        {'mix_generator|lib/spec_case.dart': source},
+        generateFor: {'mix_generator|lib/spec_case.dart'},
+        outputs: {
+          'mix_generator|lib/spec_case.g.dart': decodedMatches(
+            allOf(
+              contains(
+                'mixin _\$BoxSpecMethods on Spec<BoxSpec>, Diagnosticable',
+              ),
+              contains('List<Shadow>? get shadows;'),
+              contains('BoxSpec copyWith({List<Shadow>? shadows})'),
+              contains('shadows: shadows ?? this.shadows'),
+              contains("IterableProperty<Shadow>('shadows', shadows)"),
+              contains('MixOps.lerp(shadows, other?.shadows, t)'),
+            ),
+          ),
+        },
+      );
+    });
+
+    test(
+      'StylerGenerator unwraps Prop<T> and preserves nested generics',
+      () async {
+        const source = r'''
+library styler_case;
+
+part 'styler_case.g.dart';
+
+class MixableStyler {
+  final int methods;
+
+  const MixableStyler({
+    this.methods = 0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20,
+  });
+}
+
+class Prop<T> {
+  const Prop();
+}
+
+class Style<T> {
+  final Object? $variants;
+  final Object? $modifier;
+  final Object? $animation;
+
+  const Style({Object? variants, Object? modifier, Object? animation})
+    : $variants = variants,
+      $modifier = modifier,
+      $animation = animation;
+}
+
+class EdgeInsetsGeometry {}
+
+class Shadow {}
+
+class BoxSpec {
+  final EdgeInsetsGeometry? padding;
+  final List<Shadow>? shadows;
+
+  const BoxSpec({this.padding, this.shadows});
+}
+
+@MixableStyler()
+class BoxStyler extends Style<BoxSpec> {
+  final Prop<EdgeInsetsGeometry>? $padding;
+  final Prop<List<Shadow>>? $shadows;
+
+  const BoxStyler({
+    Prop<EdgeInsetsGeometry>? padding,
+    Prop<List<Shadow>>? shadows,
+    Object? variants,
+    Object? modifier,
+    Object? animation,
+  }) : $padding = padding,
+       $shadows = shadows,
+       super(variants: variants, modifier: modifier, animation: animation);
+
+  static BoxStyler create({
+    Prop<EdgeInsetsGeometry>? padding,
+    Prop<List<Shadow>>? shadows,
+    Object? variants,
+    Object? modifier,
+    Object? animation,
+  }) => BoxStyler(
+    padding: padding,
+    shadows: shadows,
+    variants: variants,
+    modifier: modifier,
+    animation: animation,
+  );
+}
+''';
+
+        await testBuilder(
+          _partBuilder(const StylerGenerator()),
+          {'mix_generator|lib/styler_case.dart': source},
+          generateFor: {'mix_generator|lib/styler_case.dart'},
+          outputs: {
+            'mix_generator|lib/styler_case.g.dart': decodedMatches(
+              allOf(
+                contains(
+                  'mixin _\$BoxStylerMixin on Style<BoxSpec>, Diagnosticable',
+                ),
+                contains(r'Prop<EdgeInsetsGeometry>? get $padding;'),
+                contains(r'Prop<List<Shadow>>? get $shadows;'),
+                contains('BoxStyler padding(EdgeInsetsGeometryMix value)'),
+                contains('BoxStyler shadows(List<Shadow> value)'),
+                contains(r'padding: MixOps.resolve(context, $padding),'),
+                contains(r'shadows: MixOps.resolve(context, $shadows),'),
+              ),
+            ),
+          },
+        );
+      },
+    );
+
+    test(
+      'MixableGenerator emits declared getters and defaultValue fallback',
+      () async {
+        const source = r'''
+library mix_case;
+
+part 'mix_case.g.dart';
+
+class Mixable {
+  final int methods;
+  final String? resolveToType;
+
+  const Mixable({this.methods = 0x01 | 0x02 | 0x04 | 0x08, this.resolveToType});
+}
+
+class Prop<T> {
+  const Prop();
+}
+
+class Mix<T> {
+  const Mix();
+}
+
+mixin DefaultValue<T> {
+  T get defaultValue;
+}
+
+class BoxConstraints {
+  final double? minWidth;
+
+  const BoxConstraints({this.minWidth});
+}
+
+@Mixable()
+class BoxConstraintsMix extends Mix<BoxConstraints> with DefaultValue<BoxConstraints> {
+  final Prop<double>? $minWidth;
+
+  const BoxConstraintsMix({Prop<double>? minWidth}) : $minWidth = minWidth;
+
+  static BoxConstraintsMix create({Prop<double>? minWidth}) =>
+      BoxConstraintsMix(minWidth: minWidth);
+
+  @override
+  BoxConstraints get defaultValue => const BoxConstraints(minWidth: 10);
+}
+''';
+
+        await testBuilder(
+          _partBuilder(const MixableGenerator()),
+          {'mix_generator|lib/mix_case.dart': source},
+          generateFor: {'mix_generator|lib/mix_case.dart'},
+          outputs: {
+            'mix_generator|lib/mix_case.g.dart': decodedMatches(
+              allOf(
+                contains('mixin _\$BoxConstraintsMixMixin'),
+                contains(
+                  'on Mix<BoxConstraints>, DefaultValue<BoxConstraints>, Diagnosticable {',
+                ),
+                contains(r'Prop<double>? get $minWidth;'),
+                contains(
+                  r'minWidth: MixOps.merge($minWidth, other?.$minWidth),',
+                ),
+                contains(
+                  r'minWidth: MixOps.resolve(context, $minWidth) ?? defaultValue.minWidth,',
+                ),
+                contains(r"DiagnosticsProperty('minWidth', $minWidth)"),
+              ),
+            ),
+          },
+        );
+      },
+    );
+  });
+}

--- a/packages/mix_generator/test/integration/generator_validation_test.dart
+++ b/packages/mix_generator/test/integration/generator_validation_test.dart
@@ -1,0 +1,97 @@
+import 'package:mix_generator/mix_generator.dart';
+import 'package:source_gen_test/source_gen_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('generator validation', () {
+    test(
+      'SpecGenerator throws InvalidGenerationSource for non-Spec classes',
+      () async {
+        final libraryReader = await initializeLibraryReader({
+          'spec_validation.dart': r'''
+library spec_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+
+@MixableSpec()
+class BoxSpec {
+  const BoxSpec();
+}
+''',
+        }, 'spec_validation.dart');
+
+        await expectLater(
+          () => generateForElement(
+            const SpecGenerator(),
+            libraryReader,
+            'BoxSpec',
+          ),
+          throwsInvalidGenerationSourceError(
+            '@MixableSpec can only be applied to classes extending Spec<BoxSpec>.',
+            elementMatcher: isNotNull,
+          ),
+        );
+      },
+    );
+
+    test(
+      'StylerGenerator throws InvalidGenerationSource for non-Style classes',
+      () async {
+        final libraryReader = await initializeLibraryReader({
+          'styler_validation.dart': r'''
+library styler_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+
+@MixableStyler()
+class BoxStyler {
+  const BoxStyler();
+}
+''',
+        }, 'styler_validation.dart');
+
+        await expectLater(
+          () => generateForElement(
+            const StylerGenerator(),
+            libraryReader,
+            'BoxStyler',
+          ),
+          throwsInvalidGenerationSourceError(
+            '@MixableStyler can only be applied to classes extending Style<T>.',
+            elementMatcher: isNotNull,
+          ),
+        );
+      },
+    );
+
+    test(
+      'MixableGenerator throws InvalidGenerationSource for non-Mix classes',
+      () async {
+        final libraryReader = await initializeLibraryReader({
+          'mix_validation.dart': r'''
+library mix_validation;
+
+import 'package:mix_annotations/mix_annotations.dart';
+
+@Mixable()
+class BoxConstraintsMix {
+  const BoxConstraintsMix();
+}
+''',
+        }, 'mix_validation.dart');
+
+        await expectLater(
+          () => generateForElement(
+            const MixableGenerator(),
+            libraryReader,
+            'BoxConstraintsMix',
+          ),
+          throwsInvalidGenerationSourceError(
+            '@Mixable can only be applied to classes extending Mix<T> or its subclasses.',
+            elementMatcher: isNotNull,
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
#### Related issue

N/A

### Description

Tightens `mix_generator` validation coverage and cleans up a few internal generator implementation details. This adds analyzer-backed integration tests, strengthens builder and resolver unit tests, and removes duplicated type helper logic.

### Changes

- Replaced deprecated `InvalidGenerationSourceError` usages with `InvalidGenerationSource`.
- Extracted shared type helper logic into `type_helpers.dart` and reused it across field models.
- Removed unused `options.debug` entries from `packages/mix_generator/build.yaml`.
- Added stricter fake analyzer helpers plus new `MixMixinBuilder` coverage.
- Expanded resolver and builder tests for abstract getters, lerp precedence, diagnostic labels, and iterable fallbacks.
- Added integration smoke and validation tests for `@MixableSpec`, `@MixableStyler`, and `@Mixable`.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Focused validation passed with `dart analyze` and `dart test` in `packages/mix_generator`, plus `flutter pub run build_runner build --delete-conflicting-outputs` in `packages/mix` with no generated diff under `packages/mix/lib`. `melos run gen:build` and `melos run --no-select ci` also passed. `melos run analyze` is currently blocked by unrelated existing issues in `mix_docs_preview`, `mix_lint`, and `mix_tailwinds`.
