### PR TITLE
feat/mix-skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,18 +16,18 @@ This installs FVM, Flutter SDK (3.41.2), DCM, and melos, then bootstraps all pac
 
 ```
 packages/
-  mix/              # Core framework (v2.0.0-rc.0)
+  mix/              # Core framework (see packages/mix/pubspec.yaml for version)
   mix_annotations/  # Annotations for codegen
   mix_generator/    # build_runner generator
-  mix_lint/         # Custom linter (not in pub workspace, see below)
+  mix_lint/         # Custom linter
 ```
 
-## Pub workspace
+## Package management
 
-The repo uses [Dart pub workspaces](https://dart.dev/tools/pub/workspaces): a single `pubspec.lock` and shared resolution at the root. Run `dart pub get` at the repo root to resolve all workspace packages.
+The repo is a Melos-managed monorepo. Package membership is declared in [`melos.yaml`](melos.yaml). Run `melos bootstrap` at the repo root to resolve dependencies for all packages.
 
-- **In the workspace:** mix, mix_annotations, mix_generator, mix_tailwinds, mix_tailwinds/example.
-- **Excluded:** `mix_lint` (uses analyzer ^7.x for custom_lint_builder; other packages use analyzer >=9). Run `dart pub get` inside `packages/mix_lint` when working on the linter.
+- **Managed by `melos bootstrap`:** `mix`, `mix_annotations`, `mix_generator`, `mix_tailwinds`, `mix_tailwinds/example`, and `mix_lint`.
+- **Why `mix_lint` is called out separately:** it uses `analysis_server_plugin` with a broader analyzer range (`>=8.4.0 <12.0.0`), while generator-facing packages use `analyzer >=9`. `melos.yaml` includes it via a dedicated entry so dependency resolution stays clean.
 
 ## Commands
 
@@ -121,7 +121,7 @@ melos run test:coverage   # With coverage report
 <type>(<scope>): <description>
 
 type: feat, fix, chore, docs, refactor, test, ci
-scope: mix, mix_generator, mix_annotations, mix_lint
+scope: mix, mix_generator, mix_annotations, mix_lint, mix_tailwinds
 ```
 
 ## Key Files

--- a/docs/superpowers/specs/2026-03-23-mix-coding-skill-design.md
+++ b/docs/superpowers/specs/2026-03-23-mix-coding-skill-design.md
@@ -15,8 +15,8 @@ skills/mix-coding/
 │   ├── variants.md                  # Context variants, widget states
 │   ├── animations.md                # Implicit, keyframe, phase
 │   ├── tokens.md                    # Design tokens, MixScope, theming
-│   ├── widgets.md                   # Box, HBox, VBox, Text, Icon, Pressable
-│   └── examples.md                  # Curated code examples from packages/mix_docs_preview/lib/
+│   ├── widgets.md                   # Box, FlexBox, RowBox, ColumnBox, StackBox, StyledText, StyledIcon, Pressable
+│   └── examples.md                  # Curated examples from package source and tests
 ```
 
 ## Main File (`mix-coding.md`)
@@ -39,10 +39,10 @@ skills/mix-coding/
 | User is asking about... | Load reference |
 |---|---|
 | Styling a widget, colors, padding, borders, sizing | `styling.md` |
-| Hover, press, focus, dark mode, responsive, selected | `variants.md` |
+| Hover, press, focus, dark mode, responsive, disabled/custom states | `variants.md` |
 | Animations, transitions, keyframes, spring | `animations.md` |
 | Design tokens, theming, MixScope | `tokens.md` |
-| Which widget to use, Box vs HBox, layout | `widgets.md` |
+| Which widget to use, Box vs FlexBox/RowBox/ColumnBox, layout | `widgets.md` |
 | Needs a concrete example or pattern reference | `examples.md` |
 
 Multiple references may be loaded for a single request (e.g., styling + variants for "a card that changes color on hover").
@@ -58,32 +58,32 @@ Multiple references may be loaded for a single request (e.g., styling + variants
 ### `references/styling.md`
 **Patterns:** Creating styles, chaining methods, merging styles, composing multiple stylers.
 **API tables:** BoxStyler methods (color, size, padding, margin, border, shadow, decoration), TextStyler methods (fontSize, fontWeight, color, letterSpacing), IconStyler methods.
-**Source refs:** `packages/mix_docs_preview/lib/widgets/box/`, `packages/mix_docs_preview/lib/widgets/text/`, `packages/mix_docs_preview/lib/guides/styling/`
+**Source refs:** `packages/mix/lib/src/specs/box/`, `packages/mix/lib/src/specs/text/`, `packages/mix/lib/src/specs/icon/`, `packages/mix/test/src/specs/`
 
 ### `references/variants.md`
 **Patterns:** Adding hover/press/focus states, dark/light mode, responsive sizing, custom context variants, combining multiple variants.
-**API tables:** Built-in variant methods (`.onHovered()`, `.onPressed()`, `.onFocused()`, `.onSelected()`, `.onDisabled()`, `.onDark()`, `.onLight()`), `ContextVariant` creation.
-**Source refs:** `packages/mix_docs_preview/lib/guides/dynamic_styling/`, `website/src/content/documentation/guides/dynamic-styling.mdx`
+**API tables:** Built-in variant methods (`.onHovered()`, `.onPressed()`, `.onFocused()`, `.onDisabled()`, `.onDark()`, `.onLight()`), breakpoint/platform methods, named variants, and `ContextVariant` creation.
+**Source refs:** `packages/mix/lib/src/style/mixins/variant_style_mixin.dart`, `packages/mix/lib/src/style/mixins/widget_state_variant_mixin.dart`, `packages/mix/lib/src/variants/variant.dart`, `packages/mix/test/src/variants/`
 
 ### `references/animations.md`
 **Patterns:** Implicit animations (auto-animate on state change), keyframe animations (multi-step sequences), phase animations (tap-triggered multi-phase), spring physics.
-**API tables:** `.animate()` config, `KeyframeAnimation` builder, `PhaseAnimation` builder, curve/duration options.
-**Source refs:** `packages/mix_docs_preview/lib/guides/animations/`, `website/src/content/documentation/guides/animations.mdx`
+**API tables:** `.animate()` config, `.keyframeAnimation()` builder, `.phaseAnimation()` builder, curve/duration options.
+**Source refs:** `packages/mix/lib/src/animation/`, `packages/mix/lib/src/style/mixins/animation_style_mixin.dart`, `packages/mix/test/src/animation/`
 
 ### `references/tokens.md`
 **Patterns:** Defining tokens, providing tokens via `MixScope`, using tokens in styles, creating a theme.
 **API tables:** `MixToken`, `ColorToken`, `SpaceToken`, `RadiusToken`, `MixScope` widget.
-**Source refs:** `packages/mix_docs_preview/lib/guides/design_token/theme_tokens.dart`, `packages/mix_docs_preview/lib/tutorials/theming/preview.dart`
+**Source refs:** `packages/mix/lib/src/theme/`, `packages/mix/doc/mix-scope-and-theming.md`, `packages/mix/doc/token-migration-guide.md`, `packages/mix/test/src/theme/`
 
 ### `references/widgets.md`
-**Patterns:** When to use Box vs HBox vs VBox vs ZBox, Text vs StyledText, Pressable for interactivity.
+**Patterns:** When to use Box, FlexBox, RowBox, ColumnBox, StackBox, StyledText, StyledIcon, StyledImage, Pressable, and PressableBox.
 **API tables:** Widget constructors, required/optional parameters, style parameter types.
-**Source refs:** `packages/mix_docs_preview/lib/widgets/box/`, `packages/mix_docs_preview/lib/widgets/flexbox/`, `packages/mix_docs_preview/lib/widgets/vbox/`, `website/src/content/documentation/widgets/`
+**Source refs:** `packages/mix/lib/src/specs/box/`, `packages/mix/lib/src/specs/flexbox/`, `packages/mix/lib/src/specs/stackbox/`, `packages/mix/lib/src/specs/text/`, `packages/mix/lib/src/specs/icon/`, `packages/mix/lib/src/specs/image/`, `packages/mix/lib/src/specs/pressable/`
 
 ### `references/examples.md`
 **Organization:** Basic → Intermediate → Advanced complexity.
 **Each example:** Description, full code, which concepts it demonstrates.
-**Source refs:** Paths into `packages/mix_docs_preview/lib/` for each example.
+**Source refs:** Paths into `packages/mix/test/` and `packages/mix/lib/src/specs/` for each example.
 
 ## Runtime Behavior
 
@@ -96,5 +96,5 @@ Multiple references may be loaded for a single request (e.g., styling + variants
 
 - **Lazy loading:** Only load references needed for the current request
 - **Rigid skill:** Claude must follow documented patterns, not guess at API
-- **Source refs:** Point to `packages/mix_docs_preview/lib/` files so Claude can read real implementations
+- **Source refs:** Point to `packages/mix/lib/src/`, `packages/mix/test/`, and authored docs so Claude can read real implementations
 - **External developer focus:** Patterns show how to USE Mix, not how to extend it

--- a/guides/api-composition-guidelines.md
+++ b/guides/api-composition-guidelines.md
@@ -23,7 +23,7 @@ Stack layout
 Composition
 - Reuse fragments: `final card = base.merge(elevated);`
 - Everyday props: use chaining instead of merging multiple Styler instances
-- In typed style arguments, prefer shorthand: `.onHovered(.color(...))`, `.border(.color(...).width(...))`, `.container(.shadow(...))`
+- In typed style arguments, prefer shorthand: `.onHovered(.color(...))`, `.border(.color(...).width(...))`, `.shadow(.color(...).blurRadius(...))`
 
 ---
 

--- a/packages/mix/doc/mix-scope-and-theming.md
+++ b/packages/mix/doc/mix-scope-and-theming.md
@@ -132,8 +132,12 @@ final $cardShadow = BoxShadowToken('shadow.card');
 final style = BoxStyler()
   .color($primary())
   .padding(.all($spacing()));
-  // For APIs that take lists of shadows/boxShadows
-  // .boxShadow($cardShadow())
+
+// Shadow tokens are list-based. Resolve them before converting to BoxShadowMix
+// for APIs that take lists of box shadows.
+final shadowStyle = BoxStyler().shadows(
+  $cardShadow.resolve(context).map(BoxShadowMix.value).toList(),
+);
 ```
 
 ## Modifier Ordering

--- a/packages/mix/doc/token-migration-guide.md
+++ b/packages/mix/doc/token-migration-guide.md
@@ -57,7 +57,7 @@ class SpaceToken extends MixToken<double> {
   const SpaceToken(super.name);
   
   @override
-  double call() => SpaceRef.token(this);  // Extension type
+  double call() => DoubleRef.token(this);  // Extension type
 }
 ```
 
@@ -93,21 +93,27 @@ class BreakpointToken extends MixToken<Breakpoint> {
 
 ### BoxShadowToken
 ```dart
-class BoxShadowToken extends MixToken<BoxShadow> {
+class BoxShadowToken extends MixToken<List<BoxShadow>> {
   const BoxShadowToken(super.name);
   
+  /// Returns a Mix framework compatible reference for use with Mix styling utilities.
+  BoxShadowListMixRef mix() => BoxShadowListMixRef(Prop.token(this));
+
   @override
-  BoxShadowRef call() => BoxShadowRef(Prop.token(this));
+  BoxShadowListRef call() => BoxShadowListRef(Prop.token(this));
 }
 ```
 
 ### ShadowToken
 ```dart
-class ShadowToken extends MixToken<Shadow> {
+class ShadowToken extends MixToken<List<Shadow>> {
   const ShadowToken(super.name);
   
+  /// Returns a Mix framework compatible reference for use with Mix styling utilities.
+  ShadowListMixRef mix() => ShadowListMixRef(Prop.token(this));
+
   @override
-  ShadowRef call() => ShadowRef(Prop.token(this));
+  ShadowListRef call() => ShadowListRef(Prop.token(this));
 }
 ```
 
@@ -119,22 +125,24 @@ Each token type has a corresponding reference type that implements the target in
 - **ColorRef**: Implements `Color` interface
 - **RadiusRef**: Implements `Radius` interface  
 - **TextStyleRef**: Implements `TextStyle` interface
-- **BoxShadowRef**: Implements `BoxShadow` interface
-- **ShadowRef**: Implements `Shadow` interface
+- **BoxShadowListRef**: Implements `List<BoxShadow>` interface
+- **ShadowListRef**: Implements `List<Shadow>` interface
 - **BreakpointRef**: Implements `Breakpoint` interface
+
+For list-based shadow tokens, `.mix()` returns `BoxShadowListMixRef` or `ShadowListMixRef` for Mix framework APIs that accept `BoxShadowListMix` or `ShadowListMix`.
 
 ### Extension Type Refs (Primitives)
 For primitive types, extension types are used:
 
-- **SpaceRef**: Extension type for `double` values (spacing, sizing)
+- **DoubleRef**: Extension type for `double` values (spacing, sizing, and numeric tokens)
 
 ```dart
 // Extension type example
-extension type const SpaceRef(double _value) implements double {
-  static SpaceRef token(MixToken<double> token) {
+extension type const DoubleRef(double _value) implements double {
+  static DoubleRef token(MixToken<double> token) {
     // Creates unique reference value and registers token
     final hash = token.hashCode.abs() % 100000;
-    final ref = SpaceRef(-(0.000001 + hash * 0.000001));
+    final ref = DoubleRef(-(0.000001 + hash * 0.000001));
     _tokenRegistry[ref] = token;
     return ref;
   }
@@ -259,7 +267,7 @@ final textStyle = TextStyler().style(headingStyle.mix());
 ```dart
 // Token call() method returns refs for styling
 final colorRef = primaryColor(); // Returns ColorRef
-final spaceRef = largeSpace();   // Returns SpaceRef
+final spaceRef = largeSpace();   // Returns DoubleRef
 final textStyleMixRef = headingStyle.mix(); // Returns TextStyleMixRef
 final flutterTextStyleRef = headingStyle(); // Returns TextStyleRef
 
@@ -271,8 +279,8 @@ final textStyle = TextStyler().style(textStyleMixRef);
 ### 4. Using Tokens in Properties
 
 ```dart
-// SpaceDto with tokens
-final spacing = SpaceDto.token(largeSpace);
+// Prop<T> with tokens
+final spacingProp = Prop.token(largeSpace);
 
 // Prop<T> with tokens  
 final colorProp = Prop.token(primaryColor);

--- a/packages/mix_lint/README.md
+++ b/packages/mix_lint/README.md
@@ -10,7 +10,7 @@ Add `mix_lint` as a dev dependency:
 dart pub add -d mix_lint
 ```
 
-Enable the plugin in `analysis_options.yaml` (requires Dart ≥ 3.10 / Flutter ≥ 3.38):
+Enable the plugin in `analysis_options.yaml` (requires Dart ≥ 3.11; Flutter apps using Mix should follow Mix's Flutter SDK constraint):
 
 ```yaml
 plugins:
@@ -127,12 +127,12 @@ final style = BoxStyler()
 
 Limit the number of attributes per style. The default value is 15. This rule encourages keeping styles concise and focused; split large styles into smaller, reusable Stylers and compose with `merge()`.
 
-The rule reports when a `Styler` constructor or a variant-style invocation has more than `max_number` arguments.
+The rule reports when a Styler chain has more than `max_number` chained method calls.
 
 #### Don't
 
 ```dart
-// One large style with too many arguments (exceeds max_number)
+// One large style chain with too many method calls (exceeds max_number)
 final style = BoxStyler()
     .color(Colors.blue)
     .paddingAll(8)
@@ -185,7 +185,7 @@ final style = layout
 
 ##### max_number (int)
 
-The maximum number of attributes allowed per style (or per variant invocation). The default value is 15.
+The maximum number of chained method calls allowed per style. The default value is 15.
 
 ### mix_variants_last
 

--- a/packages/mix_lint/doc/mix_max_number_of_attributes_per_style.md
+++ b/packages/mix_lint/doc/mix_max_number_of_attributes_per_style.md
@@ -2,12 +2,12 @@
 
 Limit the number of attributes per style. The default value is 15. This rule encourages keeping styles concise and focused; split large styles into smaller, reusable Stylers and compose with `merge()`.
 
-The rule reports when a `Styler` constructor or a variant-style invocation has more than `max_number` arguments.
+The rule reports when a Styler chain has more than `max_number` chained method calls.
 
 #### Don't
 
 ```dart
-// One large style with too many arguments (exceeds max_number)
+// One large style chain with too many method calls (exceeds max_number)
 final style = BoxStyler()
     .color(Colors.blue)
     .paddingAll(8)
@@ -60,4 +60,4 @@ final style = layout
 
 ##### max_number (int)
 
-The maximum number of attributes allowed per style (or per variant invocation). The default value is 15.
+The maximum number of chained method calls allowed per style. The default value is 15.

--- a/packages/mix_lint/doc/mix_mixable_styler_has_create.md
+++ b/packages/mix_lint/doc/mix_mixable_styler_has_create.md
@@ -1,4 +1,4 @@
-iml### mix_mixable_styler_has_create
+### mix_mixable_styler_has_create
 
 Ensures that every class annotated with `@MixableStyler` defines a named constructor `.create`. The generated Styler mixin and the rest of the Mix API expect this constructor for const instantiation, merging, and default styles (e.g. `const BoxStyler.create()`).
 

--- a/skills/mix-coding/SKILL.md
+++ b/skills/mix-coding/SKILL.md
@@ -1,114 +1,130 @@
 ---
 name: mix-coding
-description: "Use when the user asks to write Flutter code using Mix, or mentions Mix styling, BoxStyler, TextStyler, IconStyler, variants, animations, design tokens, or Mix widgets like Box, HBox, VBox, StyledText, StyledIcon, Pressable. Also trigger when user references 'package:mix' or fluent styling in Flutter. This skill ensures Claude writes correct, idiomatic Mix 2.0 code instead of guessing at the API."
+description: >
+  Use this skill whenever the user asks to write, review, debug, fix, migrate,
+  or modernize Flutter code using Mix; mentions package:mix, Mix 2.0,
+  BoxStyler, TextStyler, IconStyler, ImageStyler, MixScope, design tokens,
+  variants, animations, Box, FlexBox, RowBox, ColumnBox, StackBox, StyledText,
+  StyledIcon, StyledImage, Pressable, PressableBox, or stale examples with HBox,
+  VBox, ZBox, docs preview APIs, MixScopeConfig, KeyframeAnimationBuilder, or
+  PhaseAnimationBuilder. This skill helps produce source-aligned Mix code
+  instead of guessing at API names.
 ---
 
-# Mix 2.0 — Correct Code Patterns
+# Mix Coding
 
-This skill ensures you write correct Mix 2.0 code. Mix separates style semantics from widgets using a **Spec/Style/Widget** pattern with a fluent chaining API.
+Use this skill to write or review app-level Flutter code that consumes Mix 2.0.
+Mix separates widget semantics from style semantics through Specs, Stylers, and
+styled widgets.
 
-**This is a rigid skill.** Follow the documented patterns exactly. Do not guess at method names or API shapes — read the relevant reference file first.
+This is a source-aligned skill. Before giving non-trivial Mix code, load the
+smallest relevant reference file and follow its examples.
 
-## Core Principles
+## Core Rules
 
-These rules apply to ALL Mix code you write:
-
-1. **Always import Mix:**
+1. Import Mix and Flutter material/widgets as needed:
    ```dart
+   import 'package:flutter/material.dart';
    import 'package:mix/mix.dart';
    ```
 
-2. **Use fluent chaining** — styles are built by chaining methods on Stylers:
+2. Use Stylers, not Specs, in application code.
    ```dart
-   final style = BoxStyler()
-       .color(Colors.blue)
-       .size(100, 100)
+   final cardStyle = BoxStyler()
+       .color(Colors.white)
        .paddingAll(16)
-       .borderRounded(8);
+       .borderRounded(12);
    ```
 
-3. **Specs are immutable, Stylers are builders.** Never construct a Spec directly — always use the corresponding Styler (`BoxStyler`, `TextStyler`, `IconStyler`).
+3. Prefer fluent chaining and named style variables. Inline one short style is
+   fine, but move multi-property styles into variables so variants and
+   composition stay readable.
 
-4. **Define styles as variables**, not inline:
-   ```dart
-   // Correct
-   final cardStyle = BoxStyler().color(Colors.white).paddingAll(16);
-   Box(style: cardStyle, child: content);
+4. Use dot shorthands where they make code clearer. The repo targets Dart
+   `>=3.11.0`, so values like `.center`, `.bold`, `.horizontal`, `.dark`, and
+   `.easeInOut(220.ms)` are valid when the target type is known.
 
-   // Wrong — don't inline complex styles
-   Box(style: BoxStyler().color(Colors.white).paddingAll(16), child: content);
-   ```
+5. Use current widget names:
+   - Box/container: `Box`
+   - Flex layout: `FlexBox`, `RowBox`, `ColumnBox`
+   - Stack layout: `StackBox`
+   - Text/icon/image: `StyledText`, `StyledIcon`, `StyledImage`
+   - Interaction: `Pressable`, `PressableBox`
 
-5. **Dart SDK >=3.11.0** — dot-shorthands are enabled (e.g., `.center`, `.bold`, `.topLeft`).
-
-6. **Stylers can be called directly** to create their widget:
-   ```dart
-   final box = BoxStyler().color(Colors.blue).size(100, 100);
-   // These are equivalent:
-   Box(style: box);
-   box();  // Shorthand — calls the styler to produce a Box
-   ```
-
-7. **Factory constructors** allow starting with a property:
-   ```dart
-   // These are equivalent:
-   BoxStyler().color(Colors.blue)
-   BoxStyler.color(Colors.blue)
-   ```
-
-## Common Mistakes
-
-Avoid these patterns — they are the most frequent errors:
-
-| Wrong | Correct | Why |
-|-------|---------|-----|
-| `Container(color: ...)` | `Box(style: BoxStyler().color(...))` | Use Mix widgets, not Flutter primitives |
-| `Text(style: TextStyle(...))` | `StyledText('...', style: TextStyler().fontSize(...))` | Use StyledText with TextStyler |
-| `Icon(Icons.star, size: 30)` | `StyledIcon(icon: Icons.star, style: IconStyler.size(30))` | Use StyledIcon with IconStyler |
-| Mutating a styler in place | Chain returns a new styler | Stylers are immutable builders |
-| `Theme.of(context).colorScheme` | Use `ColorToken` with `MixScope` | Don't mix Flutter theming with Mix tokens |
-| Nesting `Padding`/`Align` widgets | Use `.paddingAll()`, `.alignment()` on styler | Mix handles spacing/alignment via style |
+6. Do not invent aliases or old docs-preview APIs. If a prompt contains stale
+   names, modernize them before answering.
 
 ## Reference Routing
 
-Before writing Mix code, **read the relevant reference file(s)** based on what the user needs. Load 1-2 references per request — don't load them all.
+Load only the reference files needed for the user's task.
 
-| User is asking about... | Read this reference |
+| User needs | Read |
 |---|---|
-| Styling a widget: colors, padding, borders, sizing, gradients, shadows | `references/styling.md` |
-| Hover, press, focus, dark/light mode, responsive, disabled, selected | `references/variants.md` |
-| Animations, transitions, keyframes, spring physics, phases | `references/animations.md` |
-| Design tokens, theming, MixScope, token types | `references/tokens.md` |
-| Which widget to use, Box vs FlexBox, layout, Pressable | `references/widgets.md` |
-| Need a full working example or pattern reference | `references/examples.md` |
+| Box/Text/Icon/Image styling, spacing, borders, shadows, gradients | `references/styling.md` |
+| Hover, press, focus, disabled, dark/light, responsive, platform variants | `references/variants.md` |
+| `MixScope`, tokens, semantic colors/spacing/typography | `references/tokens.md` |
+| Choosing widgets or constructor shapes | `references/widgets.md` |
+| `.animate`, `.keyframeAnimation`, `.phaseAnimation` | `references/animations.md` |
+| Full patterns to copy or adapt | `references/examples.md` |
 
-**How to use references:** Read the file with the Read tool, then follow the patterns and API tables in it. The references contain real, verified method signatures and code examples extracted from the Mix codebase.
+When a request spans more than one area, read 1-2 references. Example: a themed
+hover button usually needs `styling.md`, `variants.md`, and maybe `tokens.md`;
+prefer the two most relevant and inspect source if details remain unclear.
 
-## Style Composition
+## Output Habits
 
-Styles compose by merging — later values override earlier ones:
+- Provide complete snippets when the user asks to build something.
+- Keep examples app-level unless the user explicitly asks to extend Mix internals.
+- Explain only the Mix-specific choices that matter: which widget, which
+  Styler, which variant or token mechanism.
+- If the user asks to edit this repo, inspect current source before changing docs or code.
+
+## Common Corrections
+
+| Stale or risky pattern | Current pattern |
+|---|---|
+| `Container(...)` for Mix-styled surfaces | `Box(style: BoxStyler(...))` |
+| `Text(...)` with manual `TextStyle` when Mix styling is requested | `StyledText(..., style: TextStyler(...))` |
+| `Icon(...)` with manual size/color when Mix styling is requested | `StyledIcon(icon: ..., style: IconStyler(...))` |
+| Old flex aliases | `RowBox`, `ColumnBox`, `FlexBox`, or `StackBox` |
+| Old scope configuration helper examples | `MixScope(...)` |
+| Animation builder classes for new app examples | Style-level animation APIs |
+| Single shadow token references | list-based `ShadowToken` / `BoxShadowToken` refs |
+
+## Quick Pattern
 
 ```dart
-final base = BoxStyler()
-    .paddingX(16)
-    .paddingY(8)
+final buttonStyle = BoxStyler()
+    .color(Colors.blue)
+    .paddingX(20)
+    .paddingY(12)
     .borderRounded(8)
-    .color(Colors.black);
+    .animate(.easeInOut(180.ms))
+    .onHovered(.color(Colors.blue.shade700))
+    .onPressed(.color(Colors.blue.shade900));
 
-// Override just the color — everything else carries over
-final solid = base.color(Colors.blue);
-final soft = base.color(Colors.blue.shade100);
+final labelStyle = TextStyler()
+    .color(Colors.white)
+    .fontWeight(.bold);
+
+PressableBox(
+  style: buttonStyle,
+  onPress: onPress,
+  child: StyledText('Save', style: labelStyle),
+);
 ```
 
-## Quick Reference: Widget ↔ Styler Mapping
+## Source Anchors
 
-| Widget | Styler | Use for |
-|--------|--------|---------|
-| `Box` | `BoxStyler` | Container, card, background |
-| `RowBox` / `HBox` | `FlexBoxStyler` | Horizontal layout |
-| `ColumnBox` / `VBox` | `FlexBoxStyler` | Vertical layout |
-| `ZBox` | `FlexBoxStyler` | Stack/overlay layout |
-| `StyledText` | `TextStyler` | Styled text |
-| `StyledIcon` | `IconStyler` | Styled icon |
-| `StyledImage` | `ImageStyler` | Styled image |
-| `Pressable` / `PressableBox` | (wraps other styles) | Interactive/tappable |
+Use these source paths when the references are not enough:
+
+- `packages/mix/lib/src/specs/box/`
+- `packages/mix/lib/src/specs/flexbox/`
+- `packages/mix/lib/src/specs/stackbox/`
+- `packages/mix/lib/src/specs/text/`
+- `packages/mix/lib/src/specs/icon/`
+- `packages/mix/lib/src/specs/image/`
+- `packages/mix/lib/src/specs/pressable/`
+- `packages/mix/lib/src/style/mixins/`
+- `packages/mix/lib/src/theme/`
+- `packages/mix/test/src/`

--- a/skills/mix-coding/evals/evals.json
+++ b/skills/mix-coding/evals/evals.json
@@ -1,0 +1,82 @@
+{
+  "skill_name": "mix-coding",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Build me a reusable Flutter widget called AccountSummaryCard using Mix. It should be a white card with rounded corners, padding, a subtle shadow, a title, a balance, and a small status row with an icon. Use current Mix 2.0 patterns.",
+      "expected_output": "A complete app-level Flutter snippet using current Mix widgets and Stylers.",
+      "files": [],
+      "expectations": [
+        "Uses import 'package:mix/mix.dart'.",
+        "The primary Dart snippet uses Box, ColumnBox, or RowBox rather than Container for the styled surface.",
+        "Defines named BoxStyler/TextStyler/IconStyler variables instead of one large inline style.",
+        "If the card includes a shadow, it prefers typed dot shorthand such as .shadow(.color(...).blurRadius(...)) rather than defaulting to .shadowOnly(...).",
+        "The primary Dart snippet does not use packages/mix_docs_preview, website/src, HBox, VBox, or ZBox."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a Mix PressableBox button that has default, hover, pressed, focused, and disabled visual states. It should animate between states and use StyledText for the label.",
+      "expected_output": "A PressableBox example with current widget-state variants and animation.",
+      "files": [],
+      "expectations": [
+        "Uses PressableBox with onPress and enabled or disabled handling.",
+        "Uses .onHovered, .onPressed, .onFocused, and .onDisabled.",
+        "Uses .animate with an AnimationConfig or dot-shorthand animation config.",
+        "When showing BoxStyler shadows, prefers typed dot shorthand such as .shadow(.color(...).blurRadius(...).offset(y: ...)); does not use .shadow(color: ...) and avoids .shadowOnly(...) unless explicitly explaining it as a fallback.",
+        "Uses source-aligned Mix border APIs if borders are shown, such as .borderAll(color: ..., width: ...) or .border(.color(...).width(...)), not .border(color: ...).",
+        "Uses source-aligned Mix transform APIs if transforms are shown, such as .translate(0, -1), not .translate(y: ...) or .translateY(...).",
+        "Does not invent .onSelected for this button."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Show me how to create a small tokenized theme in Mix with ColorToken, SpaceToken, RadiusToken, and TextStyleToken, then consume it in a card style.",
+      "expected_output": "A MixScope example with typed token maps and token refs consumed by Stylers.",
+      "files": [],
+      "expectations": [
+        "Uses MixScope, not MixScopeConfig.",
+        "Uses ColorToken, SpaceToken, RadiusToken, and TextStyleToken.",
+        "Uses token call syntax such as $token() inside Stylers.",
+        "Uses TextStyleToken.mix() when passing a text style token into TextStyler.style."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I need a responsive settings shell with navigation and content. Use Mix so it is a vertical layout on mobile and horizontal on desktop. Pick the right current Mix widgets.",
+      "expected_output": "A responsive layout using FlexBox or RowBox/ColumnBox and current breakpoint variants.",
+      "files": [],
+      "expectations": [
+        "The primary Dart snippet uses FlexBox, RowBox, or ColumnBox.",
+        "Uses .onMobile, .onDesktop, or .onBreakpoint for responsive behavior.",
+        "The primary Dart snippet does not use old layout names HBox, VBox, or ZBox.",
+        "Keeps layout styling in FlexBoxStyler or related current Stylers.",
+        "Prefers typed dot shorthand in responsive variant arguments, such as .onDesktop(.direction(...).spacing(...)), rather than .onDesktop(FlexBoxStyler()...) or .onDesktop(BoxStyler()...)."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Create a Mix example for an animated pulse badge. Use a style-level animation approach, not a separate animation builder widget. Include enough code that I can adapt it.",
+      "expected_output": "A current Mix animation example using .animate, .keyframeAnimation, or .phaseAnimation.",
+      "files": [],
+      "expectations": [
+        "Uses .animate, .keyframeAnimation, or .phaseAnimation on a Styler.",
+        "Does not use KeyframeAnimationBuilder or PhaseAnimationBuilder.",
+        "Uses KeyframeTrack/Keyframe or phase styleBuilder/configBuilder only if needed.",
+        "Uses current Mix widgets such as Box or PressableBox."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Can you modernize this old Mix snippet? It uses HBox, MixScopeConfig, and KeyframeAnimationBuilder. Rewrite it for current Mix 2.0 and explain the replacements briefly.",
+      "expected_output": "A modernization answer that replaces stale APIs with current source-aligned patterns.",
+      "files": [],
+      "expectations": [
+        "The final Dart snippet uses RowBox or FlexBox in place of HBox.",
+        "The final Dart snippet uses MixScope in place of MixScopeConfig.",
+        "The final Dart snippet uses a style-level animation API such as .keyframeAnimation in place of KeyframeAnimationBuilder.",
+        "Brief prose may name the old APIs only to explain the replacements, and should not cite unavailable docs-preview paths."
+      ]
+    }
+  ]
+}

--- a/skills/mix-coding/references/animations.md
+++ b/skills/mix-coding/references/animations.md
@@ -1,281 +1,118 @@
 # Animations Reference
 
-Mix provides three animation approaches, from simple to full control:
-
-1. **Implicit** — easiest, auto-animate when state or variant changes
-2. **Phase** — multi-step flows triggered by events
-3. **Keyframe** — full timeline control with tracks
+Mix animation is configured on Stylers. Prefer style-level APIs for new app code:
+`.animate(...)`, `.keyframeAnimation(...)`, and `.phaseAnimation(...)`.
 
 ## Implicit Animations
 
-Add `.animate()` to any style — Mix auto-animates between states when variant conditions change.
-
-### Basic Implicit Animation
+Use `.animate(...)` when a style changes because of state, variants, or rebuilds.
 
 ```dart
 final style = BoxStyler()
     .color(Colors.blue)
     .size(100, 100)
-    .animate(.easeInOut(300.ms))
-    .onHovered(.color(Colors.red).size(120, 120));
-```
-
-### Animation Configs
-
-The `.animate()` method takes an `AnimationConfig`:
-
-| Config | Description |
-|--------|-------------|
-| `.easeInOut(Duration)` | Ease in and out curve |
-| `.ease(Duration)` | Standard ease curve |
-| `.linear(Duration)` | Linear interpolation |
-| `.spring(Duration)` | Spring physics |
-| `.decelerate(Duration)` | Decelerate curve |
-| `.bounceIn(Duration)` | Bounce in curve |
-| `.bounceOut(Duration)` | Bounce out curve |
-| `.elasticIn(Duration)` | Elastic in curve |
-| `.elasticOut(Duration)` | Elastic out curve |
-
-Duration uses the `.ms` extension (e.g., `300.ms`, `600.ms`).
-
-### State-Triggered Implicit Animation
-
-When state changes cause style differences, Mix interpolates automatically:
-
-```dart
-class Counter extends StatefulWidget { ... }
-
-class _CounterState extends State<Counter> {
-  int count = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    final style = BoxStyler()
-        .color(Colors.blue)
-        .size(100 + count * 20, 100 + count * 20)
-        .borderRounded(10 + count * 5)
-        .animate(.spring(600.ms));
-
-    return GestureDetector(
-      onTap: () => setState(() => count++),
-      child: Box(style: style),
-    );
-  }
-}
-```
-
-### Variant-Triggered Implicit Animation
-
-```dart
-final style = BoxStyler()
-    .color(Colors.blue)
-    .size(100, 100)
-    .borderRounded(10)
-    .animate(.easeInOut(200.ms))
+    .borderRounded(12)
+    .animate(.easeInOut(220.ms))
     .onHovered(
-      .color(Colors.deepPurple)
-          .size(120, 120)
-          .borderRounded(20),
-    );
+      .color(Colors.blue.shade700)
+          .size(112, 112),
+    )
+    .onPressed(.scale(0.96));
 ```
 
----
+Common configs from `animation_config.dart`:
 
-## Phase Animations
+| Config | Use |
+|---|---|
+| `AnimationConfig.linear(duration)` or `.linear(duration)` | constant speed |
+| `AnimationConfig.ease(duration)` or `.ease(duration)` | default ease |
+| `AnimationConfig.easeInOut(duration)` or `.easeInOut(duration)` | balanced transition |
+| `AnimationConfig.decelerate(duration)` or `.decelerate(duration)` | slow finish |
+| `AnimationConfig.bounceOut(duration)` or `.bounceOut(duration)` | playful exit |
+| `AnimationConfig.elasticOut(duration)` or `.elasticOut(duration)` | elastic movement |
+| `AnimationConfig.spring(...)` | spring physics |
 
-Multi-step animations triggered by events. Each phase runs in sequence.
+Durations can use extension getters such as `180.ms`.
 
-### Basic Phase Animation
+## Keyframe Animation
 
-```dart
-class CompressExample extends StatefulWidget { ... }
-
-class _CompressExampleState extends State<CompressExample> {
-  final controller = PhaseAnimationController();
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final style = BoxStyler()
-        .color(Colors.blue)
-        .size(100, 100)
-        .borderRounded(12);
-
-    return GestureDetector(
-      onTap: () => controller.forward(),
-      child: PhaseAnimationBuilder(
-        controller: controller,
-        phases: [
-          // Phase 1: Compress
-          PhaseConfig(
-            style.size(80, 80).borderRounded(20),
-            duration: 150.ms,
-            curve: .easeIn,
-          ),
-          // Phase 2: Expand
-          PhaseConfig(
-            style.size(120, 120),
-            duration: 300.ms,
-            curve: .bounceOut,
-          ),
-          // Phase 3: Return to original
-          PhaseConfig(
-            style,
-            duration: 200.ms,
-            curve: .easeOut,
-          ),
-        ],
-        builder: (context, phaseStyle) {
-          return Box(style: phaseStyle);
-        },
-      ),
-    );
-  }
-}
-```
-
-### PhaseConfig
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `style` | Styler | The target style for this phase |
-| `duration` | `Duration` | How long this phase takes |
-| `curve` | `Curve` | Animation curve for this phase |
-
-### PhaseAnimationController
-
-| Method | Description |
-|--------|-------------|
-| `.forward()` | Start/restart the animation sequence |
-| `.dispose()` | Clean up resources |
-
----
-
-## Keyframe Animations
-
-Full timeline control with multiple tracks animating different properties.
-
-### Basic Keyframe Animation
+Use `.keyframeAnimation(...)` for timeline values. The `styleBuilder` receives
+computed keyframe values and returns a new Styler.
 
 ```dart
-class HeartAnimation extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final baseStyle = IconStyler()
-        .icon(Icons.favorite)
-        .size(40)
-        .color(Colors.red);
+final pulseTrigger = ValueNotifier(0);
 
-    return KeyframeAnimationBuilder(
-      duration: 1200.ms,
-      repeat: true,
-      keyframes: {
-        // Scale track
-        KeyframeTrack<double>(
-          property: KeyframeProperty.iconSize,
-          keyframes: [
-            Keyframe(0.0, 40),     // Start at size 40
-            Keyframe(0.3, 56),     // Grow to 56 at 30%
-            Keyframe(0.5, 40),     // Return to 40 at 50%
-            Keyframe(0.7, 52),     // Second beat at 70%
-            Keyframe(1.0, 40),     // Return to 40
-          ],
-        ),
-        // Color track
-        KeyframeTrack<Color>(
-          property: KeyframeProperty.iconColor,
-          keyframes: [
-            Keyframe(0.0, Colors.red),
-            Keyframe(0.3, Colors.red.shade900),
-            Keyframe(0.5, Colors.red),
-            Keyframe(0.7, Colors.red.shade800),
-            Keyframe(1.0, Colors.red),
-          ],
-        ),
-      },
-      builder: (context, keyframeStyle) {
-        return StyledIcon(style: baseStyle.merge(keyframeStyle));
-      },
-    );
-  }
-}
-```
-
-### Keyframe Toggle (e.g., Switch)
-
-```dart
-KeyframeAnimationBuilder(
-  duration: 400.ms,
-  playing: isOn,          // Animate forward when true, reverse when false
-  keyframes: {
-    KeyframeTrack<double>(
-      property: KeyframeProperty.width,
-      keyframes: [
-        Keyframe(0.0, 24),
-        Keyframe(0.5, 40),   // Stretch in the middle
-        Keyframe(1.0, 24),
-      ],
-    ),
-    KeyframeTrack<double>(
-      property: KeyframeProperty.translateX,
-      keyframes: [
-        Keyframe(0.0, 0),
-        Keyframe(1.0, 20),   // Slide to the right
-      ],
-    ),
-  },
-  builder: (context, style) => Box(style: baseStyle.merge(style)),
-);
-```
-
-### Looping Animation
-
-```dart
-KeyframeAnimationBuilder(
-  duration: 2000.ms,
-  repeat: true,           // Loop forever
-  keyframes: { ... },
-  builder: (context, style) => widget,
-);
-```
-
-### KeyframeAnimationBuilder
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `duration` | `Duration` | Total animation duration |
-| `keyframes` | `Set<KeyframeTrack>` | Set of animation tracks |
-| `builder` | `(context, style) => Widget` | Build widget with animated style |
-| `repeat` | `bool` | Loop animation (default: false) |
-| `playing` | `bool?` | Control play/reverse (null = auto-play) |
-| `curve` | `Curve?` | Overall animation curve |
-
-### Widget State Animation (Simplest)
-
-For simple hover/press animations without explicit animation builders:
-
-```dart
 final style = BoxStyler()
