### PR TITLE
feat(mix): add DefaultTextStylerModifier for TextStyler inheritance

### DIFF
--- a/packages/mix/lib/mix.dart
+++ b/packages/mix/lib/mix.dart
@@ -52,6 +52,7 @@ export 'src/modifiers/blur_modifier.dart';
 export 'src/modifiers/box_modifier.dart';
 export 'src/modifiers/clip_modifier.dart';
 export 'src/modifiers/default_text_style_modifier.dart';
+export 'src/modifiers/default_text_styler_modifier.dart';
 export 'src/modifiers/flexible_modifier.dart';
 export 'src/modifiers/fractionally_sized_box_modifier.dart';
 export 'src/modifiers/icon_theme_modifier.dart';

--- a/packages/mix/lib/src/modifiers/default_text_styler_modifier.dart
+++ b/packages/mix/lib/src/modifiers/default_text_styler_modifier.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+
+import '../core/providers/style_provider.dart';
+import '../core/style.dart';
+import '../core/widget_modifier.dart';
+import '../specs/text/text_spec.dart';
+import '../specs/text/text_style.dart';
+
+/// Modifier that propagates a [TextStyler] to descendant [StyledText] widgets.
+///
+/// Wraps the child in a [StyleProvider] of [TextSpec] (also known as
+/// [DefaultStyledText]) so descendants can merge their own [TextStyler] on top
+/// of the inherited one. Unlike [DefaultTextStyleModifier], this preserves the
+/// full unresolved [TextStyler] — including variants, modifiers, and merge
+/// semantics — rather than a flattened [TextStyle].
+final class DefaultTextStylerModifier
+    extends WidgetModifier<DefaultTextStylerModifier>
+    with Diagnosticable {
+  final TextStyler style;
+
+  const DefaultTextStylerModifier([TextStyler? style])
+    : style = style ?? const TextStyler.create();
+
+  @override
+  DefaultTextStylerModifier copyWith({TextStyler? style}) {
+    return DefaultTextStylerModifier(style ?? this.style);
+  }
+
+  @override
+  DefaultTextStylerModifier lerp(DefaultTextStylerModifier? other, double t) {
+    if (other == null) return this;
+
+    return t < 0.5 ? this : other;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('style', style));
+  }
+
+  @override
+  List<Object?> get props => [style];
+
+  @override
+  Widget build(Widget child) {
+    return StyleProvider<TextSpec>(style: style, child: child);
+  }
+}
+
+/// Mix class for [DefaultTextStylerModifier].
+class DefaultTextStylerModifierMix
+    extends ModifierMix<DefaultTextStylerModifier>
+    with Diagnosticable {
+  final TextStyler style;
+
+  const DefaultTextStylerModifierMix(this.style);
+
+  @override
+  DefaultTextStylerModifier resolve(BuildContext context) {
+    return DefaultTextStylerModifier(style);
+  }
+
+  @override
+  DefaultTextStylerModifierMix merge(DefaultTextStylerModifierMix? other) {
+    if (other == null) return this;
+
+    return DefaultTextStylerModifierMix(style.merge(other.style));
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty('style', style));
+  }
+
+  @override
+  List<Object?> get props => [style];
+}

--- a/packages/mix/lib/src/modifiers/widget_modifier_config.dart
+++ b/packages/mix/lib/src/modifiers/widget_modifier_config.dart
@@ -17,6 +17,7 @@ import 'blur_modifier.dart';
 import 'box_modifier.dart';
 import 'clip_modifier.dart';
 import 'default_text_style_modifier.dart';
+import 'default_text_styler_modifier.dart';
 import 'flexible_modifier.dart';
 import 'fractionally_sized_box_modifier.dart';
 import 'icon_theme_modifier.dart';
@@ -277,6 +278,10 @@ final class WidgetModifierConfig with Equatable {
         textHeightBehavior: textMix.$textHeightBehavior,
       ),
     );
