### PR TITLE
fix(website): make buttons and cards full-width on mobile

### DIFF
--- a/website/components/HomeContent.tsx
+++ b/website/components/HomeContent.tsx
@@ -114,10 +114,10 @@ export const HomeContent = () => {
               custom={0.3}
               variants={fadeUp}
             >
-              <Button href="/documentation/overview/getting-started" arrow="right">
+              <Button href="/documentation/overview/getting-started" arrow="right" className="w-full sm:w-auto">
                 <>Get Started</>
               </Button>
-              <Button href="https://discord.com/invite/Ycn6GV3m2k" variant="secondary" target="_blank">
+              <Button href="https://discord.com/invite/Ycn6GV3m2k" variant="secondary" target="_blank" className="w-full sm:w-auto">
                 <>Join the community</>
               </Button>
             </motion.div>
@@ -143,7 +143,7 @@ export const HomeContent = () => {
               viewport={{ once: true, margin: "-80px" }}
               transition={{ duration: 0.6, delay: 0.1, ease: [0.25, 0.4, 0.25, 1] as const }}
             >
-              <div className="rounded-2xl ring-1 ring-white/[0.08] bg-[var(--mix-surface)] p-5 overflow-x-auto">
+              <div className="rounded-2xl ring-1 ring-white/[0.08] bg-[var(--mix-surface)] p-5 overflow-x-auto min-w-0">
                 <span className="mb-3 block text-xs font-medium uppercase tracking-wider text-[var(--mix-text-muted)]">
                   Without Mix
                 </span>
@@ -158,7 +158,7 @@ export const HomeContent = () => {
 )`} />
               </div>
 
-              <div className="rounded-2xl ring-1 ring-[var(--mix-accent)]/40 bg-[var(--mix-accent)]/[0.06] backdrop-blur-md p-5 overflow-x-auto shadow-[0_0_24px_-4px_var(--mix-accent)]/10">
+              <div className="rounded-2xl ring-1 ring-[var(--mix-accent)]/40 bg-[var(--mix-accent)]/[0.06] backdrop-blur-md p-5 overflow-x-auto min-w-0 shadow-[0_0_24px_-4px_var(--mix-accent)]/10">
                 <span className="mb-3 block text-xs font-medium uppercase tracking-wider text-[var(--mix-accent)]">
                   With Mix
                 </span>
@@ -222,7 +222,7 @@ Box(style: cardStyle, child: ...)`} />
               Start building your first Mix-styled widget in under 5 minutes.
             </p>
             <div className="mt-8 flex flex-col sm:flex-row gap-4">
-              <Button href="/documentation/overview/getting-started" variant="filled" arrow="right">
+              <Button href="/documentation/overview/getting-started" variant="filled" arrow="right" className="w-full sm:w-auto">
                 <>Get started in 5 minutes</>
               </Button>
             </div>

--- a/website/components/HomeContent.tsx
+++ b/website/components/HomeContent.tsx
@@ -195,7 +195,7 @@ Box(style: cardStyle, child: ...)`} />
       </Layout>
 
       {/* Feature showcase — full width to breakpoint */}
-      <div className="relative z-10 mx-auto w-full max-w-7xl px-4 md:px-8">
+      <div className="relative z-10 mx-auto w-full max-w-7xl px-2 sm:px-4 md:px-8">
         <FeatureShowcase />
       </div>
 

--- a/website/components/Layout.tsx
+++ b/website/components/Layout.tsx
@@ -8,7 +8,7 @@ type LayoutProps = { children?: React.ReactNode };
 const Layout = ({ children }: LayoutProps) => {
   return (
     <div className="flex justify-center">
-      <div className="w-full max-w-5xl px-4 md:px-8">{children}</div>
+      <div className="w-full max-w-5xl px-2 sm:px-4 md:px-8">{children}</div>
     </div>
   );
 };

--- a/website/globals.css
+++ b/website/globals.css
@@ -73,6 +73,11 @@ pre {
     font-size: 0.875em;
 }
 
+/* Hide Nextra's copy button on code blocks */
+pre button {
+    display: none !important;
+}
+
 a,
 button {
     text-decoration: none !important;

--- a/website/globals.css
+++ b/website/globals.css
@@ -73,11 +73,6 @@ pre {
     font-size: 0.875em;
 }
 
-/* Hide Nextra's copy button on code blocks */
-pre button {
-    display: none !important;
-}
-
 a,
 button {
     text-decoration: none !important;

--- a/website/src/app/layout.jsx
+++ b/website/src/app/layout.jsx
@@ -91,6 +91,7 @@ export default async function RootLayout({ children }) {
                     docsRepositoryBase="https://github.com/btwld/mix/tree/main/website"
                     footer={footer}
                     darkMode={false}
+                    copyPageButton={false}
                     navigation={{ prev: true, next: true }}
                     toc={{ float: true, backToTop: "Scroll to top" }}
                     nextThemes={{


### PR DESCRIPTION
#### Related issue

No related issue.

### Description

Fixes mobile layout where hero/CTA buttons and "Why Mix" comparison cards were not stretching to full screen width.

### Changes

- Added `w-full sm:w-auto` to hero buttons (Get Started, Join the community), CTA button (Get started in 5 minutes) so they fill the viewport on mobile and revert to content-width on `sm+`
- Added `min-w-0` to both "Why Mix" code comparison cards so they respect grid column bounds instead of overflowing due to code block content

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?