-    .size(100, 100)
-    .color(Colors.blue)
-    .borderRounded(8)
-    .animate(.spring(300.ms))
-    .onHovered(.size(110, 110).color(Colors.blue.shade700));
+    .color(Colors.pink)
+    .size(80, 80)
+    .shapeCircle()
+    .keyframeAnimation(
+      trigger: pulseTrigger,
+      timeline: [
+        KeyframeTrack<double>(
+          'scale',
+          [
+            Keyframe.easeOut(1.12, 120.ms),
+            Keyframe.easeIn(1.0, 160.ms),
+          ],
+          initial: 1.0,
+        ),
+      ],
+      styleBuilder: (values, style) {
+        return style.scale(values.get<double>('scale'));
+      },
+    );
 ```
 
----
+If `trigger` is omitted in the underlying config, keyframe animation is treated
+as looping. Prefer explicit triggers for event-based examples.
+
+## Phase Animation
+
+Use `.phaseAnimation(...)` for named or indexed steps where each phase maps to a target style.
+
+```dart
+enum ButtonPhase { compress, expand, settle }
+
+final trigger = ValueNotifier(0);
+
+final style = BoxStyler()
+    .color(Colors.blue)
+    .size(96, 48)
+    .borderRounded(12)
+    .phaseAnimation<ButtonPhase>(
+      trigger: trigger,
+      phases: ButtonPhase.values,
+      styleBuilder: (phase, style) {
+        return switch (phase) {
+          ButtonPhase.compress => style.scale(0.94),
+          ButtonPhase.expand => style.scale(1.04),
+          ButtonPhase.settle => style.scale(1.0),
+        };
+      },
+      configBuilder: (phase) {
+        return CurveAnimationConfig(
+          duration: 120.ms,
+          curve: Curves.easeInOut,
+        );
+      },
+    );
+```
+
+## Practical Guidance
+
+- Use `.animate(...)` for hover/press/theme transitions.
+- Use `.keyframeAnimation(...)` when one or more numeric values need a timeline.
+- Use `.phaseAnimation(...)` when the animation is a sequence of named states.
+- Dispose or own any external `Listenable` such as `ValueNotifier` in the
+  surrounding stateful widget.
+- Do not use builder-class examples for new app code unless source/docs specifically require them.
 
 ## Source Files
 
-- `packages/mix_docs_preview/lib/guides/animations/implicit_state_counter.dart` — State-triggered growth
-- `packages/mix_docs_preview/lib/guides/animations/implicit_variant_hover.dart` — Hover variant animation
-- `packages/mix_docs_preview/lib/guides/animations/implicit_curved_scale.dart` — Curved scale animation
-- `packages/mix_docs_preview/lib/guides/animations/implicit_spring_translate.dart` — Spring translation animation
-- `packages/mix_docs_preview/lib/guides/animations/keyframe_switch.dart` — Toggle switch keyframes
-- `packages/mix_docs_preview/lib/guides/animations/keyframe_loop.dart` — Looping keyframe
-- `packages/mix_docs_preview/lib/guides/animations/phase_tap_compress.dart` — Phase tap animation
+- `packages/mix/lib/src/style/mixins/animation_style_mixin.dart`
+- `packages/mix/lib/src/animation/animation_config.dart`
+- `packages/mix/lib/src/core/extensions/extensions.dart`
+- `packages/mix/test/src/style/styler_mixin_conformance_test.dart`
+- `packages/mix/test/src/animation/animation_config_test.dart`
+- `packages/mix/test/src/animation/style_animation_driver_test.dart`

--- a/skills/mix-coding/references/examples.md
+++ b/skills/mix-coding/references/examples.md
@@ -1,368 +1,221 @@
 # Examples Reference
 
-Curated code examples organized by complexity. Each example is a complete, runnable snippet.
+Use these examples as source-aligned starting points. Adapt names and colors to the user's app.
 
----
-
-## Basic
-
-### Styled Box
-
-A simple colored box with rounded corners.
+## Card
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:mix/mix.dart';
 
-class SimpleBox extends StatelessWidget {
+class AccountCard extends StatelessWidget {
+  const AccountCard({super.key});
+
   @override
   Widget build(BuildContext context) {
-    final style = BoxStyler.color(Colors.red)
-        .size(100, 100)
-        .borderRounded(10);
-
-    return Box(style: style);
-  }
-}
-```
-
-**Concepts:** BoxStyler, fluent chaining, factory constructor
-**Source:** `packages/mix_docs_preview/lib/widgets/box/simple_box.dart`
-
-### Gradient Box with Shadow
-
-```dart
-final style = BoxStyler.height(50)
-    .width(100)
-    .borderRounded(10)
-    .linearGradient(
-      colors: [Colors.deepPurple.shade700, Colors.deepPurple.shade200],
-      begin: .topLeft,
-      end: .bottomRight,
-    )
-    .shadowOnly(
-      color: Colors.deepPurple.shade700,
-      offset: Offset(0, 4),
-      blurRadius: 10,
-    );
-
-Box(style: style);
-```
-
-**Concepts:** Gradients, shadows, dot-shorthands
-**Source:** `packages/mix_docs_preview/lib/widgets/box/gradient_box.dart`
-
-### Styled Text
-
-```dart
-final style = TextStyler()
-    .fontSize(20)
-    .fontWeight(.w700)
-    .color(Colors.red)
-    .titlecase();
-
-StyledText('hello world', style: style);
-```
-
-**Concepts:** TextStyler, text directives, typography
-**Source:** `packages/mix_docs_preview/lib/widgets/text/styled_text.dart`
-
-### Styled Icon
-
-```dart
-final style = IconStyler.size(30).color(Colors.blueAccent);
-StyledIcon(icon: Icons.format_paint_rounded, style: style);
-```
-
-**Concepts:** IconStyler, factory constructor
-**Source:** `packages/mix_docs_preview/lib/widgets/icon/styled_icon.dart`
-
----
-
-## Intermediate
-
-### Interactive Hover Box
-
-A box that changes color on hover:
-
-```dart
-class HoverBox extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final style = BoxStyler()
-        .color(Colors.red)
-        .size(100, 100)
-        .borderRounded(10)
-        .onHovered(.color(Colors.blue));
-
-    return style();  // Callable shorthand
-  }
-}
-```
-
-**Concepts:** Variants, onHovered, callable styler
-**Source:** `packages/mix_docs_preview/lib/guides/dynamic_styling/hovered.dart`
-
-### Pressable Button
-
-```dart
-class PressableButton extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final boxStyle = BoxStyler()
-        .color(Colors.blue)
-        .paddingX(24)
-        .paddingY(12)
-        .borderRounded(8)
-        .onHovered(.color(Colors.blue.shade700))
-        .onPressed(.color(Colors.blue.shade900));
-
-    final textStyle = TextStyler()
+    final cardStyle = BoxStyler()
         .color(Colors.white)
-        .fontSize(16)
-        .fontWeight(.bold);
-
-    return PressableBox(
-      style: boxStyle,
-      onPress: () => print('pressed'),
-      child: StyledText('Click Me', style: textStyle),
-    );
-  }
-}
-```
-
-**Concepts:** PressableBox, multiple stylers, hover + press variants
-
-### Dark/Light Mode Toggle
-
-```dart
-class ThemeToggle extends StatefulWidget { ... }
-
-class _ThemeToggleState extends State<ThemeToggle> {
-  bool isDark = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final buttonStyle = BoxStyler()
-        .height(60)
-        .width(60)
-        .borderRounded(30)
-        .color(Colors.grey.shade200)
-        .animate(.easeInOut(600.ms))
-        .onDark(.color(Colors.grey.shade800))
-        .shadowOnly(
-          color: Colors.black.withValues(alpha: 0.1),
-          offset: Offset(0, 4),
-          blurRadius: 10,
+        .paddingAll(16)
+        .borderRounded(12)
+        .shadow(
+          .color(Colors.black.withValues(alpha: 0.12))
+              .offset(y: 4)
+              .blurRadius(12),
         );
 
-    final iconStyle = IconStyler()
-        .color(Colors.grey.shade800)
-        .size(28)
-        .icon(Icons.dark_mode)
-        .animate(.easeInOut(200.ms))
-        .onDark(.icon(Icons.light_mode).color(Colors.yellow));
+    final titleStyle = TextStyler()
+        .fontSize(18)
+        .fontWeight(.bold)
+        .color(Colors.black);
 
-    return MediaQuery(
-      data: MediaQuery.of(context).copyWith(
-        platformBrightness: isDark ? .dark : .light,
-      ),
-      child: PressableBox(
-        style: buttonStyle,
-        onPress: () => setState(() => isDark = !isDark),
-        child: StyledIcon(style: iconStyle),
+    final subtitleStyle = TextStyler()
+        .fontSize(13)
+        .color(Colors.grey.shade700);
+
+    return Box(
+      style: cardStyle,
+      child: ColumnBox(
+        style: FlexBoxStyler().spacing(4),
+        children: [
+          StyledText('Checking', style: titleStyle),
+          StyledText('Updated today', style: subtitleStyle),
+        ],
       ),
     );
   }
 }
 ```
 