+  }
+
+  factory WidgetModifierConfig.defaultTextStyler(TextStyler style) {
+    return WidgetModifierConfig.modifier(DefaultTextStylerModifierMix(style));
   }
 
   factory WidgetModifierConfig.defaultIcon(IconStyler iconMix) {
@@ -564,6 +569,10 @@ final class WidgetModifierConfig with Equatable {
     return merge(WidgetModifierConfig.defaultText(textMix));
   }
 
+  WidgetModifierConfig defaultTextStyler(TextStyler style) {
+    return merge(WidgetModifierConfig.defaultTextStyler(style));
+  }
+
   WidgetModifierConfig modifier(ModifierMix value) {
     return merge(WidgetModifierConfig.modifier(value));
   }
@@ -641,6 +650,10 @@ const _defaultOrder = [
   // 4. DefaultTextStyleModifier: Provides default text styling context to descendant Text widgets.
   // Applied early alongside IconTheme to establish text theme context before layout.
   DefaultTextStyleModifier,
+
+  // 4b. DefaultTextStylerModifier: Propagates a full TextStyler (variants, modifiers,
+  // merge semantics) to descendant StyledText widgets via Mix inheritance.
+  DefaultTextStylerModifier,
 
   // === PHASE 2: SIZE ESTABLISHMENT ===
 

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -25,6 +25,7 @@ import '../../style/mixins/decoration_style_mixin.dart';
 import '../../style/mixins/shadow_style_mixin.dart';
 import '../../style/mixins/spacing_style_mixin.dart';
 import '../../style/mixins/transform_style_mixin.dart';
+import '../text/text_style.dart';
 import 'box_spec.dart';
 import 'box_widget.dart';
 
@@ -163,6 +164,10 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
       BoxStyler().scale(scale, alignment: alignment);
   factory BoxStyler.rotate(double radians, {Alignment alignment = .center}) =>
       BoxStyler().rotate(radians, alignment: alignment);
+
+  // Text style convenience
+  factory BoxStyler.textStyle(TextStyler value) =>
+      BoxStyler().textStyle(value);
 
   // Style metadata convenience
   factory BoxStyler.animate(AnimationConfig value) =>
@@ -309,5 +314,11 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
   @override
   BoxStyler transform(Matrix4 value, {Alignment alignment = .center}) {
     return merge(BoxStyler(transform: value, transformAlignment: alignment));
+  }
+
+  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
+  /// [DefaultTextStylerModifier] (Mix inheritance).
+  BoxStyler textStyle(TextStyler value) {
+    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 }

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -166,8 +166,7 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
       BoxStyler().rotate(radians, alignment: alignment);
 
   // Text style convenience
-  factory BoxStyler.textStyle(TextStyler value) =>
-      BoxStyler().textStyle(value);
+  factory BoxStyler.textStyle(TextStyler value) => BoxStyler().textStyle(value);
 
   // Style metadata convenience
   factory BoxStyler.animate(AnimationConfig value) =>

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -30,6 +30,7 @@ import '../box/box_spec.dart';
 import '../box/box_style.dart';
 import '../flex/flex_spec.dart';
 import '../flex/flex_style.dart';
+import '../text/text_style.dart';
 import 'flexbox_spec.dart';
 import 'flexbox_widget.dart';
 
@@ -197,6 +198,10 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
     double radians, {
     Alignment alignment = .center,
   }) => FlexBoxStyler().rotate(radians, alignment: alignment);
+
+  // Text style convenience
+  factory FlexBoxStyler.textStyle(TextStyler value) =>
+      FlexBoxStyler().textStyle(value);
 
   // Style metadata convenience
   factory FlexBoxStyler.animate(AnimationConfig value) =>
@@ -446,5 +451,11 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   @override
   FlexBoxStyler border(BoxBorderMix value) {
     return merge(FlexBoxStyler(decoration: DecorationMix.border(value)));
+  }
+
+  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
+  /// [DefaultTextStylerModifier] (Mix inheritance).
+  FlexBoxStyler textStyle(TextStyler value) {
+    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 }

--- a/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
@@ -29,6 +29,7 @@ import '../box/box_spec.dart';
 import '../box/box_style.dart';
 import '../stack/stack_spec.dart';
 import '../stack/stack_style.dart';
+import '../text/text_style.dart';
 import 'stackbox_spec.dart';
 import 'stackbox_widget.dart';
 
@@ -177,6 +178,10 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
     double radians, {
     Alignment alignment = .center,
   }) => StackBoxStyler().rotate(radians, alignment: alignment);
+
+  // Text style convenience
+  factory StackBoxStyler.textStyle(TextStyler value) =>
+      StackBoxStyler().textStyle(value);
 
   // Style metadata convenience
   factory StackBoxStyler.animate(AnimationConfig value) =>
@@ -441,5 +446,11 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
   @override
   StackBoxStyler border(BoxBorderMix value) {
     return merge(StackBoxStyler(decoration: DecorationMix.border(value)));
+  }
+
+  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
+  /// [DefaultTextStylerModifier] (Mix inheritance).
+  StackBoxStyler textStyle(TextStyler value) {
+    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 }

