### PR TITLE
fix(mix): fix RotateModifier lerp to interpolate angle instead of matrix

### DIFF
--- a/packages/mix/lib/src/modifiers/transform_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_modifier.dart
@@ -329,17 +329,19 @@ class TranslateModifierMix extends ModifierMix<TranslateModifier>
 }
 
 class RotateModifier extends _TransformModifier<RotateModifier> {
-  RotateModifier({double radians = 0.0, super.alignment})
-    : super(transform: Matrix4.rotationZ(radians));
+  final double radians;
 
-  RotateModifier._({super.transform, super.alignment});
+  RotateModifier({this.radians = 0.0, super.alignment})
+    : super(transform: Matrix4.rotationZ(radians));
 
   @override
   RotateModifier lerp(RotateModifier? other, double t) {
     if (other == null) return this;
 
-    return RotateModifier._(
-      transform: MixOps.lerp(transform, other.transform, t),
+    final lerpedRadians = MixOps.lerp(radians, other.radians, t) ?? radians;
+
+    return RotateModifier(
+      radians: lerpedRadians,
       alignment: MixOps.lerp(alignment, other.alignment, t)!,
     );
   }
@@ -347,11 +349,14 @@ class RotateModifier extends _TransformModifier<RotateModifier> {
   @override
   // ignore: avoid-incomplete-copy-with
   RotateModifier copyWith({double? radians, Alignment? alignment}) {
-    return RotateModifier._(
-      transform: radians != null ? Matrix4.rotationZ(radians) : transform,
+    return RotateModifier(
+      radians: radians ?? this.radians,
       alignment: alignment ?? this.alignment,
     );
   }
+
+  @override
+  List<Object?> get props => [radians, alignment];
 }
 
 /// ModifierMix for rotation transform (around Z axis).

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -162,8 +162,8 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
   // Transform convenience
   factory BoxStyler.scale(double scale, {Alignment alignment = .center}) =>
       BoxStyler().scale(scale, alignment: alignment);
-  factory BoxStyler.rotate(double angle, {Alignment alignment = .center}) =>
-      BoxStyler().rotate(angle, alignment: alignment);
+  factory BoxStyler.rotate(double radians, {Alignment alignment = .center}) =>
+      BoxStyler().rotate(radians, alignment: alignment);
 
   // Style metadata convenience
   factory BoxStyler.animate(AnimationConfig value) =>

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -194,8 +194,10 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   // Transform convenience
   factory FlexBoxStyler.scale(double scale, {Alignment alignment = .center}) =>
       FlexBoxStyler().scale(scale, alignment: alignment);
-  factory FlexBoxStyler.rotate(double radians, {Alignment alignment = .center}) =>
-      FlexBoxStyler().rotate(radians, alignment: alignment);
+  factory FlexBoxStyler.rotate(
+    double radians, {
+    Alignment alignment = .center,
+  }) => FlexBoxStyler().rotate(radians, alignment: alignment);
 
   // Style metadata convenience
   factory FlexBoxStyler.animate(AnimationConfig value) =>

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -194,8 +194,8 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   // Transform convenience
   factory FlexBoxStyler.scale(double scale, {Alignment alignment = .center}) =>
       FlexBoxStyler().scale(scale, alignment: alignment);
-  factory FlexBoxStyler.rotate(double angle, {Alignment alignment = .center}) =>
-      FlexBoxStyler().rotate(angle, alignment: alignment);
+  factory FlexBoxStyler.rotate(double radians, {Alignment alignment = .center}) =>
+      FlexBoxStyler().rotate(radians, alignment: alignment);
 
   // Style metadata convenience
   factory FlexBoxStyler.animate(AnimationConfig value) =>

--- a/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
@@ -175,9 +175,9 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
   factory StackBoxStyler.scale(double scale, {Alignment alignment = .center}) =>
       StackBoxStyler().scale(scale, alignment: alignment);
   factory StackBoxStyler.rotate(
-    double angle, {
+    double radians, {
     Alignment alignment = .center,
-  }) => StackBoxStyler().rotate(angle, alignment: alignment);
+  }) => StackBoxStyler().rotate(radians, alignment: alignment);
 
   // Style metadata convenience
   factory StackBoxStyler.animate(AnimationConfig value) =>

--- a/packages/mix/lib/src/style/mixins/transform_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/transform_style_mixin.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/widgets.dart';
 
 import '../../core/mix_element.dart';
+import '../../modifiers/widget_modifier_config.dart';
 
 /// Mixin that provides convenient transform styling methods for styles
 mixin TransformStyleMixin<T extends Mix<Object?>> {
   /// Must be implemented by the class using this mixin
   T transform(Matrix4 value, {Alignment alignment = .center});
 
-  /// Sets rotation transform
-  T rotate(double angle, {Alignment alignment = .center}) {
-    return transform(Matrix4.rotationZ(angle), alignment: alignment);
+  /// Must be implemented by the class using this mixin
+  T wrap(WidgetModifierConfig value);
+
+  /// Sets rotation transform in radians.
+  T rotate(double radians, {Alignment alignment = .center}) {
+    return wrap(
+      WidgetModifierConfig.rotate(radians: radians, alignment: alignment),
+    );
   }
 
   /// Sets scale transform

--- a/packages/mix/test/src/specs/box/box_style_test.dart
+++ b/packages/mix/test/src/specs/box/box_style_test.dart
@@ -196,11 +196,10 @@ void main() {
         expect(constraints.maxHeight, 150.0);
       });
 
-      test('rotate method sets rotation transform', () {
-        final boxMix = BoxStyler().rotate(1.5);
+      test('rotate method sets rotation modifier', () {
+        final boxMix = BoxStyler().rotate(0.5);
 
-        expect(boxMix.$transform, isNotNull);
-        expect(boxMix.$transform, resolvesTo(isA<Matrix4>()));
+        expect(boxMix.$modifier, isNotNull);
       });
 
       test('scale method sets scale transform', () {


### PR DESCRIPTION
#### Related issue

Closes #896

### Description

`RotateModifier.lerp()` was interpolating `Matrix4` elements directly instead of the rotation angle. This produces incorrect rotation intermediates and breaks animation (e.g., a full 2π rotation results in near-identity start/end matrices, so no visible animation occurs). Additionally, `.rotate()` on stylers was setting `Container`'s `transform` property directly, bypassing the modifier system entirely.

### Changes

- **`RotateModifier`**: Now stores `radians` as a field and lerps the angle value instead of the matrix. The matrix is recomputed from the interpolated angle.
- **`TransformStyleMixin.rotate()`**: Now delegates to `wrap(WidgetModifierConfig.rotate(...))` instead of calling `transform(Matrix4.rotationZ(...))`, ensuring rotation goes through the `RotateModifier` which can properly animate.
- **Factory constructors**: Renamed parameter from `angle` to `radians` in `BoxStyler.rotate`, `FlexBoxStyler.rotate`, `StackBoxStyler.rotate` for clarity.
- **Tests**: Updated `box_style_test.dart` to verify the modifier is set instead of the transform property.

**Review Checklist**

- [x] **Testing**: All 3736 existing tests pass.
- [x] **Breaking Changes**: Yes — `.rotate()` now applies via a modifier (`wrap`) instead of the Container `transform` property. The parameter name changed from `angle` to `radians` in factory constructors.
- [ ] **Documentation Updates**: API docs updated in code.
- [ ] **Website Updates**: N/A

### Additional Information (optional)

The core issue was that `Matrix4` element-wise interpolation (via `Matrix4Tween`) cannot properly represent rotation animation — the angle information is lost once baked into the matrix.