-**Concepts:** Dark/light variants, animate, PressableBox, IconStyler
-**Source:** `packages/mix_docs_preview/lib/guides/dynamic_styling/on_dark_light.dart`
+Concepts: `Box`, `ColumnBox`, `BoxStyler`, `TextStyler`, shadows, spacing.
 
-### Horizontal Chip Layout
+Source anchors:
+- `packages/mix/lib/src/specs/box/box_style.dart`
+- `packages/mix/lib/src/specs/flexbox/flexbox_widget.dart`
+- `packages/mix/lib/src/specs/text/text_widget.dart`
+
+## Pressable Button
 
 ```dart
-final chipStyle = BoxStyler()
-    .shapeStadium(side: .new().color(Colors.blue.shade200))
-    .color(Colors.blue.shade50)
-    .padding(.horizontal(12).vertical(6));
+final buttonStyle = BoxStyler()
+    .color(Colors.blue)
+    .paddingX(20)
+    .paddingY(12)
+    .borderRounded(8)
+    .animate(.easeInOut(180.ms))
+    .onHovered(.color(Colors.blue.shade700))
+    .onPressed(.color(Colors.blue.shade900))
+    .onFocused(.borderAll(color: Colors.white, width: 2))
+    .onDisabled(.color(Colors.grey));
 
-final iconStyle = IconStyler.size(16).color(Colors.blue);
-final labelStyle = TextStyler.fontSize(14).color(Colors.blue);
+final labelStyle = TextStyler()
+    .color(Colors.white)
+    .fontWeight(.bold);
 
-RowBox(
-  style: FlexBoxStyler().spacing(8).crossAxisAlignment(.center),
+PressableBox(
+  style: buttonStyle,
+  enabled: isEnabled,
+  onPress: onPress,
+  child: StyledText('Save', style: labelStyle),
+);
+```
+
+Concepts: `PressableBox`, widget state variants, animation.
+
+Source anchors:
+- `packages/mix/lib/src/specs/pressable/pressable_widget.dart`
+- `packages/mix/lib/src/style/mixins/widget_state_variant_mixin.dart`
+- `packages/mix/test/src/core/style_builder_hover_test.dart`
+
+## Responsive Layout
+
+```dart
+final shellStyle = FlexBoxStyler()
+    .direction(.vertical)
+    .spacing(16)
+    .paddingAll(16)
+    .onDesktop(
+      .direction(.horizontal)
+          .spacing(24)
+          .paddingAll(24),
+    );
+
+FlexBox(
+  style: shellStyle,
   children: [
-    StyledIcon(icon: Icons.check, style: iconStyle),
-    StyledText('Complete', style: labelStyle),
+    Box(style: sidebarStyle, child: sidebar),
+    Box(style: contentStyle, child: content),
   ],
 );
 ```
 