--- a/packages/mix/test/src/modifiers/default_text_styler_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/default_text_styler_modifier_test.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+void main() {
+  group('DefaultTextStylerModifier', () {
+    test('can be created with a TextStyler', () {
+      final style = TextStyler(style: TextStyleMix(fontSize: 16));
+      final modifier = DefaultTextStylerModifier(style);
+
+      expect(modifier.style, equals(style));
+    });
+
+    test('default constructor uses an empty TextStyler', () {
+      const modifier = DefaultTextStylerModifier();
+
+      expect(modifier.style, equals(const TextStyler.create()));
+    });
+
+    testWidgets('build() wraps child in StyleProvider<TextSpec>', (
+      tester,
+    ) async {
+      final style = TextStyler(style: TextStyleMix(fontSize: 20));
+      final modifier = DefaultTextStylerModifier(style);
+      const child = SizedBox(key: Key('child'));
+
+      await tester.pumpWidget(
+        MaterialApp(home: modifier.build(child)),
+      );
+
+      final provider = tester.widget<StyleProvider<TextSpec>>(
+        find.byType(StyleProvider<TextSpec>),
+      );
+      expect(provider.style, equals(style));
+      expect(find.byKey(const Key('child')), findsOneWidget);
+    });
+
+    test('copyWith creates new instance with updated style', () {
+      final style1 = TextStyler(style: TextStyleMix(fontSize: 12));
+      final style2 = TextStyler(style: TextStyleMix(fontSize: 24));
+      final modifier1 = DefaultTextStylerModifier(style1);
+
+      final modifier2 = modifier1.copyWith(style: style2);
+
+      expect(modifier1.style, equals(style1));
+      expect(modifier2.style, equals(style2));
+    });
+
+    test('lerp returns this when other is null', () {
+      final modifier = DefaultTextStylerModifier(
+        TextStyler(style: TextStyleMix(fontSize: 16)),
+      );
+
+      expect(modifier.lerp(null, 0.5), same(modifier));
+    });
+
+    test('lerp snaps to this when t < 0.5', () {
+      final a = DefaultTextStylerModifier(
+        TextStyler(style: TextStyleMix(fontSize: 12)),
+      );
+      final b = DefaultTextStylerModifier(
+        TextStyler(style: TextStyleMix(fontSize: 24)),
+      );
+
+      expect(a.lerp(b, 0.49), same(a));
+    });
+
+    test('lerp snaps to other when t >= 0.5', () {
+      final a = DefaultTextStylerModifier(
+        TextStyler(style: TextStyleMix(fontSize: 12)),
+      );
+      final b = DefaultTextStylerModifier(
+        TextStyler(style: TextStyleMix(fontSize: 24)),
+      );
+
+      expect(a.lerp(b, 0.5), same(b));
+    });
+  });
+
+  group('DefaultTextStylerModifierMix', () {
+    testWidgets('resolves to DefaultTextStylerModifier with same style', (
+      tester,
+    ) async {
+      final style = TextStyler(style: TextStyleMix(fontSize: 18));
+      final mix = DefaultTextStylerModifierMix(style);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              final resolved = mix.resolve(context);
+              expect(resolved, isA<DefaultTextStylerModifier>());
+              expect(resolved.style, equals(style));
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+    });
+
+    test('merge combines two instances by merging their TextStylers', () {
+      final mix1 = DefaultTextStylerModifierMix(
+        TextStyler(style: TextStyleMix(fontSize: 12)),
+      );
+      final mix2 = DefaultTextStylerModifierMix(
+        TextStyler(style: TextStyleMix(color: Colors.red)),
+      );
+
+      final merged = mix1.merge(mix2);
+
+      expect(merged, isA<DefaultTextStylerModifierMix>());
+      final expectedStyle = TextStyler(style: TextStyleMix(fontSize: 12)).merge(
+        TextStyler(style: TextStyleMix(color: Colors.red)),
+      );
+      expect(merged.style, equals(expectedStyle));
+    });
+
+    test('merge with null returns original', () {
+      final mix = DefaultTextStylerModifierMix(
+        TextStyler(style: TextStyleMix(fontSize: 12)),
+      );
+
+      expect(mix.merge(null), equals(mix));
+    });
+
+    test('equality based on style field', () {
+      final style = TextStyler(style: TextStyleMix(fontSize: 12));
+      final mix1 = DefaultTextStylerModifierMix(style);
+      final mix2 = DefaultTextStylerModifierMix(style);
+
+      expect(mix1, equals(mix2));
+    });
+  });
+
+  group('WidgetModifierConfig.defaultTextStyler', () {
+    test('factory wraps a DefaultTextStylerModifierMix', () {
+      final style = TextStyler(style: TextStyleMix(fontSize: 16));
+      final config = WidgetModifierConfig.defaultTextStyler(style);
+
+      expect(config.$modifiers, isNotNull);
+      expect(config.$modifiers!.length, equals(1));
+      expect(config.$modifiers!.first, isA<DefaultTextStylerModifierMix>());
+    });
+  });
+
+  group('DefaultTextStylerModifier inheritance', () {
+    testWidgets(
+      'descendant StyledText inherits style propagated through the modifier',
+      (tester) async {
+        final inherited = TextStyler(
+          style: TextStyleMix(
+            fontSize: 24,
+            color: Colors.red,
+            fontWeight: FontWeight.bold,
+          ),
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Box(
+              style: BoxStyler().textStyle(inherited),
+              child: const StyledText('hello'),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('hello'));
+        expect(textWidget.style?.fontSize, equals(24));
+        expect(textWidget.style?.color, equals(Colors.red));
+        expect(textWidget.style?.fontWeight, equals(FontWeight.bold));
+      },
+    );
+
+    testWidgets(
+      'descendant StyledText merges its own style on top of the inherited one',
+      (tester) async {
+        final inherited = TextStyler(
+          style: TextStyleMix(fontSize: 24, color: Colors.red),
+        );
+        final local = TextStyler(style: TextStyleMix(color: Colors.blue));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Box(
+              style: BoxStyler().textStyle(inherited),
+              child: StyledText('hello', style: local),
+            ),
+          ),
+        );
+
+        final textWidget = tester.widget<Text>(find.text('hello'));
+        expect(textWidget.style?.fontSize, equals(24));
+        expect(textWidget.style?.color, equals(Colors.blue));
+      },
+    );
+  });
+}

