### PR TITLE
chore(mix, mix_generator): release mix v2.0.2 and mix_generator v2.0.1

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 2.0.2
+
+This release completes the 2.0 Styler migration by removing the remaining legacy utility surface, and adds new ergonomic shorthands and variant tooling.
+
+### Removals
+
+- **Legacy utility classes and mutable stylers:** All remaining deprecated utility classes and mutable stylers were removed, finishing the transition to the Styler-first API (#901).
+
+### New features
+
+- **EnumVariant mixin:** Define type-safe enum-based variants without hand-written boilerplate (#894).
+- **DefaultTextStylerModifier:** Propagate default `TextStyler` values down the widget tree via a modifier, matching the pattern used by other default stylers (#905).
+- **Text shadow shorthand:** Dot-shorthand entry point for configuring text shadows (#890).
+- **Uniform border shorthand:** Dot-shorthand for applying a uniform border in one call (#889).
+- **`MixStyler` export:** `MixStyler` is now exported from the public API, matching the documentation (#900).
+
+### Fixes
+
+- **RotateModifier lerp:** Interpolate the rotation angle directly instead of the transform matrix, producing smoother rotation transitions (#898).
+
 ## 2.0.1
 
 This patch release improves day-to-day styling ergonomics and makes looping animations more reliable in edge cases.

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2.0.1
+
+ - **REFACTOR**: Tighten field-model validation and shared type-helper extraction across mix/styler generators (#895).
+ - **TEST**: Add generator smoke and validation integration tests plus broader builder coverage (#895).
+
+## 2.0.0
+
+ - Stable release matching the `2.0.0-rc.1` surface, with READMEs refreshed for the 2.0 generator API (#887, #888).
+
 ## 2.0.0-rc.1
 
  - **BREAKING**: The Mix Generator was completely rebuilt to support the architecture and requirements of Mix V2.0.

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 


### PR DESCRIPTION
#### Related issue

N/A — release prep.

### Description

Publishes `mix` v2.0.2 and `mix_generator` v2.0.1, bumping pubspecs and updating CHANGELOGs with the changes landed since the previous releases. Also backfills a `2.0.0` entry for `mix_generator` that was missing from its CHANGELOG.

### Changes

- `packages/mix`: bump version `2.0.1` → `2.0.2`; add CHANGELOG entry covering the legacy utility removal (#901), new features (EnumVariant #894, DefaultTextStylerModifier #905, text shadow shorthand #890, uniform border shorthand #889, `MixStyler` export #900) and the RotateModifier lerp fix (#898).
- `packages/mix_generator`: bump version `2.0.0` → `2.0.1`; add CHANGELOG entry for the generator validation tightening and expanded tests (#895), and backfill the previously missing `2.0.0` entry referencing #887/#888.

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [x] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Release-only change — no source code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)