-**Concepts:** RowBox, FlexBoxStyler, shapeStadium, multiple stylers
+Concepts: `FlexBox`, breakpoint variants, direction changes.
 
----
+Source anchors:
+- `packages/mix/lib/src/specs/flexbox/flexbox_style.dart`
+- `packages/mix/lib/src/style/mixins/variant_style_mixin.dart`
 
-## Advanced
-
-### Animated Toggle with Keyframes
-
-```dart
-class AnimatedToggle extends StatefulWidget { ... }
-
-class _AnimatedToggleState extends State<AnimatedToggle> {
-  bool isOn = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final trackStyle = BoxStyler()
-        .width(56)
-        .height(32)
-        .shapeStadium()
-        .color(isOn ? Colors.green : Colors.grey.shade300);
-
-    final thumbStyle = BoxStyler()
-        .size(24, 24)
-        .shapeCircle()
-        .color(Colors.white)
-        .shadowOnly(blurRadius: 4, color: Colors.black26);
-
-    return GestureDetector(
-      onTap: () => setState(() => isOn = !isOn),
-      child: Box(
-        style: trackStyle,
-        child: KeyframeAnimationBuilder(
-          duration: 400.ms,
-          playing: isOn,
-          keyframes: {
-            KeyframeTrack<double>(
-              property: KeyframeProperty.width,
-              keyframes: [
-                Keyframe(0.0, 24),
-                Keyframe(0.5, 32),  // Stretch
-                Keyframe(1.0, 24),
-              ],
-            ),
-            KeyframeTrack<double>(
-              property: KeyframeProperty.translateX,
-              keyframes: [
-                Keyframe(0.0, 0),
-                Keyframe(1.0, 24),  // Slide right
-              ],
-            ),
-          },
-          builder: (context, animStyle) {
-            return Box(style: thumbStyle.merge(animStyle));
-          },
-        ),
-      ),
-    );
-  }
-}
-```
-
-**Concepts:** KeyframeAnimationBuilder, multiple tracks, playing toggle
-**Source:** `packages/mix_docs_preview/lib/guides/animations/keyframe_switch.dart`
-
-### Themed Profile Page with Tokens
+## Tokenized Theme
 
 ```dart
-// tokens.dart
-final $primary = ColorToken('primary');
-final $surface = ColorToken('surface');
-final $onSurface = ColorToken('on.surface');
-final $heading = TextStyleToken('heading');
-final $body = TextStyleToken('body');
-final $radiusMd = RadiusToken('radius.md');
+final $primary = ColorToken('color.primary');
+final $surface = ColorToken('color.surface');
+final $onSurface = ColorToken('color.on_surface');
 final $spaceMd = SpaceToken('space.md');
+final $heading = TextStyleToken('text.heading');
 
-// theme.dart
-final lightTheme = MixScopeConfig(
+MixScope(
   colors: {
     $primary: Colors.blue,
     $surface: Colors.white,
     $onSurface: Colors.black,
   },
-  textStyles: {
-    $heading: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
-    $body: TextStyle(fontSize: 16),
+  spaces: {
+    $spaceMd: 16,
   },
-  radii: {$radiusMd: Radius.circular(12)},
-  spaces: {$spaceMd: 16.0},
+  textStyles: {
+    $heading: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+  },
+  child: Builder(
+    builder: (context) {
+      final cardStyle = BoxStyler()
+          .color($surface())
+          .paddingAll($spaceMd());
+
+      final titleStyle = TextStyler()
+          .style($heading.mix())
+          .color($onSurface());
+
+      return Box(
+        style: cardStyle,
+        child: StyledText('Dashboard', style: titleStyle),
+      );
+    },
+  ),
 );
-
-// profile_page.dart
-class ProfilePage extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final cardStyle = BoxStyler()
-        .color($surface())
-        .paddingAll($spaceMd())
-        .borderRadiusAll($radiusMd());
-
-    final titleStyle = TextStyler()
-        .style($heading.mix())
-        .color($onSurface());
-
-    final bodyStyle = TextStyler()
-        .style($body.mix())
-        .color($onSurface());
-
-    return ColumnBox(
-      style: FlexBoxStyler().spacing($spaceMd()).marginAll($spaceMd()),
-      children: [
-        Box(
-          style: cardStyle,
-          child: Column(
-            crossAxisAlignment: .start,
-            children: [
-              StyledText('Profile', style: titleStyle),
-              StyledText('Welcome back!', style: bodyStyle),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-}
 ```
 