--- a/packages/mix/test/src/modifiers/default_text_styler_modifier_test.dart
+++ b/packages/mix/test/src/modifiers/default_text_styler_modifier_test.dart
@@ -24,9 +24,7 @@ void main() {
       final modifier = DefaultTextStylerModifier(style);
       const child = SizedBox(key: Key('child'));
 
-      await tester.pumpWidget(
-        MaterialApp(home: modifier.build(child)),
-      );
+      await tester.pumpWidget(MaterialApp(home: modifier.build(child)));
 
       final provider = tester.widget<StyleProvider<TextSpec>>(
         find.byType(StyleProvider<TextSpec>),
@@ -109,9 +107,9 @@ void main() {
       final merged = mix1.merge(mix2);
 
       expect(merged, isA<DefaultTextStylerModifierMix>());
-      final expectedStyle = TextStyler(style: TextStyleMix(fontSize: 12)).merge(
-        TextStyler(style: TextStyleMix(color: Colors.red)),
-      );
+      final expectedStyle = TextStyler(
+        style: TextStyleMix(fontSize: 12),
+      ).merge(TextStyler(style: TextStyleMix(color: Colors.red)));
       expect(merged.style, equals(expectedStyle));
     });
 


### PR DESCRIPTION
#### Related issue

None.

### Description

Adds a new widget modifier that propagates a `TextStyler` to descendant `StyledText` widgets via Mix inheritance (`StyleProvider<TextSpec>`), preserving variants, modifiers, and merge semantics rather than a flattened `TextStyle`. `BoxStyler`/`FlexBoxStyler`/`StackBoxStyler` gain a `.textStyle(TextStyler)` fluent method that attaches this modifier, so descendants can still merge their own `TextStyler` on top.

### Changes

- New `DefaultTextStylerModifier` + `DefaultTextStylerModifierMix` in `packages/mix/lib/src/modifiers/default_text_styler_modifier.dart`, exported from `mix.dart`.
- `WidgetModifierConfig.defaultTextStyler(TextStyler)` factory + instance method; registered in the default modifier order.
- `.textStyle(TextStyler)` on `BoxStyler`, `FlexBoxStyler`, `StackBoxStyler` now wraps with the new modifier.
- Unit + widget tests covering construction, `build`, `copyWith`, `lerp` (snap at 0.5), `resolve`, `merge`, and end-to-end inheritance through `StyledText`.

**Review Checklist**

- [x] **Testing**: Unit tests and widget integration tests added; full analyze + test suite passes.
- [ ] **Breaking Changes**: None — `DefaultTextStyleModifier` remains available for Flutter-native `DefaultTextStyle` interop.
- [ ] **Documentation Updates**: Not updated in this PR.
- [ ] **Website Updates**: Not updated in this PR.

### Additional Information (optional)

Unlike `DefaultTextStyleModifier` (which propagates a resolved `TextStyle`), this modifier holds the unresolved `TextStyler`, so descendants' own `TextStyler`s can merge through Mix's existing inheritance path. `lerp` uses snap semantics at `t=0.5` because `TextStyler` has no natural interpolation.