-**Concepts:** Design tokens, MixScope, TextStyleToken, theme separation
-**Source:** `packages/mix_docs_preview/lib/tutorials/theming/preview.dart`
+Concepts: `MixScope`, typed token maps, token call refs, `TextStyleToken.mix()`.
 
-### Custom Context Variant
+Source anchors:
+- `packages/mix/lib/src/theme/mix_theme.dart`
+- `packages/mix/lib/src/theme/tokens/value_tokens.dart`
+- `packages/mix/doc/mix-scope-and-theming.md`
+
+## Keyframe Animation
 
 ```dart
-// Define variant based on InheritedWidget
-class ShiftPressedVariant extends ContextVariant {
-  ShiftPressedVariant()
-    : super('shift_pressed', (context) {
-        return ShiftPressedWidget.of(context)?.isShiftPressed ?? false;
-      });
-}
+final trigger = ValueNotifier(0);
 
-// Use in style
-final style = BoxStyler()
-    .color(Colors.grey)
-    .paddingAll(8)
-    .shapeStadium()
-    .variant(ShiftPressedVariant(), .color(Colors.purple))
-    .animate(.ease(300.ms));
+final pulseStyle = BoxStyler()
+    .color(Colors.pink)
+    .size(80, 80)
+    .shapeCircle()
+    .keyframeAnimation(
+      trigger: trigger,
+      timeline: [
+        KeyframeTrack<double>(
+          'scale',
+          [
+            Keyframe.easeOut(1.12, 120.ms),
+            Keyframe.easeIn(1.0, 160.ms),
+          ],
+          initial: 1.0,
+        ),
+      ],
+      styleBuilder: (values, style) {
+        return style.scale(values.get<double>('scale'));
+      },
+    );
+
+Box(style: pulseStyle);
 ```
 
-**Concepts:** Custom ContextVariant, InheritedWidget integration, animate
-**Source:** `packages/mix_docs_preview/lib/guides/dynamic_styling/context_variant_flag.dart`
+Concepts: `.keyframeAnimation(...)`, `KeyframeTrack`, `Keyframe`, `ValueNotifier`.
 
----
+Source anchors:
+- `packages/mix/lib/src/style/mixins/animation_style_mixin.dart`
+- `packages/mix/test/src/style/styler_mixin_conformance_test.dart`
 
-## Full Example Index
+## Modernizing Stale Mix Code
 
-For more examples, browse these directories:
-- `packages/mix_docs_preview/lib/widgets/box/` — Box styling patterns
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/` — All variant types
-- `packages/mix_docs_preview/lib/guides/animations/` — All animation types
-- `packages/mix_docs_preview/lib/guides/gradients/` — Gradient examples
-- `packages/mix_docs_preview/lib/guides/` — Documentation guide examples
-- `packages/mix_docs_preview/lib/tutorials/` — Step-by-step tutorials
-- `packages/mix_docs_preview/lib/widgets/` — Widget-specific examples
+When a prompt contains old names, rewrite to current names before explaining.
+
+```dart
+final $spaceMd = SpaceToken('space.md');
+
+// Stale idea: horizontal layout alias and old theme config.
+// Current app-level shape:
+MixScope(
+  tokens: {
+    $spaceMd: 16.0,
+  },
+  child: RowBox(
+    style: FlexBoxStyler().spacing($spaceMd()),
+    children: children,
+  ),
+);
+```
+
+Source anchors:
+- `packages/mix/lib/src/specs/flexbox/flexbox_widget.dart`
+- `packages/mix/lib/src/theme/mix_theme.dart`

--- a/skills/mix-coding/references/styling.md
+++ b/skills/mix-coding/references/styling.md
@@ -1,269 +1,203 @@
 # Styling Reference
 
-## Patterns
+Use Stylers to describe visual intent, then pass them to Mix widgets. Keep app
+code on `BoxStyler`, `TextStyler`, `IconStyler`, `ImageStyler`,
+`FlexBoxStyler`, and `StackBoxStyler`; do not construct Specs directly.
 
-### Creating a Style
-
-```dart
-// Start from constructor
-final style = BoxStyler()
-    .color(Colors.blue)
-    .size(100, 100)
-    .borderRounded(12);
-
-// Start from factory (equivalent)
-final style = BoxStyler.color(Colors.blue)
-    .size(100, 100)
-    .borderRounded(12);
-```
-
-### Composing Styles
-
-Build new styles on top of existing ones. Later values override earlier ones:
+## Basic Box Styling
 
 ```dart
-final base = BoxStyler()
-    .paddingX(16)
-    .paddingY(8)
-    .borderRounded(8)
-    .color(Colors.black);
-
-final solid = base.color(Colors.blue);        // Override color only
-final soft = base.color(Colors.blue.shade100); // Different override
-```
-
-### Merging Styles
-
-Use `.merge()` to combine two stylers:
-
-```dart
-final layout = BoxStyler().paddingAll(16).size(200, 200);
-final visual = BoxStyler().color(Colors.blue).borderRounded(12);
-final combined = layout.merge(visual);
-```
-
-### Applying to Widgets
-
-```dart
-// Explicit style parameter
-Box(style: style, child: child);
-
-// Callable shorthand
-final box = BoxStyler().color(Colors.blue).size(100, 100);
-box(child: child);  // Creates a Box widget
-```
-
-### Widget Modifiers (wrap)
-
-Add widget-level behavior without nesting widgets:
-
-```dart
-final style = BoxStyler()
-    .color(Colors.blue)
-    .wrap(
-      .new().defaultTextStyle(
-        style: TextStyleMix().color(Colors.white).fontWeight(.bold),
-      ),
+final cardStyle = BoxStyler()
+    .color(Colors.white)
+    .paddingAll(16)
+    .borderRounded(12)
+    .shadow(
+      .color(Colors.black.withValues(alpha: 0.12))
+          .offset(y: 4)
+          .blurRadius(12),
     );
+
+Box(style: cardStyle, child: child);
 ```
 
----
-
-## BoxStyler API
-
-### Color & Background
-
-| Method | Description |
-|--------|-------------|
-| `.color(Color)` | Background color |
-| `.linearGradient({colors, begin, end, stops, tileMode})` | Linear gradient background |
-| `.radialGradient({center, radius, colors, stops, tileMode})` | Radial gradient background |
-| `.sweepGradient({center, startAngle, endAngle, colors, stops, tileMode})` | Sweep gradient background |
-| `.backgroundImage(ImageProvider, {fit, alignment, repeat})` | Background image |
-| `.backgroundImageUrl(String, {fit, alignment, repeat})` | Background image from URL |
-| `.backgroundImageAsset(String, {fit, alignment, repeat})` | Background image from asset |
-
-### Sizing & Constraints
-
-| Method | Description |
-|--------|-------------|
-| `.width(double)` | Fixed width |
-| `.height(double)` | Fixed height |
-| `.size(double w, double h)` | Fixed width and height |
-| `.minWidth(double)` | Minimum width |
-| `.maxWidth(double)` | Maximum width |
-| `.minHeight(double)` | Minimum height |
-| `.maxHeight(double)` | Maximum height |
-
-### Spacing
-
-| Method | Description |
-|--------|-------------|
-| `.paddingAll(double)` | Padding on all sides |
-| `.paddingX(double)` | Horizontal padding (left + right) |
-| `.paddingY(double)` | Vertical padding (top + bottom) |
-| `.paddingTop(double)` | Top padding |
-| `.paddingBottom(double)` | Bottom padding |
-| `.paddingLeft(double)` | Left padding |
-| `.paddingRight(double)` | Right padding |
-| `.paddingStart(double)` | Start padding (RTL-aware) |
-| `.paddingEnd(double)` | End padding (RTL-aware) |
-| `.paddingOnly({top, bottom, left, right})` | Individual padding |
-| `.marginAll(double)` | Margin on all sides |
-| `.marginX(double)` | Horizontal margin |
-| `.marginY(double)` | Vertical margin |
-| `.marginTop(double)` / `.marginBottom(double)` / `.marginLeft(double)` / `.marginRight(double)` | Directional margin |
-| `.marginStart(double)` / `.marginEnd(double)` | RTL-aware margin |
-
-### Border
-
-| Method | Description |
-|--------|-------------|
-| `.borderAll({color, width, style, strokeAlign})` | Border on all sides |
-| `.borderTop({color, width, style, strokeAlign})` | Top border |
-| `.borderBottom({color, width, style, strokeAlign})` | Bottom border |
-| `.borderLeft({color, width, style, strokeAlign})` | Left border |
-| `.borderRight({color, width, style, strokeAlign})` | Right border |
-| `.borderStart({color, width, style, strokeAlign})` | Start border (RTL-aware) |
-| `.borderEnd({color, width, style, strokeAlign})` | End border (RTL-aware) |
-| `.borderVertical({color, width, style, strokeAlign})` | Top + bottom borders |
-| `.borderHorizontal({color, width, style, strokeAlign})` | Left + right borders |
-
-### Border Radius
-
-| Method | Description |
-|--------|-------------|
-| `.borderRounded(double)` | Uniform circular radius |
-| `.borderRadiusAll(Radius)` | Uniform custom radius |
-| `.borderRoundedTop(double)` | Top corners |
-| `.borderRoundedBottom(double)` | Bottom corners |
-| `.borderRoundedLeft(double)` | Left corners |
-| `.borderRoundedRight(double)` | Right corners |
-| `.borderRoundedTopLeft(double)` / `.borderRoundedTopRight(double)` | Individual corners |
-| `.borderRoundedBottomLeft(double)` / `.borderRoundedBottomRight(double)` | Individual corners |
-
-### Shadows
-
-| Method | Description |
-|--------|-------------|
-| `.shadowOnly({color, offset, blurRadius, spreadRadius})` | Single box shadow |
-| `.elevation(ElevationShadow)` | Material elevation shadow |
-
-### Shape
-
-| Method | Description |
-|--------|-------------|
-| `.shapeCircle({side})` | Circular shape |
-| `.shapeStadium({side})` | Stadium/pill shape |
-| `.shapeRoundedRectangle({side, borderRadius})` | Rounded rectangle |
-| `.shapeBeveledRectangle({side, borderRadius})` | Beveled rectangle |
-| `.shapeSuperellipse({side, borderRadius})` | Superellipse shape |
-
-### Layout
-
-| Method | Description |
-|--------|-------------|
-| `.alignment(AlignmentGeometry)` | Child alignment |
-| `.clipBehavior(Clip)` | Clip behavior |
-
-### Transform
-
-| Method | Description |
-|--------|-------------|
-| `.rotate(double angle, {alignment})` | Rotation |
-| `.scale(double, {alignment})` | Scale |
-| `.translate(double x, double y)` | Translation |
-| `.skew(double skewX, double skewY)` | Skew |
-
----
-
-## TextStyler API
-
-### Typography
-
-| Method | Description |
-|--------|-------------|
-| `.fontSize(double)` | Font size |
-| `.fontWeight(FontWeight)` | Font weight (e.g., `.bold`, `.w700`) |
-| `.fontStyle(FontStyle)` | Italic/normal |
-| `.fontFamily(String)` | Font family |
-| `.letterSpacing(double)` | Letter spacing |
-| `.wordSpacing(double)` | Word spacing |
-| `.height(double)` | Line height multiplier |
-| `.color(Color)` | Text color |
-| `.backgroundColor(Color)` | Text background color |
-
-### Text Layout
-
-| Method | Description |
-|--------|-------------|
-| `.textAlign(TextAlign)` | Alignment (`.center`, `.left`, `.right`) |
-| `.maxLines(int)` | Maximum line count |
-| `.overflow(TextOverflow)` | Overflow behavior |
-| `.softWrap(bool)` | Enable/disable soft wrapping |
-
-### Text Decoration
-
-| Method | Description |
-|--------|-------------|
-| `.decoration(TextDecoration)` | Underline, strikethrough, etc. |
-| `.decorationColor(Color)` | Decoration color |
-| `.decorationStyle(TextDecorationStyle)` | Decoration style |
-
-### Text Directives (transforms)
-
-| Method | Description |
-|--------|-------------|
-| `.uppercase()` | ALL CAPS |
-| `.lowercase()` | all lowercase |
-| `.capitalize()` | First letter uppercase |
-| `.titlecase()` | Title Case |
-| `.sentencecase()` | Sentence case |
-
-### Using TextStyler
+Factory constructors are available for many first properties:
 
 ```dart
-final style = TextStyler()
-    .fontSize(20)
-    .fontWeight(.w700)
-    .color(Colors.red)
-    .titlecase();
-
-StyledText('hello world', style: style);
-// Or shorthand:
-style('hello world');
+final badgeStyle = BoxStyler.color(Colors.green)
+    .paddingX(10)
+    .paddingY(4)
+    .shapeStadium();
 ```
 
----
+## Composition
 
-## IconStyler API
-
-| Method | Description |
-|--------|-------------|
-| `.icon(IconData)` | Icon data |
-| `.size(double)` | Icon size |
-| `.color(Color)` | Icon color |
-| `.weight(double)` | Icon weight |
-| `.fill(double)` | Icon fill |
-| `.opacity(double)` | Icon opacity |
-| `.shadows(List<ShadowMix>)` | Icon shadows |
-
-### Using IconStyler
+Stylers are immutable. Chain methods or merge smaller Stylers.
 
 ```dart
-final style = IconStyler.size(30).color(Colors.blueAccent);
-StyledIcon(icon: Icons.star, style: style);
-// Or shorthand:
-style(icon: Icons.star);
+final baseCard = BoxStyler()
+    .paddingAll(16)
+    .borderRounded(12);
+
+final elevated = BoxStyler().shadow(
+  .color(Colors.black26).offset(y: 6).blurRadius(16),
+);
+
+final selectedCard = baseCard
+    .merge(elevated)
+    .color(Colors.blue.shade50);
 ```
 
----
+Use variant styles to override only what changes:
+
+```dart
+final buttonStyle = BoxStyler()
+    .color(Colors.blue)
+    .paddingX(20)
+    .paddingY(12)
+    .borderRounded(8)
+    .onHovered(.color(Colors.blue.shade700));
+```
+
+## BoxStyler Surface
+
+Common methods from `packages/mix/lib/src/specs/box/box_style.dart` and mixins:
+
+- Color and decoration: `.color(...)`, `.gradient(...)`, `.linearGradient(...)`,
+  `.radialGradient(...)`, `.sweepGradient(...)`, `.image(...)`,
+  `.backgroundImage(...)`, `.backgroundImageUrl(...)`,
+  `.backgroundImageAsset(...)`
+- Spacing: `.paddingAll(...)`, `.paddingX(...)`, `.paddingY(...)`,
+  `.paddingOnly(...)`, `.marginAll(...)`, `.marginX(...)`, `.marginY(...)`,
+  `.marginOnly(...)`
+- Constraints: `.width(...)`, `.height(...)`, `.size(width, height)`,
+  `.minWidth(...)`, `.maxWidth(...)`, `.minHeight(...)`, `.maxHeight(...)`
+- Border: `.border(...)`, `.borderAll(...)`, `.borderTop(...)`,
+  `.borderBottom(...)`, `.borderLeft(...)`, `.borderRight(...)`,
+  `.borderHorizontal(...)`, `.borderVertical(...)`
+- Radius: `.borderRadius(...)`, `.borderRounded(...)`,
+  `.borderRoundedTop(...)`, `.borderRoundedBottom(...)`,
+  `.borderRoundedLeft(...)`, `.borderRoundedRight(...)`
+- Shadows: `.shadow(.color(...).blurRadius(...))`, `.shadow(BoxShadowMix(...))`,
+  `.shadows([...])`, `.boxShadows([...])`, `.shadowOnly(...)`,
+  `.elevation(...)`, `.boxElevation(...)`
+- Shape: `.shape(...)`, `.shapeCircle(...)`, `.shapeStadium(...)`,
+  `.shapeRoundedRectangle(...)`, `.shapeSuperellipse(...)`
+- Transform: `.scale(value)`, `.rotate(radians)`, `.translate(x, y, [z])`,
+  `.skew(x, y)`
+- Layout/modifiers: `.alignment(...)`, `.clipBehavior(...)`, `.wrap(...)`,
+  `.modifier(...)`
+
+For generated examples, prefer typed dot shorthand for one-off shadows:
+`.shadow(.color(...).offset(y: ...).blurRadius(...))`. Use `.shadowOnly(...)`
+only when explicitly showing the named-argument convenience fallback. Never call
+`.shadow(color: ...)`; `.shadow(...)` takes a `BoxShadowMix`.
+
+For simple named borders, use helpers such as
+`.borderAll(color: ..., width: ...)`, `.borderTop(...)`, or `.borderBottom(...)`.
+Never call `.border(color: ...)`; `.border(...)` takes a `BoxBorderMix`.
+
+Transform helpers use positional arguments from `transform_style_mixin.dart`;
+for a hover lift use `.translate(0, -1)`, not `.translate(y: -1)` or
+`.translateY(...)`.
+
+```dart
+final style = BoxStyler()
+    .shadow(.color(Colors.black26).offset(y: 4).blurRadius(8))
+    .boxShadows([
+      BoxShadowMix.color(Colors.black12).offset(y: 6).blurRadius(12),
+    ]);
+```
+
+## TextStyler
+
+`TextStyler` styles `StyledText`.
+
+```dart
+final titleStyle = TextStyler()
+    .fontSize(22)
+    .fontWeight(.bold)
+    .color(Colors.black)
+    .letterSpacing(0.2);
+
+StyledText('Revenue', style: titleStyle);
+```
+
+Common methods:
+
+- Typography: `.fontSize(...)`, `.fontWeight(...)`, `.fontStyle(...)`,
+  `.fontFamily(...)`, `.fontFamilyFallback(...)`, `.letterSpacing(...)`,
+  `.wordSpacing(...)`, `.height(...)`
+- Color: `.color(...)`, `.backgroundColor(...)`, `.selectionColor(...)`
+- Layout: `.textAlign(...)`, `.maxLines(...)`, `.overflow(...)`,
+  `.softWrap(...)`, `.textDirection(...)`
+- Decoration: `.decoration(...)`, `.decorationColor(...)`,
+  `.decorationStyle(...)`, `.decorationThickness(...)`
+- Text transforms: `.uppercase()`, `.lowercase()`, `.capitalize()`,
+  `.titlecase()`, `.sentencecase()`
+- Shadows: `.shadow(...)`, `.shadows(...)`
+
+Callable shorthand:
+
+```dart
+final label = TextStyler.fontSize(14).color(Colors.grey.shade700);
+
+label('Updated today');
+```
+
+## IconStyler
+
+```dart
+final iconStyle = IconStyler()
+    .icon(Icons.check_circle)
+    .size(20)
+    .color(Colors.green);
+
+StyledIcon(style: iconStyle);
+```
+
+Common methods:
+`.icon(...)`, `.size(...)`, `.color(...)`, `.weight(...)`, `.grade(...)`,
+`.opticalSize(...)`, `.fill(...)`, `.opacity(...)`, `.shadow(...)`,
+`.shadows(...)`.
+
+## ImageStyler
+
+```dart
+final imageStyle = ImageStyler()
+    .width(96)
+    .height(96)
+    .fit(BoxFit.cover)
+    .alignment(.center);
+
+StyledImage(
+  image: const NetworkImage('https://example.com/avatar.png'),
+  style: imageStyle,
+);
+```
+
+Common methods:
+`.image(...)`, `.width(...)`, `.height(...)`, `.color(...)`, `.fit(...)`,
+`.alignment(...)`, `.repeat(...)`, `.filterQuality(...)`,
+`.colorBlendMode(...)`.
+
+## Widget Modifiers
+
+Prefer Mix style methods to extra Flutter wrapper widgets when Mix provides the
+behavior. Use `.wrap(...)` or `.modifier(...)` for widget-level behavior.
+
+```dart
+final style = BoxStyler()
+    .color(Colors.blue)
+    .wrap(.new().opacity(0.92));
+```
 
 ## Source Files
 
-For real implementations, read these example files:
-- `packages/mix_docs_preview/lib/widgets/box/simple_box.dart` — Basic styled box
-- `packages/mix_docs_preview/lib/widgets/box/gradient_box.dart` — Gradient + shadow
-- `packages/mix_docs_preview/lib/widgets/text/styled_text.dart` — Styled text with directives
-- `packages/mix_docs_preview/lib/widgets/icon/styled_icon.dart` — Styled icon
-- `packages/mix_docs_preview/lib/guides/styling/styling_basic.dart` — Styling guide examples
+- `packages/mix/lib/src/specs/box/box_style.dart`
+- `packages/mix/lib/src/specs/text/text_style.dart`
+- `packages/mix/lib/src/specs/icon/icon_style.dart`
+- `packages/mix/lib/src/specs/image/image_style.dart`
+- `packages/mix/lib/src/style/mixins/spacing_style_mixin.dart`
+- `packages/mix/lib/src/style/mixins/decoration_style_mixin.dart`
+- `packages/mix/lib/src/style/mixins/shadow_style_mixin.dart`
+- `packages/mix/lib/src/style/mixins/text_style_mixin.dart`

--- a/skills/mix-coding/references/tokens.md
+++ b/skills/mix-coding/references/tokens.md
@@ -1,220 +1,150 @@
-# Design Tokens Reference
+# Tokens and Theming Reference
 
-Design tokens centralize visual properties (colors, spacing, typography) so styles reference semantic names instead of hardcoded values. Swap token values to switch themes.
+Use Mix tokens for semantic values that should change by theme, brand,
+platform, or scope. Tokens are provided by `MixScope` and consumed through
+Stylers.
 
-## Patterns
-
-### Define Tokens
+## Define Tokens
 
 ```dart
-import 'package:mix/mix.dart';
-
-// Color tokens
-final $primary = ColorToken('primary');
-final $surface = ColorToken('surface');
-final $onPrimary = ColorToken('on.primary');
-final $onSurface = ColorToken('on.surface');
-
-// Spacing tokens
-final $spaceSm = SpaceToken('space.sm');
+final $primary = ColorToken('color.primary');
+final $surface = ColorToken('color.surface');
+final $onSurface = ColorToken('color.on_surface');
 final $spaceMd = SpaceToken('space.md');
-final $spaceLg = SpaceToken('space.lg');
-
-// Radius tokens
-final $radiusSm = RadiusToken('radius.sm');
 final $radiusMd = RadiusToken('radius.md');
+final $heading = TextStyleToken('text.heading');
 ```
 
-### Provide Token Values with MixScope
+Use stable semantic names rather than raw visual names when possible.
 
-`MixScope` provides token values to all descendant widgets, similar to Flutter's `Theme`:
+## Provide Tokens with MixScope
 
 ```dart
 MixScope(
   colors: {
     $primary: Colors.blue,
     $surface: Colors.white,
-    $onPrimary: Colors.white,
     $onSurface: Colors.black,
   },
   spaces: {
-    $spaceSm: 8.0,
-    $spaceMd: 16.0,
-    $spaceLg: 24.0,
+    $spaceMd: 16,
   },
   radii: {
-    $radiusSm: Radius.circular(4),
-    $radiusMd: Radius.circular(8),
+    $radiusMd: const Radius.circular(12),
   },
-  child: MyApp(),
+  textStyles: {
+    $heading: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+  },
+  child: child,
 );
 ```
 
-### Use Tokens in Styles
-
-Use the call syntax `$token()` to reference a token in a style:
+You can also use the generic `tokens:` map:
 
 ```dart
-final style = BoxStyler()
-    .color($primary())
+MixScope(
+  tokens: {
+    $primary: Colors.blue,
+    $spaceMd: 16.0,
+  },
+  child: child,
+);
+```
+
+## Use Tokens in Styles
+
+Call the token to create a style reference.
+
+```dart
+final cardStyle = BoxStyler()
+    .color($surface())
     .paddingAll($spaceMd())
     .borderRadiusAll($radiusMd());
+
+final titleStyle = TextStyler()
+    .style($heading.mix())
+    .color($onSurface());
 ```
 
-### Use Token Mix Reference
-
-For `TextStyleToken`, use `.mix()` to get a `TextStyleMix`:
+Resolve tokens only when you need concrete Flutter values outside a Mix style:
 
 ```dart
-final $heading = TextStyleToken('heading');
-
-// Provide the value
-MixScope(
-  textStyles: {
-    $heading: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-  },
-  child: app,
-);
-
-// Use in a style
-final style = TextStyler.style($heading.mix()).color($onSurface());
+final primaryColor = $primary.resolve(context);
 ```
-
-### Resolve Tokens Programmatically
-
-Use `.resolve(context)` to get the concrete value outside of styles:
-
-```dart
-@override
-Widget build(BuildContext context) {
-  final primaryColor = $primary.resolve(context);
-  final spacing = $spaceMd.resolve(context);
-  // Use with Flutter widgets if needed
-}
-```
-
----
-
-## Theme Switching
-
-Define separate token maps and swap them:
-
-```dart
-final lightColors = {
-  $primary: Colors.blue,
-  $surface: Colors.white,
-  $onSurface: Colors.black,
-};
-
-final darkColors = {
-  $primary: Color(0xFF617AFA),
-  $surface: Color(0xFF1C1C21),
-  $onSurface: Colors.white,
-};
-
-class ThemedApp extends StatefulWidget { ... }
-
-class _ThemedAppState extends State<ThemedApp> {
-  bool isDark = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return MixScope(
-      colors: isDark ? darkColors : lightColors,
-      child: MaterialApp(home: MyPage()),
-    );
-  }
-}
-```
-
-### Enum-Based Tokens
-
-For organized token management, use enums:
-
-```dart
-enum AppColor {
-  primary('primary'),
-  onPrimary('on-primary'),
-  surface('surface'),
-  onSurface('on-surface');
-
-  final String name;
-  const AppColor(this.name);
-  ColorToken get token => ColorToken(name);
-}
-
-// Usage
-final style = BoxStyler().color(AppColor.primary.token());
-```
-
-### Theme Classes
-
-Group token maps into theme classes:
-
-```dart
-class LightTheme {
-  static Map<ColorToken, Color> get colors => {
-    AppColor.primary.token: Colors.blue,
-    AppColor.surface.token: Colors.white,
-  };
-
-  static Map<SpaceToken, double> get spaces => {
-    $spaceMd: 16.0,
-    $spaceLg: 24.0,
-  };
-}
-
-// Apply
-MixScope(
-  colors: LightTheme.colors,
-  spaces: LightTheme.spaces,
-  child: app,
-);
-```
-
----
 
 ## Built-in Token Types
 
-| Token Class | Value Type | Use Case |
-|-------------|-----------|----------|
-| `ColorToken` | `Color` | Colors and backgrounds |
-| `SpaceToken` | `double` | Spacing (padding, margin) |
-| `DoubleToken` | `double` | Any numeric value |
-| `RadiusToken` | `Radius` | Border radii |
-| `TextStyleToken` | `TextStyle` | Typography styles |
-| `BorderSideToken` | `BorderSide` | Border definitions |
-| `ShadowToken` | `List<Shadow>` | Text shadows |
-| `BoxShadowToken` | `List<BoxShadow>` | Box shadows |
-| `FontWeightToken` | `FontWeight` | Font weights |
-| `DurationToken` | `Duration` | Animation durations |
-| `BreakpointToken` | `Breakpoint` | Responsive breakpoints |
+| Token | Value type | Notes |
+|---|---|---|
+| `ColorToken` | `Color` | background, foreground, border colors |
+| `SpaceToken` | `double` | spacing and sizing; call returns a `DoubleRef` |
+| `DoubleToken` | `double` | generic numeric values; call returns a `DoubleRef` |
+| `RadiusToken` | `Radius` | corner radius values |
+| `TextStyleToken` | `TextStyle` | use `.mix()` for `TextStyler.style(...)` |
+| `BorderSideToken` | `BorderSide` | border side values |
+| `ShadowToken` | `List<Shadow>` | text/icon shadow lists |
+| `BoxShadowToken` | `List<BoxShadow>` | box shadow lists |
+| `FontWeightToken` | `FontWeight` | font weight values |
+| `DurationToken` | `Duration` | animation timing |
+| `BreakpointToken` | `Breakpoint` | responsive variants |
 
-## MixScope Parameters
+`ShadowToken` and `BoxShadowToken` are list-based in current source. Their
+`.mix()` methods return list mix refs for APIs that accept `ShadowListMix` or
+`BoxShadowListMix`.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `colors` | `Map<ColorToken, Color>` | Color token values |
-| `spaces` | `Map<SpaceToken, double>` | Space token values |
-| `radii` | `Map<RadiusToken, Radius>` | Radius token values |
-| `textStyles` | `Map<TextStyleToken, TextStyle>` | Text style token values |
-| `tokens` | `Map<MixToken, dynamic>` | Generic/custom tokens |
-| `child` | `Widget` | Child widget tree |
+## Shadow Tokens
 
----
+When an API needs `List<BoxShadowMix>`, resolve a `BoxShadowToken` and convert values.
 
-## Best Practices
+```dart
+final $cardShadow = BoxShadowToken('shadow.card');
 
-- Use descriptive, hierarchical names: `$colorPrimary`, `$spacingMd`
-- Group related tokens in separate files (`tokens/colors.dart`, `tokens/spacing.dart`)
-- Replace hardcoded values with semantic tokens for consistency
-- Define tokens as top-level `final` variables
-- Use enums for structured token sets in larger apps
+final shadowStyle = BoxStyler().shadows(
+  $cardShadow.resolve(context).map(BoxShadowMix.value).toList(),
+);
+```
 
----
+For common app code, a direct style is often simpler:
+
+```dart
+final cardStyle = BoxStyler().shadow(
+  .color(Colors.black26).offset(y: 4).blurRadius(12),
+);
+```
+
+## Theme Organization
+
+Group related tokens in files and provide values near app root.
+
+```dart
+class AppTokens {
+  static const primary = ColorToken('color.primary');
+  static const surface = ColorToken('color.surface');
+  static const spaceMd = SpaceToken('space.md');
+}
+
+final lightTokens = <MixToken, Object>{
+  AppTokens.primary: Colors.blue,
+  AppTokens.surface: Colors.white,
+  AppTokens.spaceMd: 16.0,
+};
+```
+
+Then scope them:
+
+```dart
+MixScope(
+  tokens: lightTokens,
+  child: const App(),
+);
+```
 
 ## Source Files
 
-- `packages/mix_docs_preview/lib/guides/design_token/theme_tokens.dart` — Simple token definitions
-- `packages/mix_docs_preview/lib/tutorials/theming/preview.dart` — Full theming tutorial with theme switching
-- `website/src/content/documentation/guides/design-token.mdx` — Complete token documentation
+- `packages/mix/lib/src/theme/mix_theme.dart`
+- `packages/mix/lib/src/theme/tokens/mix_token.dart`
+- `packages/mix/lib/src/theme/tokens/value_tokens.dart`
+- `packages/mix/lib/src/theme/tokens/token_refs.dart`
+- `packages/mix/doc/mix-scope-and-theming.md`
+- `packages/mix/doc/token-migration-guide.md`
+- `packages/mix/test/src/theme/tokens/shadow_list_token_integration_test.dart`

--- a/skills/mix-coding/references/variants.md
+++ b/skills/mix-coding/references/variants.md
@@ -1,259 +1,151 @@
 # Variants Reference
 
-Variants make styles context-aware — they adapt to hover, press, dark mode, and other states automatically. You define what changes; Mix handles when it applies.
+Variants make a Styler context-aware. Define the base style first, then add only
+the values that change.
 
-## Patterns
-
-### Basic Variant
-
-Add a variant by chaining the variant method. Only specify what changes — Mix merges it with the base style:
+## Widget State Variants
 
 ```dart
-final style = BoxStyler()
-    .color(Colors.red)
-    .height(100)
-    .width(100)
-    .borderRounded(10)
-    .onHovered(.color(Colors.blue));  // Only color changes on hover
+final buttonStyle = BoxStyler()
+    .color(Colors.blue)
+    .paddingX(20)
+    .paddingY(12)
+    .borderRounded(8)
+    .onHovered(.color(Colors.blue.shade700))
+    .onPressed(.color(Colors.blue.shade900))
+    .onFocused(.borderAll(color: Colors.white, width: 2))
+    .onDisabled(.color(Colors.grey));
+
+PressableBox(
+  style: buttonStyle,
+  enabled: isEnabled,
+  onPress: onPress,
+  child: label,
+);
 ```
 
-### Multiple Variants
+Widget state methods from `widget_state_variant_mixin.dart`:
 
-Chain multiple variants on the same style:
+| Method | Applies when |
+|---|---|
+| `.onHovered(style)` | hovered |
+| `.onPressed(style)` | pressed |
+| `.onFocused(style)` | focused |
+| `.onDisabled(style)` | disabled |
+| `.onEnabled(style)` | not disabled |
+
+Styled widgets automatically track hover and press when their style contains
+widget-state variants and no external controller is supplied. Use `Pressable` or
+`PressableBox` when the surface needs tap handling, focus/keyboard activation,
+disabled behavior, or explicit controller-driven state.
+
+## Theme and Context Variants
+
+```dart
+final surfaceStyle = BoxStyler()
+    .color(Colors.white)
+    .onDark(.color(const Color(0xFF1E1E24)))
+    .onLight(.color(Colors.white));
+```
+
+Context methods from `variant_style_mixin.dart`:
+
+- Brightness: `.onDark(style)`, `.onLight(style)`
+- Breakpoints: `.onBreakpoint(breakpoint, style)`, `.onMobile(style)`,
+  `.onTablet(style)`, `.onDesktop(style)`
+- Orientation: `.onPortrait(style)`, `.onLandscape(style)`
+- Directionality: `.onLtr(style)`, `.onRtl(style)`
+- Platform: `.onIos(style)`, `.onAndroid(style)`, `.onMacos(style)`,
+  `.onWindows(style)`, `.onLinux(style)`, `.onFuchsia(style)`, `.onWeb(style)`
+- Advanced: `.onNot(contextVariant, style)`, `.onBuilder((context) => style)`,
+  `.variant(variant, style)`
+
+Responsive example:
+
+```dart
+final panelStyle = BoxStyler()
+    .width(320)
+    .paddingAll(16)
+    .onMobile(.width(280).paddingAll(12))
+    .onDesktop(.width(520).paddingAll(24));
+```
+
+## Custom Context Variants
+
+Use `ContextVariant` when the condition comes from `BuildContext`.
+
+```dart
+class CompactModeVariant extends ContextVariant {
+  CompactModeVariant()
+      : super('compact_mode', (context) {
+          return MediaQuery.sizeOf(context).width < 480;
+        });
+}
+
+final style = BoxStyler()
+    .paddingAll(16)
+    .variant(CompactModeVariant(), .paddingAll(8));
+```
+
+## Named Variants
+
+Use `NamedVariant` for explicitly selected style modes.
+
+```dart
+const primary = NamedVariant('primary');
+
+final style = BoxStyler()
+    .color(Colors.grey)
+    .variant(primary, .color(Colors.blue));
+
+final primaryStyle = style.applyVariants([primary]);
+```
+
+## Selected or Custom Widget States
+
+There is no fluent `.onSelected()` helper in the current source. Use
+`ContextVariant.widgetState(...)` with a `WidgetStatesController` when you need
+selected state.
+
+```dart
+final controller = WidgetStatesController();
+
+final style = BoxStyler()
+    .color(Colors.grey)
+    .variant(
+      ContextVariant.widgetState(.selected),
+      .color(Colors.blue),
+    );
+
+Pressable(
+  controller: controller,
+  onPress: () {
+    controller.update(.selected, !controller.has(.selected));
+  },
+  child: Box(style: style, child: child),
+);
+```
+
+Dispose externally owned controllers in stateful widgets.
+
+## Variant Ordering
+
+Keep variants at the end of a chain for readability. Build the base style first,
+then attach variants.
 
 ```dart
 final style = BoxStyler()
     .color(Colors.blue)
-    .size(100, 100)
-    .borderRounded(10)
+    .paddingAll(16)
+    .animate(.easeInOut(180.ms))
     .onHovered(.color(Colors.blue.shade700))
-    .onPressed(.color(Colors.blue.shade900))
-    .onDisabled(.color(Colors.grey));
+    .onPressed(.color(Colors.blue.shade900));
 ```
-
-### Composing Styles with Variants
-
-When you override a style that already has variants, the new variant values merge with existing ones:
-
-```dart
-final styleA = BoxStyler()
-    .color(Colors.red)
-    .size(100, 100)
-    .onHovered(.color(Colors.blue).width(200));
-
-// styleB inherits hover width=200 but overrides hover color
-final styleB = styleA.onHovered(.color(Colors.green));
-// Hover result: color=green, width=200
-```
-
-### Nesting Variants
-
-Combine variants for compound conditions:
-
-```dart
-final hoverStyle = BoxStyler()
-    .onDark(.color(Colors.blue))
-    .onLight(.color(Colors.green));
-
-final style = BoxStyler()
-    .color(Colors.red)
-    .size(100, 100)
-    .onHovered(hoverStyle);  // Different hover colors per theme
-```
-
-### Dark/Light Mode
-
-```dart
-final buttonStyle = BoxStyler()
-    .height(60)
-    .width(60)
-    .borderRounded(30)
-    .color(Colors.grey.shade200)
-    .onDark(.color(Colors.grey.shade800));
-
-final iconStyle = IconStyler()
-    .color(Colors.grey.shade800)
-    .size(28)
-    .icon(Icons.dark_mode)
-    .onDark(.icon(Icons.light_mode).color(Colors.yellow));
-```
-
-### Responsive Breakpoints
-
-```dart
-final style = BoxStyler()
-    .width(100)
-    .height(100)
-    .color(Colors.blue.shade400)
-    .onBreakpoint(Breakpoint.maxWidth(575), .color(Colors.green))
-    .onMobile(.width(80))
-    .onTablet(.width(120))
-    .onDesktop(.width(200));
-```
-
-### Widget State with Pressable
-
-For hover, press, and focus to work, the widget must be wrapped in a `Pressable` or use `PressableBox`:
-
-```dart
-// Using Pressable wrapper
-final style = BoxStyler()
-    .color(Colors.red)
-    .size(100, 100)
-    .onPressed(.color(Colors.blue));
-
-Pressable(
-  onPress: () => print('tapped'),
-  child: Box(style: style),
-);
-
-// Or use PressableBox (Box + Pressable combined)
-PressableBox(
-  style: style,
-  onPress: () => print('tapped'),
-  child: child,
-);
-```
-
-### Selected State with Controller
-
-```dart
-class MyWidget extends StatefulWidget { ... }
-
-class _MyWidgetState extends State<MyWidget> {
-  final controller = WidgetStatesController();
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final style = BoxStyler()
-        .color(Colors.red)
-        .size(100, 100)
-        .variant(ContextVariant.widgetState(.selected), .color(Colors.blue));
-
-    return Pressable(
-      onPress: () {
-        final isSelected = controller.has(.selected);
-        controller.update(.selected, !isSelected);
-      },
-      controller: controller,
-      child: Box(style: style),
-    );
-  }
-}
-```
-
-### Custom Context Variant
-
-Create variants based on any `InheritedWidget` or `BuildContext` condition:
-
-```dart
-class MyCustomVariant extends ContextVariant {
-  MyCustomVariant()
-    : super('my_custom', (context) {
-        // Return true when this variant should be active
-        return MyInheritedWidget.of(context)?.isActive ?? false;
-      });
-}
-
-// Usage
-final style = BoxStyler()
-    .color(Colors.grey)
-    .variant(MyCustomVariant(), .color(Colors.blue));
-```
-
-### Animating Variants
-
-Add `.animate()` to smoothly transition between variant states:
-
-```dart
-final style = BoxStyler()
-    .color(Colors.grey.shade200)
-    .animate(.easeInOut(600.ms))
-    .onDark(.color(Colors.grey.shade800))
-    .onHovered(.color(Colors.blue));
-```
-
----
-
-## Built-in Variant Methods
-
-All stylers (`BoxStyler`, `TextStyler`, `IconStyler`, etc.) support these variant methods:
-
-### Widget State Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onHovered(style)` | When widget is hovered |
-| `.onPressed(style)` | When widget is pressed |
-| `.onFocused(style)` | When widget is focused |
-| `.onDisabled(style)` | When widget is disabled |
-| `.onEnabled(style)` | When widget is enabled |
-
-### Theme Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onDark(style)` | In dark mode |
-| `.onLight(style)` | In light mode |
-
-### Orientation Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onPortrait(style)` | Portrait orientation |
-| `.onLandscape(style)` | Landscape orientation |
-
-### Responsive Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onBreakpoint(Breakpoint, style)` | Custom breakpoint |
-| `.onMobile(style)` | Mobile screen size |
-| `.onTablet(style)` | Tablet screen size |
-| `.onDesktop(style)` | Desktop screen size |
-
-### Direction Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onLtr(style)` | Left-to-right |
-| `.onRtl(style)` | Right-to-left |
-
-### Platform Variants
-
-| Method | Description |
-|--------|-------------|
-| `.onIos(style)` | iOS platform |
-| `.onAndroid(style)` | Android platform |
-| `.onMacos(style)` | macOS platform |
-| `.onWindows(style)` | Windows platform |
-| `.onLinux(style)` | Linux platform |
-| `.onFuchsia(style)` | Fuchsia platform |
-| `.onWeb(style)` | Web platform |
-
-### Advanced
-
-| Method | Description |
-|--------|-------------|
-| `.onNot(contextVariant, style)` | When variant is NOT active |
-| `.onBuilder((context) => style)` | Custom function-based variant |
-| `.variant(ContextVariant, style)` | Apply any custom variant |
-
----
 
 ## Source Files
 
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/hovered.dart` — Hover example
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/pressed.dart` — Press with Pressable
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/on_dark_light.dart` — Dark/light mode toggle
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/selected.dart` — Selected state with controller
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/disabled.dart` — Disabled state
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/context_variant_flag.dart` — Custom variant
-- `packages/mix_docs_preview/lib/guides/dynamic_styling/responsive_size.dart` — Responsive breakpoints
-- `website/src/content/documentation/guides/dynamic-styling.mdx` — Variants guide documentation
+- `packages/mix/lib/src/style/mixins/variant_style_mixin.dart`
+- `packages/mix/lib/src/style/mixins/widget_state_variant_mixin.dart`
+- `packages/mix/lib/src/variants/variant.dart`
+- `packages/mix/test/src/variants/variant_mixin_test.dart`
+- `packages/mix/test/src/specs/pressable/pressable_widget_test.dart`

--- a/skills/mix-coding/references/widgets.md
+++ b/skills/mix-coding/references/widgets.md
@@ -1,278 +1,182 @@
 # Widgets Reference
 
-Mix provides styled widget equivalents for common Flutter widgets. Each Mix widget takes a `style` parameter built with its corresponding Styler.
+Mix widgets pair with Stylers. Choose the widget first, then build a named style for it.
 
-## Widget Selection Guide
+## Selection Guide
 
-| Need | Use | Styler |
-|------|-----|--------|
-| Container/card/background | `Box` | `BoxStyler` |
-| Horizontal layout | `RowBox` (alias: `HBox`) | `FlexBoxStyler` |
-| Vertical layout | `ColumnBox` (alias: `VBox`) | `FlexBoxStyler` |
-| Stack/overlay | `ZBox` | `FlexBoxStyler` |
-| Text | `StyledText` | `TextStyler` |
-| Icon | `StyledIcon` | `IconStyler` |
-| Image | `StyledImage` | `ImageStyler` |
-| Tappable wrapper | `Pressable` | (wraps child styles) |
-| Tappable box | `PressableBox` | `BoxStyler` |
-
----
+| Need | Widget | Styler |
+|---|---|---|
+| Styled surface, card, background, constraints | `Box` | `BoxStyler` |
+| Dynamic flex direction | `FlexBox` | `FlexBoxStyler` |
+| Horizontal flex layout | `RowBox` | `FlexBoxStyler` |
+| Vertical flex layout | `ColumnBox` | `FlexBoxStyler` |
+| Stack/overlay layout | `StackBox` | `StackBoxStyler` |
+| Styled text | `StyledText` | `TextStyler` |
+| Styled icon | `StyledIcon` | `IconStyler` |
+| Styled image | `StyledImage` | `ImageStyler` |
+| Generic interaction state wrapper | `Pressable` | child keeps its own style |
+| Interactive styled box | `PressableBox` | `BoxStyler` |
 
 ## Box
 
-Replacement for Flutter's `Container`. Supports color, padding, margin, borders, shadows, gradients, and constraints.
+`Box` is the Mix surface widget. Use it instead of `Container` when the user wants Mix styling.
 
 ```dart
-final style = BoxStyler()
+final cardStyle = BoxStyler()
     .color(Colors.white)
     .paddingAll(16)
-    .borderRounded(12)
-    .shadowOnly(color: Colors.black12, blurRadius: 8);
+    .borderRounded(12);
 
-Box(style: style, child: content);
+Box(style: cardStyle, child: content);
 ```
 
-### Box Constructor
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `style` | `BoxStyler` | The box style |
-| `child` | `Widget?` | Child widget |
-| `inherit` | `bool` | Inherit parent style (default: false) |
-
----
-
-## FlexBox (RowBox, ColumnBox, ZBox)
-
-`FlexBox` combines Flutter's `Flex` + `Container`. Use the directional aliases:
-
-### RowBox / HBox — Horizontal Layout
+Constructor shape:
 
 ```dart
-final style = FlexBoxStyler()
+Box({
+  BoxStyler style = const BoxStyler.create(),
+  StyleSpec<BoxSpec>? styleSpec,
+  Widget? child,
+});
+```
+
+## FlexBox, RowBox, ColumnBox
+
+`FlexBox` combines flex layout with box styling. Use `RowBox` and `ColumnBox`
+when the direction is fixed.
+
+```dart
+final rowStyle = FlexBoxStyler()
+    .spacing(8)
     .crossAxisAlignment(.center)
-    .spacing(8);
+    .paddingAll(12)
+    .borderRounded(8)
+    .color(Colors.blue.shade50);
 
 RowBox(
-  style: style,
+  style: rowStyle,
   children: [
-    StyledIcon(icon: Icons.star, style: iconStyle),
-    StyledText('Label', style: textStyle),
+    StyledIcon(icon: Icons.info, style: IconStyler.color(Colors.blue)),
+    StyledText('Details', style: TextStyler.fontWeight(.bold)),
   ],
 );
 ```
 
-### ColumnBox / VBox — Vertical Layout
+Use `FlexBox` directly when direction itself is part of the style:
 
 ```dart
-final style = FlexBoxStyler()
-    .crossAxisAlignment(.start)
-    .spacing(16)
-    .marginAll(16);
-
-ColumnBox(
-  style: style,
-  children: [
-    StyledText('Title', style: titleStyle),
-    StyledText('Subtitle', style: subtitleStyle),
-    Box(style: cardStyle, child: content),
-  ],
+FlexBox(
+  style: FlexBoxStyler()
+      .direction(.vertical)
+      .spacing(12)
+      .paddingAll(16),
+  children: children,
 );
 ```
 
-### ZBox — Stack/Overlay Layout
+## StackBox
+
+Use `StackBox` for overlay layouts that also need Mix box styling.
 
 ```dart
-ZBox(
-  style: FlexBoxStyler().alignment(.center),
+final stackStyle = StackBoxStyler()
+    .stackAlignment(.center)
+    .color(Colors.black)
+    .borderRounded(12);
+
+StackBox(
+  style: stackStyle,
   children: [
-    Box(style: backgroundStyle),
-    Box(style: foregroundStyle),
+    StyledImage(image: imageProvider, style: imageStyle),
+    StyledText('Live', style: badgeTextStyle),
   ],
 );
 ```
-
-### FlexBoxStyler API
-
-All `BoxStyler` methods are available plus:
-
-| Method | Description |
-|--------|-------------|
-| `.direction(Axis)` | Main axis direction |
-| `.mainAxisAlignment(MainAxisAlignment)` | Main axis alignment |
-| `.crossAxisAlignment(CrossAxisAlignment)` | Cross axis alignment |
-| `.mainAxisSize(MainAxisSize)` | Main axis size |
-| `.spacing(double)` | Gap between children |
-| `.verticalDirection(VerticalDirection)` | Vertical ordering |
-| `.textDirection(TextDirection)` | Text direction |
-| `.textBaseline(TextBaseline)` | Text baseline |
-| `.clipBehavior(Clip)` | Clip behavior |
-
-### FlexBox Constructor
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `style` | `FlexBoxStyler` | The flex box style |
-| `children` | `List<Widget>` | Child widgets |
-| `direction` | `Axis` | Main axis (RowBox=horizontal, ColumnBox=vertical) |
-| `inherit` | `bool` | Inherit parent style (default: false) |
-
----
 
 ## StyledText
 
-Replacement for Flutter's `Text` widget with Mix styling.
-
 ```dart
-final style = TextStyler()
+final textStyle = TextStyler()
     .fontSize(18)
-    .fontWeight(.bold)
-    .color(Colors.black)
-    .letterSpacing(0.5);
+    .fontWeight(.w700)
+    .color(Colors.black);
 
-StyledText('Hello World', style: style);
+StyledText('Hello Mix', style: textStyle);
 ```
 
-### StyledText Constructor
+`TextStyler.call(String)` creates `StyledText`:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `text` | `String` | The text content (positional) |
-| `style` | `TextStyler` | The text style |
-| `inherit` | `bool` | Inherit parent style (default: false) |
-
----
+```dart
+final caption = TextStyler.fontSize(12).color(Colors.grey);
+caption('Caption');
+```
 
 ## StyledIcon
 
-Replacement for Flutter's `Icon` widget with Mix styling.
-
 ```dart
-final style = IconStyler()
-    .size(30)
-    .color(Colors.blueAccent);
+final iconStyle = IconStyler()
+    .size(24)
+    .color(Colors.amber);
 
-StyledIcon(icon: Icons.star, style: style);
+StyledIcon(icon: Icons.star, style: iconStyle);
 ```
 
-### StyledIcon Constructor
+`IconStyler.call(...)` creates `StyledIcon`:
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `icon` | `IconData?` | The icon data |
-| `style` | `IconStyler` | The icon style |
-| `inherit` | `bool` | Inherit parent style (default: false) |
-
----
+```dart
+IconStyler.size(20).color(Colors.green)(icon: Icons.check);
+```
 
 ## StyledImage
 
-Styled image widget.
-
 ```dart
-final style = ImageStyler()
-    .width(200)
-    .height(150)
-    .fit(BoxFit.cover)
-    .borderRounded(8);
+final imageStyle = ImageStyler()
+    .width(160)
+    .height(120)
+    .fit(BoxFit.cover);
 
 StyledImage(
-  image: NetworkImage('https://example.com/photo.jpg'),
-  style: style,
+  image: const NetworkImage('https://example.com/photo.jpg'),
+  style: imageStyle,
 );
 ```
 
-### StyledImage Constructor
+`StyledImage` needs an `ImageProvider` either on the widget or inside `ImageStyler.image(...)`.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `image` | `ImageProvider` | The image source |
-| `style` | `ImageStyler` | The image style |
-| `inherit` | `bool` | Inherit parent style (default: false) |
+## Pressable and PressableBox
 
----
-
-## Pressable & PressableBox
-
-Makes widgets interactive (tappable) and enables hover/press/focus/disabled variants.
-
-### Pressable — Generic Wrapper
-
-Wraps any widget to enable interaction state variants:
+Use `PressableBox` when the interactive target is a styled box. Use `Pressable`
+when wrapping another widget.
 
 ```dart
-final style = BoxStyler()
+final buttonStyle = BoxStyler()
     .color(Colors.blue)
-    .size(100, 100)
+    .paddingX(20)
+    .paddingY(12)
+    .borderRounded(8)
     .onHovered(.color(Colors.blue.shade700))
-    .onPressed(.color(Colors.blue.shade900));
+    .onPressed(.color(Colors.blue.shade900))
+    .onDisabled(.color(Colors.grey));
 
-Pressable(
-  onPress: () => print('tapped'),
-  child: Box(style: style),
-);
-```
-
-### PressableBox — Box + Pressable Combined
-
-Shorthand for a pressable Box:
-
-```dart
 PressableBox(
-  style: BoxStyler()
-      .color(Colors.blue)
-      .paddingAll(16)
-      .borderRounded(8)
-      .onHovered(.color(Colors.blue.shade700))
-      .onPressed(.color(Colors.blue.shade900)),
-  onPress: () => print('tapped'),
-  child: StyledText('Click me', style: textStyle),
+  style: buttonStyle,
+  enabled: isEnabled,
+  onPress: onPress,
+  child: StyledText('Continue', style: TextStyler.color(Colors.white)),
 );
 ```
 
-### Pressable Constructor
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `onPress` | `VoidCallback?` | Tap callback |
-| `onLongPress` | `VoidCallback?` | Long press callback |
-| `enabled` | `bool` | Enable/disable (default: true) |
-| `controller` | `WidgetStatesController?` | External state controller |
-| `child` | `Widget` | Child widget |
-
-### PressableBox Constructor
-
-Same as Pressable, plus:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `style` | `BoxStyler` | The box style |
-
----
-
-## Callable Stylers (Shorthand)
-
-Any styler can be called directly to create its widget:
-
-```dart
-final box = BoxStyler().color(Colors.blue).size(100, 100);
-box();                    // Creates Box()
-box(child: text);         // Creates Box(child: text)
-
-final text = TextStyler().fontSize(18).color(Colors.black);
-text('Hello');            // Creates StyledText('Hello')
-
-final icon = IconStyler().size(24).color(Colors.red);
-icon(icon: Icons.star);   // Creates StyledIcon()
-```
-
----
+`PressableBox` manages hover, press, focus, disabled, and keyboard activation
+for styled boxes. Use `Pressable` when wrapping another widget or when you need
+an optional external `WidgetStatesController`; `PressableBox` does not expose a
+controller parameter.
 
 ## Source Files
 
-- `packages/mix_docs_preview/lib/widgets/box/simple_box.dart` — Basic Box
-- `packages/mix_docs_preview/lib/widgets/box/gradient_box.dart` — Gradient Box
-- `packages/mix_docs_preview/lib/widgets/flexbox/icon_label_chip.dart` — FlexBox layout examples
-- `packages/mix_docs_preview/lib/widgets/pressable/pressable_button.dart` — Pressable interaction examples
-- `packages/mix_docs_preview/lib/widgets/icon/styled_icon.dart` — Icon examples
-- `packages/mix_docs_preview/lib/widgets/image/styled_image.dart` — Image examples
+- `packages/mix/lib/src/specs/box/box_widget.dart`
+- `packages/mix/lib/src/specs/flexbox/flexbox_widget.dart`
+- `packages/mix/lib/src/specs/stackbox/stackbox_widget.dart`
+- `packages/mix/lib/src/specs/text/text_widget.dart`
+- `packages/mix/lib/src/specs/icon/icon_widget.dart`
+- `packages/mix/lib/src/specs/image/image_widget.dart`
+- `packages/mix/lib/src/specs/pressable/pressable_widget.dart`


### PR DESCRIPTION
## Summary

- Updates authored Mix docs for current token, theming, mix_lint, and API guidance.
- Rewrites and formats the `skills/mix-coding` skill references for current Mix 2.0 usage.
- Adds eval coverage for source-aligned Mix examples, including typed dot shorthand, variants, tokens, widgets, and animations.

## Validation

- `git diff --cached --check`
- `python3.10 -m json.tool skills/mix-coding/evals/evals.json >/dev/null`
- Markdown code fence balance check for `skills/mix-coding/SKILL.md` and reference docs
- Targeted `rg` checks for stale reviewed strings and source-aligned APIs

## Notes

- Left unrelated local changes unstaged: `.vscode/settings.json`, `melos.yaml`, and `mix-coding-workspace/`.
- Removed the untracked rewrite-plan doc and did not include it in this PR.