### PR TITLE
chore: fix analyze and DCM warnings

### DIFF
--- a/packages/mix/lib/src/animation/style_animation_builder.dart
+++ b/packages/mix/lib/src/animation/style_animation_builder.dart
@@ -11,18 +11,18 @@ import 'style_animation_driver.dart';
 /// animated style changes. It also manages the animation lifecycle,
 /// triggering animations when the style changes.
 class StyleAnimationBuilder<S extends Spec<S>> extends StatefulWidget {
-  /// The target spec to animate to.
-  final StyleSpec<S> spec;
-
-  /// The builder function that creates the widget with the animated spec.
-  final Widget Function(BuildContext context, StyleSpec<S> spec) builder;
-
   const StyleAnimationBuilder({
     super.key,
 
     required this.spec,
     required this.builder,
   });
+
+  /// The target spec to animate to.
+  final StyleSpec<S> spec;
+
+  /// The builder function that creates the widget with the animated spec.
+  final Widget Function(BuildContext context, StyleSpec<S> spec) builder;
 
   @override
   State<StyleAnimationBuilder<S>> createState() =>
@@ -33,6 +33,14 @@ class _StyleAnimationBuilderState<S extends Spec<S>>
     extends State<StyleAnimationBuilder<S>>
     with TickerProviderStateMixin {
   late StyleAnimationDriver<S> animationDriver;
+
+  @override
+  void initState() {
+    super.initState();
+    final spec = widget.spec;
+    final config = spec.animation;
+    animationDriver = _createAnimationDriver(config: config, initialSpec: spec);
+  }
 
   StyleAnimationDriver<S> _createAnimationDriver({
     required AnimationConfig? config,
@@ -68,14 +76,6 @@ class _StyleAnimationBuilderState<S extends Spec<S>>
       // ignore: avoid-undisposed-instances
       null => NoAnimationDriver(vsync: this, initialSpec: initialSpec),
     };
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    final spec = widget.spec;
-    final config = spec.animation;
-    animationDriver = _createAnimationDriver(config: config, initialSpec: spec);
   }
 
   @override

--- a/packages/mix/lib/src/core/internal/mix_interaction_detector.dart
+++ b/packages/mix/lib/src/core/internal/mix_interaction_detector.dart
@@ -14,12 +14,6 @@ import '../providers/widget_state_provider.dart';
 /// gates interactions, and clears transient hover/press states. When true, it tracks these.
 @internal
 class MixInteractionDetector extends StatefulWidget {
-  final Widget child;
-
-  final WidgetStatesController? controller;
-  final bool enabled;
-  final ValueChanged<bool>? onHoverChange;
-  final ValueChanged<PointerPosition>? onPointerPositionChange;
   const MixInteractionDetector({
     super.key,
     required this.child,
@@ -29,6 +23,12 @@ class MixInteractionDetector extends StatefulWidget {
     this.onPointerPositionChange,
   });
 
+  final Widget child;
+  final WidgetStatesController? controller;
+  final bool enabled;
+  final ValueChanged<bool>? onHoverChange;
+  final ValueChanged<PointerPosition>? onPointerPositionChange;
+
   @override
   State<MixInteractionDetector> createState() => _MixInteractionDetectorState();
 }
@@ -36,6 +36,13 @@ class MixInteractionDetector extends StatefulWidget {
 class _MixInteractionDetectorState extends State<MixInteractionDetector> {
   WidgetStatesController? _internalController;
   late final PointerPositionNotifier _cursorPositionNotifier;
+
+  @override
+  void initState() {
+    super.initState();
+    _cursorPositionNotifier = PointerPositionNotifier();
+    _syncDisabledState();
+  }
 
   /// Creates an internal controller with initial disabled state if needed.
   WidgetStatesController _createInternalController() {
@@ -160,13 +167,6 @@ class _MixInteractionDetectorState extends State<MixInteractionDetector> {
   WidgetStatesController get _effectiveController =>
       widget.controller ??
       (_internalController ??= _createInternalController());
-
-  @override
-  void initState() {
-    super.initState();
-    _cursorPositionNotifier = PointerPositionNotifier();
-    _syncDisabledState();
-  }
 
   @override
   void didUpdateWidget(MixInteractionDetector oldWidget) {

--- a/packages/mix/lib/src/core/providers/style_provider.dart
+++ b/packages/mix/lib/src/core/providers/style_provider.dart
@@ -11,10 +11,10 @@ import '../style.dart';
 /// For accessing styles from the widget tree, prefer using [Style.of] or
 /// [Style.maybeOf] static methods.
 class StyleProvider<S extends Spec<S>> extends InheritedWidget {
+  const StyleProvider({super.key, required this.style, required super.child});
+
   /// The style provided to descendant widgets.
   final Style<S> style;
-
-  const StyleProvider({super.key, required this.style, required super.child});
 
   @override
   bool updateShouldNotify(StyleProvider<S> oldWidget) {

--- a/packages/mix/lib/src/core/providers/style_spec_provider.dart
+++ b/packages/mix/lib/src/core/providers/style_spec_provider.dart
@@ -5,9 +5,6 @@ import '../style_spec.dart';
 
 /// Provides a resolved StyleSpec<S> to descendant widgets.
 class StyleSpecProvider<T extends Spec<T>> extends InheritedWidget {
-  /// The resolved style spec provided to descendant widgets.
-  final StyleSpec<T> spec;
-
   const StyleSpecProvider({
     super.key,
     required this.spec,
@@ -23,6 +20,9 @@ class StyleSpecProvider<T extends Spec<T>> extends InheritedWidget {
 
     return provider?.spec;
   }
+
+  /// The resolved style spec provided to descendant widgets.
+  final StyleSpec<T> spec;
 
   @override
   bool updateShouldNotify(covariant StyleSpecProvider<T> oldWidget) =>

--- a/packages/mix/lib/src/core/providers/widget_state_provider.dart
+++ b/packages/mix/lib/src/core/providers/widget_state_provider.dart
@@ -19,27 +19,6 @@ extension on Set<WidgetState> {
 /// allowing them to conditionally style based on states like hover, pressed, focused, etc.
 /// Uses [InheritedModel] for efficient updates - only widgets depending on changed states rebuild.
 class WidgetStateProvider extends InheritedModel<WidgetState> {
-  /// Whether the widget is disabled.
-  final bool disabled;
-
-  /// Whether the widget is being hovered.
-  final bool hovered;
-
-  /// Whether the widget has focus.
-  final bool focused;
-
-  /// Whether the widget is being pressed.
-  final bool pressed;
-
-  /// Whether the widget is being dragged.
-  final bool dragged;
-
-  /// Whether the widget is selected.
-  final bool selected;
-
-  /// Whether the widget has an error.
-  final bool error;
-
   WidgetStateProvider({
     super.key,
     required Set<WidgetState> states,
@@ -83,6 +62,27 @@ class WidgetStateProvider extends InheritedModel<WidgetState> {
       .scrolledUnder => false,
     };
   }
+
+  /// Whether the widget is disabled.
+  final bool disabled;
+
+  /// Whether the widget is being hovered.
+  final bool hovered;
+
+  /// Whether the widget has focus.
+  final bool focused;
+
+  /// Whether the widget is being pressed.
+  final bool pressed;
+
+  /// Whether the widget is being dragged.
+  final bool dragged;
+
+  /// Whether the widget is selected.
+  final bool selected;
+
+  /// Whether the widget has an error.
+  final bool error;
 
   @override
   bool updateShouldNotify(WidgetStateProvider oldWidget) {

--- a/packages/mix/lib/src/core/shape_border_merge.dart
+++ b/packages/mix/lib/src/core/shape_border_merge.dart
@@ -37,7 +37,7 @@ class ShapeBorderMerger {
         $borderRadius: b.$borderRadius,
         $side: b.$side,
       ),
-      _ => throw ArgumentError(
+      OutlinedBorderMix() => throw ArgumentError(
         'Expected rectangle variant, got ${border.runtimeType}',
       ),
     };

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -44,9 +44,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
       throw FlutterError(
         'Style.of() called with a context that does not contain a Style of type $S.\n'
         'No Style<$S> ancestor could be found starting from the context that was passed to Style.of().\n\n'
-        'If you are using StyleBuilder, make sure to set inheritable: true to provide the style to descendant widgets.\n\n'
-        'The context used was:\n'
-        '  $context',
+        'If you are using StyleBuilder, make sure to set inheritable: true to provide the style to descendant widgets.',
       );
     }
 

--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -16,6 +16,14 @@ import 'style_spec.dart';
 /// and provides it to the builder function. It also manages style inheritance,
 /// variant application, and modifier rendering.
 class StyleBuilder<S extends Spec<S>> extends StatefulWidget {
+  const StyleBuilder({
+    super.key,
+    required this.style,
+    required this.builder,
+    this.controller,
+    this.inheritable = false,
+  });
+
   /// The style element to resolve and apply.
   final Style<S> style;
 
@@ -34,14 +42,6 @@ class StyleBuilder<S extends Spec<S>> extends StatefulWidget {
   /// Defaults to false.
   final bool inheritable;
 
-  const StyleBuilder({
-    super.key,
-    required this.style,
-    required this.builder,
-    this.controller,
-    this.inheritable = false,
-  });
-
   @override
   State<StyleBuilder<S>> createState() => _StyleBuilderState<S>();
 }
@@ -52,6 +52,12 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
 
   /// Tracks whether we created the controller internally (and thus own it)
   bool _ownsController = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _initController();
+  }
 
   void _initController() {
     if (widget.controller != null) {
@@ -84,12 +90,6 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
     final inheritedStyle = Style.maybeOf<S>(context);
 
     return inheritedStyle?.merge(widget.style) ?? widget.style;
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _initController();
   }
 
   @override
@@ -159,17 +159,17 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
 /// Applies resolved style specs, widget modifiers, and animation support
 /// to the builder function while providing the spec through StyleSpecProvider.
 class StyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
-  /// The style to resolve.
-  final StyleSpec<S> styleSpec;
-
-  /// The builder function that receives the resolved style.
-  final Widget Function(BuildContext context, S spec) builder;
-
   const StyleSpecBuilder({
     super.key,
     required this.builder,
     required this.styleSpec,
   });
+
+  /// The style to resolve.
+  final StyleSpec<S> styleSpec;
+
+  /// The builder function that receives the resolved style.
+  final Widget Function(BuildContext context, S spec) builder;
 
   @override
   Widget build(BuildContext context) {
@@ -201,13 +201,13 @@ class StyleSpecBuilder<S extends Spec<S>> extends StatelessWidget {
 }
 
 class _ExternalControllerProvider extends StatelessWidget {
-  final WidgetStatesController controller;
-
-  final Widget child;
   const _ExternalControllerProvider({
     required this.controller,
     required this.child,
   });
+
+  final WidgetStatesController controller;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mix/lib/src/core/style_widget.dart
+++ b/packages/mix/lib/src/core/style_widget.dart
@@ -10,14 +10,14 @@ import 'style_spec.dart';
 /// Provides style application and inheritance through the Mix framework.
 /// Type [S] must extend [Spec<S>] for type-safe styling.
 abstract class StyleWidget<S extends Spec<S>> extends StatefulWidget {
+  /// Creates a [StyleWidget] with either [style] or [styleSpec].
+  const StyleWidget({required this.style, this.styleSpec, super.key});
+
   /// Style to apply to this widget.
   final Style<S> style;
 
   /// Direct spec to apply to this widget.
   final StyleSpec<S>? styleSpec;
-
-  /// Creates a [StyleWidget] with either [style] or [styleSpec].
-  const StyleWidget({required this.style, this.styleSpec, super.key});
 
   @override
   State<StyleWidget<S>> createState() => _StyleWidgetState<S>();

--- a/packages/mix/lib/src/modifiers/internal/render_modifier.dart
+++ b/packages/mix/lib/src/modifiers/internal/render_modifier.dart
@@ -8,18 +8,18 @@ import '../../core/widget_modifier.dart';
 /// Renders a widget with applied modifiers in the correct order.
 @internal
 class RenderModifiers extends StatelessWidget {
-  /// Widget to which modifiers will be applied.
-  final Widget child;
-
-  /// List of modifiers to apply to the [child].
-  final List<WidgetModifier> widgetModifiers;
-
   /// Creates a widget that applies [widgetModifiers] to a [child] widget.
   const RenderModifiers({
     required this.child,
     required this.widgetModifiers,
     super.key,
   });
+
+  /// Widget to which modifiers will be applied.
+  final Widget child;
+
+  /// List of modifiers to apply to the [child].
+  final List<WidgetModifier> widgetModifiers;
 
   @override
   Widget build(BuildContext context) {
@@ -29,13 +29,13 @@ class RenderModifiers extends StatelessWidget {
 
 /// Internal widget that iteratively applies modifiers to a child widget.
 class _RenderModifiers extends StatelessWidget {
+  const _RenderModifiers({required this.child, required this.modifiers});
+
   /// Base widget to transform.
   final Widget child;
 
   /// Modifiers to apply in sequence.
   final Iterable<WidgetModifier> modifiers;
-
-  const _RenderModifiers({required this.child, required this.modifiers});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/mix/lib/src/modifiers/transform_modifier.dart
+++ b/packages/mix/lib/src/modifiers/transform_modifier.dart
@@ -288,7 +288,6 @@ class RotateModifier extends _TransformModifier<RotateModifier> {
   }
 
   @override
-  // ignore: avoid-incomplete-copy-with
   RotateModifier copyWith({double? radians, Alignment? alignment}) {
     return RotateModifier(
       radians: radians ?? this.radians,

--- a/packages/mix/lib/src/properties/layout/edge_insets_geometry_mix.dart
+++ b/packages/mix/lib/src/properties/layout/edge_insets_geometry_mix.dart
@@ -36,7 +36,7 @@ sealed class EdgeInsetsGeometryMix<T extends EdgeInsetsGeometry>
   }
 
   /// All offsets equal to [value].
-  static EdgeInsetsMix all(double value) => EdgeInsetsMix.all(value);
+  static EdgeInsetsMix all(double value) => .all(value);
 
   /// Creates insets with only specified values.
   static EdgeInsetsMix only({
@@ -54,23 +54,17 @@ sealed class EdgeInsetsGeometryMix<T extends EdgeInsetsGeometry>
     double? end,
     double? top,
     double? bottom,
-  }) => EdgeInsetsDirectionalMix(
-    top: top,
-    bottom: bottom,
-    start: start,
-    end: end,
-  );
+  }) => .new(top: top, bottom: bottom, start: start, end: end);
 
   /// Equal horizontal offsets.
-  static EdgeInsetsMix horizontal(double value) =>
-      EdgeInsetsMix.horizontal(value);
+  static EdgeInsetsMix horizontal(double value) => .horizontal(value);
 
   /// Equal vertical offsets.
-  static EdgeInsetsMix vertical(double value) => EdgeInsetsMix.vertical(value);
+  static EdgeInsetsMix vertical(double value) => .vertical(value);
 
   /// Symmetric vertical and horizontal offsets.
   static EdgeInsetsMix symmetric({double? vertical, double? horizontal}) =>
-      EdgeInsetsMix.symmetric(vertical: vertical, horizontal: horizontal);
+      .symmetric(vertical: vertical, horizontal: horizontal);
 
   /// Creates from left, top, right, bottom.
   static EdgeInsetsMix fromLTRB(
@@ -78,7 +72,7 @@ sealed class EdgeInsetsGeometryMix<T extends EdgeInsetsGeometry>
     double top,
     double right,
     double bottom,
-  ) => EdgeInsetsMix.fromLTRB(left, top, right, bottom);
+  ) => .fromLTRB(left, top, right, bottom);
 
   /// Creates from start, top, end, bottom.
   static EdgeInsetsDirectionalMix fromSTEB(
@@ -86,7 +80,7 @@ sealed class EdgeInsetsGeometryMix<T extends EdgeInsetsGeometry>
     double top,
     double end,
     double bottom,
-  ) => EdgeInsetsDirectionalMix.fromSTEB(start, top, end, bottom);
+  ) => .fromSTEB(start, top, end, bottom);
 
   /// Creates from nullable [EdgeInsetsGeometry].
   static EdgeInsetsGeometryMix<T>? maybeValue<T extends EdgeInsetsGeometry>(
@@ -98,24 +92,22 @@ sealed class EdgeInsetsGeometryMix<T extends EdgeInsetsGeometry>
   }
 
   /// Top offset only.
-  static EdgeInsetsMix top(double value) => EdgeInsetsMix(top: value);
+  static EdgeInsetsMix top(double value) => .new(top: value);
 
   /// Bottom offset only.
-  static EdgeInsetsMix bottom(double value) => EdgeInsetsMix(bottom: value);
+  static EdgeInsetsMix bottom(double value) => .new(bottom: value);
 
   /// Left offset only.
-  static EdgeInsetsMix left(double value) => EdgeInsetsMix(left: value);
+  static EdgeInsetsMix left(double value) => .new(left: value);
 
   /// Right offset only.
-  static EdgeInsetsMix right(double value) => EdgeInsetsMix(right: value);
+  static EdgeInsetsMix right(double value) => .new(right: value);
 
   /// Start offset only.
-  static EdgeInsetsDirectionalMix start(double value) =>
-      EdgeInsetsDirectionalMix(start: value);
+  static EdgeInsetsDirectionalMix start(double value) => .new(start: value);
 
   /// End offset only.
-  static EdgeInsetsDirectionalMix end(double value) =>
-      EdgeInsetsDirectionalMix(end: value);
+  static EdgeInsetsDirectionalMix end(double value) => .new(end: value);
 
   static EdgeInsetsGeometryMix? tryToMerge(
     EdgeInsetsGeometryMix? a,
@@ -290,7 +282,7 @@ final class EdgeInsetsMix extends EdgeInsetsGeometryMix<EdgeInsets>
   }
 
   @override
-  EdgeInsets get defaultValue => EdgeInsets.zero;
+  EdgeInsets get defaultValue => .zero;
 }
 
 /// Mix representation of [EdgeInsetsDirectional].

--- a/packages/mix/lib/src/properties/painting/shape_border_mix.dart
+++ b/packages/mix/lib/src/properties/painting/shape_border_mix.dart
@@ -41,23 +41,23 @@ sealed class ShapeBorderMix<T extends ShapeBorder> extends Mix<T> {
   static RoundedRectangleBorderMix roundedRectangle({
     BorderRadiusGeometryMix? borderRadius,
     BorderSideMix? side,
-  }) => RoundedRectangleBorderMix(borderRadius: borderRadius, side: side);
+  }) => .new(borderRadius: borderRadius, side: side);
 
   /// Creates a [BeveledRectangleBorder] shape.
   static BeveledRectangleBorderMix beveledRectangle({
     BorderRadiusGeometryMix? borderRadius,
     BorderSideMix? side,
-  }) => BeveledRectangleBorderMix(borderRadius: borderRadius, side: side);
+  }) => .new(borderRadius: borderRadius, side: side);
 
   /// Creates a [ContinuousRectangleBorder] shape.
   static ContinuousRectangleBorderMix continuousRectangle({
     BorderRadiusGeometryMix? borderRadius,
     BorderSideMix? side,
-  }) => ContinuousRectangleBorderMix(borderRadius: borderRadius, side: side);
+  }) => .new(borderRadius: borderRadius, side: side);
 
   /// Creates a [CircleBorder] shape.
   static CircleBorderMix circle({BorderSideMix? side, double? eccentricity}) =>
-      CircleBorderMix(side: side, eccentricity: eccentricity);
+      .new(side: side, eccentricity: eccentricity);
 
   /// Creates a [StarBorder] shape.
   static StarBorderMix star({
@@ -68,7 +68,7 @@ sealed class ShapeBorderMix<T extends ShapeBorder> extends Mix<T> {
     double? valleyRounding,
     double? rotation,
     double? squash,
-  }) => StarBorderMix(
+  }) => .new(
     side: side,
     points: points,
     innerRadiusRatio: innerRadiusRatio,
@@ -85,23 +85,16 @@ sealed class ShapeBorderMix<T extends ShapeBorder> extends Mix<T> {
     LinearBorderEdgeMix? end,
     LinearBorderEdgeMix? top,
     LinearBorderEdgeMix? bottom,
-  }) => LinearBorderMix(
-    side: side,
-    start: start,
-    end: end,
-    top: top,
-    bottom: bottom,
-  );
+  }) => .new(side: side, start: start, end: end, top: top, bottom: bottom);
 
   /// Creates a [StadiumBorder] shape.
-  static StadiumBorderMix stadium({BorderSideMix? side}) =>
-      StadiumBorderMix(side: side);
+  static StadiumBorderMix stadium({BorderSideMix? side}) => .new(side: side);
 
   /// Creates a [RoundedSuperellipseBorder] shape.
   static RoundedSuperellipseBorderMix superellipse({
     BorderRadiusGeometryMix? borderRadius,
     BorderSideMix? side,
-  }) => RoundedSuperellipseBorderMix(borderRadius: borderRadius, side: side);
+  }) => .new(borderRadius: borderRadius, side: side);
 
   /// Merges instances of the same type.
   @override

--- a/packages/mix/lib/src/providers/icon_scope.dart
+++ b/packages/mix/lib/src/providers/icon_scope.dart
@@ -7,12 +7,6 @@ import '../specs/icon/icon_style.dart';
 /// Wraps its child in an [IconTheme] with the resolved icon styling
 /// and makes the icon style available through inheritance.
 class IconScope extends StatelessWidget {
-  /// The icon style to provide to descendant widgets.
-  final IconStyler icon;
-
-  /// The widget below this widget in the tree.
-  final Widget child;
-
   const IconScope({required this.icon, required this.child, super.key});
 
   /// Gets the closest [IconStyler] from the widget tree, or null if not found.
@@ -32,6 +26,12 @@ class IconScope extends StatelessWidget {
 
     return result!;
   }
+
+  /// The icon style to provide to descendant widgets.
+  final IconStyler icon;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
@@ -59,9 +59,9 @@ class IconScope extends StatelessWidget {
 }
 
 class _IconInheritedWidget extends InheritedWidget {
-  final IconStyler icon;
-
   const _IconInheritedWidget({required this.icon, required super.child});
+
+  final IconStyler icon;
 
   @override
   bool updateShouldNotify(_IconInheritedWidget oldWidget) {

--- a/packages/mix/lib/src/providers/text_scope.dart
+++ b/packages/mix/lib/src/providers/text_scope.dart
@@ -7,12 +7,6 @@ import '../specs/text/text_style.dart';
 /// Wraps its child in a [DefaultTextStyle] with the resolved text styling
 /// and makes the text style available through inheritance.
 class TextScope extends StatelessWidget {
-  /// The text style to provide to descendant widgets.
-  final TextStyler text;
-
-  /// The widget below this widget in the tree.
-  final Widget child;
-
   const TextScope({required this.text, required this.child, super.key});
 
   /// Gets the closest [TextStyler] from the widget tree, or null if not found.
@@ -32,6 +26,12 @@ class TextScope extends StatelessWidget {
 
     return result!;
   }
+
+  /// The text style to provide to descendant widgets.
+  final TextStyler text;
+
+  /// The widget below this widget in the tree.
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
@@ -55,9 +55,9 @@ class TextScope extends StatelessWidget {
 }
 
 class _TextInheritedWidget extends InheritedWidget {
-  final TextStyler text;
-
   const _TextInheritedWidget({required this.text, required super.child});
+
+  final TextStyler text;
 
   @override
   bool updateShouldNotify(_TextInheritedWidget oldWidget) {

--- a/packages/mix/lib/src/specs/box/box_style.dart
+++ b/packages/mix/lib/src/specs/box/box_style.dart
@@ -310,14 +310,14 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
     return Box(key: key, style: this, child: child);
   }
 
-  @override
-  BoxStyler transform(Matrix4 value, {Alignment alignment = .center}) {
-    return merge(BoxStyler(transform: value, transformAlignment: alignment));
-  }
-
   /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
   /// [DefaultTextStylerModifier] (Mix inheritance).
   BoxStyler textStyle(TextStyler value) {
     return wrap(WidgetModifierConfig.defaultTextStyler(value));
+  }
+
+  @override
+  BoxStyler transform(Matrix4 value, {Alignment alignment = .center}) {
+    return merge(BoxStyler(transform: value, transformAlignment: alignment));
   }
 }

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -24,15 +24,15 @@ import 'box_style.dart';
 /// ```
 ///
 class Box extends StyleWidget<BoxSpec> {
-  /// Child widget to display inside the box.
-  final Widget? child;
-
   const Box({
     super.style = const BoxStyler.create(),
     super.styleSpec,
     super.key,
     this.child,
   });
+
+  /// Child widget to display inside the box.
+  final Widget? child;
 
   @override
   Widget build(BuildContext context, BoxSpec spec) {

--- a/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_style.dart
@@ -349,6 +349,7 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
       FlexBoxStyler().translate(x, y, z);
   factory FlexBoxStyler.skew(double skewX, double skewY) =>
       FlexBoxStyler().skew(skewX, skewY);
+
   // Box-style instance methods
 
   /// Sets the alignment property.
@@ -374,6 +375,12 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   /// Creates a FlexBox widget with children.
   FlexBox call({Key? key, required List<Widget> children}) {
     return FlexBox(key: key, style: this, children: children);
+  }
+
+  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
+  /// [DefaultTextStylerModifier] (Mix inheritance).
+  FlexBoxStyler textStyle(TextStyler value) {
+    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 
   /// Sets the animation property.
@@ -451,11 +458,5 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
   @override
   FlexBoxStyler border(BoxBorderMix value) {
     return merge(FlexBoxStyler(decoration: DecorationMix.border(value)));
-  }
-
-  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
-  /// [DefaultTextStylerModifier] (Mix inheritance).
-  FlexBoxStyler textStyle(TextStyler value) {
-    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 }

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -39,15 +39,15 @@ import 'flexbox_style.dart';
 /// ```
 ///
 class FlexBox extends StyleWidget<FlexBoxSpec> {
-  /// Child widgets to be arranged in the flex layout.
-  final List<Widget> children;
-
   const FlexBox({
     super.style = const FlexBoxStyler.create(),
     super.styleSpec,
     super.key,
     this.children = const <Widget>[],
   });
+
+  /// Child widgets to be arranged in the flex layout.
+  final List<Widget> children;
 
   /// Constrains the flex direction for RowBox/ColumnBox.
   /// When specified, prevents conflicting direction in style specs.

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -20,12 +20,6 @@ import 'icon_style.dart';
 /// )
 /// ```
 class StyledIcon extends StyleWidget<IconSpec> {
-  /// The icon to display.
-  final IconData? icon;
-
-  /// Semantic label for accessibility.
-  final String? semanticLabel;
-
   const StyledIcon({
     this.icon,
     this.semanticLabel,
@@ -33,6 +27,12 @@ class StyledIcon extends StyleWidget<IconSpec> {
     super.styleSpec,
     super.key,
   });
+
+  /// The icon to display.
+  final IconData? icon;
+
+  /// Semantic label for accessibility.
+  final String? semanticLabel;
 
   @override
   Widget build(BuildContext context, IconSpec spec) {

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -24,6 +24,17 @@ import 'image_style.dart';
 /// )
 /// ```
 class StyledImage extends StyleWidget<ImageSpec> {
+  const StyledImage({
+    super.key,
+    super.style = const ImageStyler.create(),
+    super.styleSpec,
+    this.frameBuilder,
+    this.loadingBuilder,
+    this.errorBuilder,
+    this.image,
+    this.opacity,
+  });
+
   /// The image to display.
   final ImageProvider<Object>? image;
 
@@ -38,17 +49,6 @@ class StyledImage extends StyleWidget<ImageSpec> {
 
   /// Animation for opacity changes.
   final Animation<double>? opacity;
-
-  const StyledImage({
-    super.key,
-    super.style = const ImageStyler.create(),
-    super.styleSpec,
-    this.frameBuilder,
-    this.loadingBuilder,
-    this.errorBuilder,
-    this.image,
-    this.opacity,
-  });
 
   @override
   Widget build(BuildContext context, ImageSpec spec) {

--- a/packages/mix/lib/src/specs/pressable/pressable_widget.dart
+++ b/packages/mix/lib/src/specs/pressable/pressable_widget.dart
@@ -9,25 +9,6 @@ import '../box/box_widget.dart';
 ///
 /// Provides press, long press, and focus interactions.
 class PressableBox extends StatelessWidget {
-  /// Enables audible/haptic feedback for gestures.
-  final bool enableFeedback;
-
-  /// Called when the box is pressed.
-  final VoidCallback? onPress;
-
-  /// Called when the box is long-pressed.
-  final VoidCallback? onLongPress;
-
-  final BoxStyler? style;
-
-  final Widget child;
-  final bool enabled;
-  final FocusNode? focusNode;
-  final bool autofocus;
-  final Function(bool focus)? onFocusChange;
-
-  final HitTestBehavior hitTestBehavior;
-
   const PressableBox({
     super.key,
     this.style,
@@ -42,6 +23,25 @@ class PressableBox extends StatelessWidget {
     this.hitTestBehavior = HitTestBehavior.opaque,
     this.enabled = true,
   });
+
+  /// Enables audible/haptic feedback for gestures.
+  final bool enableFeedback;
+
+  /// Called when the box is pressed.
+  final VoidCallback? onPress;
+
+  /// Called when the box is long-pressed.
+  final VoidCallback? onLongPress;
+
+  final BoxStyler? style;
+  final Widget child;
+  final bool enabled;
+  final FocusNode? focusNode;
+  final bool autofocus;
+
+  final Function(bool focus)? onFocusChange;
+
+  final HitTestBehavior hitTestBehavior;
 
   @override
   Widget build(BuildContext context) {
@@ -62,6 +62,27 @@ class PressableBox extends StatelessWidget {
 ///
 /// Manages press, hover, and focus states with configurable behavior.
 class Pressable extends StatefulWidget {
+  const Pressable({
+    super.key,
+    this.enabled = true,
+    this.enableFeedback = false,
+    this.onPress,
+    this.hitTestBehavior = HitTestBehavior.opaque,
+    this.onLongPress,
+    this.onFocusChange,
+    this.autofocus = false,
+    this.focusNode,
+    this.mouseCursor,
+    this.onKey,
+    this.canRequestFocus = true,
+    this.excludeFromSemantics = false,
+    this.semanticButtonLabel,
+    this.onKeyEvent,
+    this.controller,
+    this.actions,
+    required this.child,
+  });
+
   final Widget child;
 
   final bool enabled;
@@ -106,27 +127,6 @@ class Pressable extends StatefulWidget {
 
   final WidgetStatesController? controller;
 
-  const Pressable({
-    super.key,
-    this.enabled = true,
-    this.enableFeedback = false,
-    this.onPress,
-    this.hitTestBehavior = HitTestBehavior.opaque,
-    this.onLongPress,
-    this.onFocusChange,
-    this.autofocus = false,
-    this.focusNode,
-    this.mouseCursor,
-    this.onKey,
-    this.canRequestFocus = true,
-    this.excludeFromSemantics = false,
-    this.semanticButtonLabel,
-    this.onKeyEvent,
-    this.controller,
-    this.actions,
-    required this.child,
-  });
-
   @override
   State createState() => PressableWidgetState();
 }
@@ -134,6 +134,12 @@ class Pressable extends StatefulWidget {
 @visibleForTesting
 class PressableWidgetState extends State<Pressable> {
   late final WidgetStatesController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? WidgetStatesController();
+  }
 
   void _onTap() {
     widget.onPress?.call();
@@ -176,12 +182,6 @@ class PressableWidgetState extends State<Pressable> {
       ),
       ...?widget.actions,
     };
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = widget.controller ?? WidgetStatesController();
   }
 
   @override

--- a/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_style.dart
@@ -325,6 +325,7 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
       StackBoxStyler().translate(x, y, z);
   factory StackBoxStyler.skew(double skewX, double skewY) =>
       StackBoxStyler().skew(skewX, skewY);
+
   // Box-style instance methods
 
   /// Sets the alignment for the box.
@@ -375,6 +376,12 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
   /// Applies a custom StackStyler to the StackBox.
   StackBoxStyler stack(StackStyler value) {
     return merge(StackBoxStyler.create(stack: Prop.maybeMix(value)));
+  }
+
+  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
+  /// [DefaultTextStylerModifier] (Mix inheritance).
+  StackBoxStyler textStyle(TextStyler value) {
+    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 
   /// Sets animation
@@ -446,11 +453,5 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
   @override
   StackBoxStyler border(BoxBorderMix value) {
     return merge(StackBoxStyler(decoration: DecorationMix.border(value)));
-  }
-
-  /// Propagates the given [TextStyler] to descendant [StyledText] widgets via
-  /// [DefaultTextStylerModifier] (Mix inheritance).
-  StackBoxStyler textStyle(TextStyler value) {
-    return wrap(WidgetModifierConfig.defaultTextStyler(value));
   }
 }

--- a/packages/mix/lib/src/specs/stackbox/stackbox_widget.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_widget.dart
@@ -38,15 +38,15 @@ import 'stackbox_style.dart';
 /// )
 /// ```
 class StackBox extends StyleWidget<StackBoxSpec> {
-  /// Child widgets to be arranged in the stack layout.
-  final List<Widget> children;
-
   const StackBox({
     super.style = const StackBoxStyler.create(),
     super.styleSpec,
     super.key,
     this.children = const <Widget>[],
   });
+
+  /// Child widgets to be arranged in the stack layout.
+  final List<Widget> children;
 
   @override
   Widget build(BuildContext context, StackBoxSpec spec) {

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -24,9 +24,6 @@ import 'text_style.dart';
 /// )
 /// ```
 class StyledText extends StyleWidget<TextSpec> {
-  /// The text to display.
-  final String text;
-
   /// Creates a [StyledText] with required [text] and optional [style] or [spec].
   const StyledText(
     this.text, {
@@ -34,6 +31,9 @@ class StyledText extends StyleWidget<TextSpec> {
     super.styleSpec,
     super.key,
   });
+
+  /// The text to display.
+  final String text;
 
   @override
   Widget build(BuildContext context, TextSpec spec) {

--- a/packages/mix/lib/src/theme/mix_theme.dart
+++ b/packages/mix/lib/src/theme/mix_theme.dart
@@ -12,10 +12,6 @@ import 'tokens/value_tokens.dart';
 /// Exposes type-safe design tokens, modifier ordering, and token resolution.
 /// Uses [InheritedModel] with aspects: `tokens` and `modifierOrder`.
 class MixScope extends InheritedModel<String> {
-  final List<Type>? orderOfModifiers;
-
-  final Map<MixToken, Object>? _tokens;
-
   /// Creates a [MixScope] with the provided tokens and modifier ordering.
   factory MixScope({
     Map<MixToken, Object>? tokens,
@@ -167,6 +163,10 @@ class MixScope extends InheritedModel<String> {
       child: child,
     );
   }
+
+  final List<Type>? orderOfModifiers;
+
+  final Map<MixToken, Object>? _tokens;
 
   /// Returns the raw token map provided to this scope.
   Map<MixToken, Object>? get tokens => _tokens;

--- a/packages/mix/lib/src/variants/variant.dart
+++ b/packages/mix/lib/src/variants/variant.dart
@@ -216,8 +216,8 @@ mixin EnumVariant on Enum implements NamedVariant {
   String get name => _EnumName(this).name;
 }
 
-extension type _EnumName(Enum value) {
-  String get name => value.name;
+extension type const _EnumName(Enum _value) implements Enum {
+  String get name => _value.name;
 }
 
 // Common named variants

--- a/packages/mix/scripts/exports.dart
+++ b/packages/mix/scripts/exports.dart
@@ -56,10 +56,8 @@ bool _isDartFile(String path) {
   return path.endsWith('.dart');
 }
 
-String _joinPaths(String path1, String path2, [String? path3, String? path4]) {
-  final paths = [path1, path2, path3, path4];
-
-  return paths.where((e) => e != null).join(Platform.pathSeparator);
+String _joinPaths(String path1, String path2) {
+  return [path1, path2].join(Platform.pathSeparator);
 }
 
 String _getRelativePath(String filePath, String fromPath) {

--- a/packages/mix_annotations/lib/src/annotations.dart
+++ b/packages/mix_annotations/lib/src/annotations.dart
@@ -65,7 +65,7 @@ class MixableField {
   final bool ignoreSetter;
 
   /// Optional type override for the setter parameter.
-  /// If not specified, the type is inferred from the field's Prop<T> type argument.
+  /// If not specified, the type is inferred from the field's `Prop<T>` type argument.
   final Type? setterType;
 
   const MixableField({this.ignoreSetter = false, this.setterType});

--- a/packages/mix_generator/lib/src/core/models/mix_field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/mix_field_model.dart
@@ -56,7 +56,10 @@ class MixFieldModel {
 
     // Check if wrapped in Prop<>
     final wrappedInProp = type_helpers.isWrappedInProp(type);
-    final innerTypeName = type_helpers.getInnerTypeName(type, wrappedInProp);
+    final innerTypeName = type_helpers.getInnerTypeName(
+      type,
+      isWrapped: wrappedInProp,
+    );
 
     return MixFieldModel(
       name: name,

--- a/packages/mix_generator/lib/src/core/models/styler_field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/styler_field_model.dart
@@ -93,7 +93,10 @@ class StylerFieldModel {
 
     // Check if wrapped in Prop<>
     final wrappedInProp = type_helpers.isWrappedInProp(type);
-    final innerTypeName = type_helpers.getInnerTypeName(type, wrappedInProp);
+    final innerTypeName = type_helpers.getInnerTypeName(
+      type,
+      isWrapped: wrappedInProp,
+    );
 
     // Check if raw list
     final isRawList = rawListTypes.containsKey(name);

--- a/packages/mix_generator/lib/src/core/models/type_helpers.dart
+++ b/packages/mix_generator/lib/src/core/models/type_helpers.dart
@@ -19,7 +19,7 @@ bool isWrappedInProp(DartType type) {
   return type.element.name == 'Prop';
 }
 
-String getInnerTypeName(DartType type, bool isWrapped) {
+String getInnerTypeName(DartType type, {required bool isWrapped}) {
   if (!isWrapped) {
     return getBaseTypeName(type);
   }


### PR DESCRIPTION
## Summary

Pure housekeeping pass to silence existing `dart analyze` + `dcm analyze --fatal-style --fatal-warnings` warnings across the workspace. No behavior changes, no `analysis_options.yaml` edits, no public API changes.

- Mass-applied `dcm fix --unsafe` (member-ordering, dot-shorthand rewrites) and `dart format` across all packages.
- Hand-fixed the handful of items the auto-fixers couldn't:
  - `shape_border_merge.dart` — replaced wildcard `_ =>` with explicit `OutlinedBorderMix()` case in sealed-class switch (exhaustiveness; unreachable in practice because callers gate on `_isRectangleVariant`).
  - `transform_modifier.dart` — dropped stale `// ignore: avoid-incomplete-copy-with`.
  - `variant.dart` — renamed private extension-type representation field `value` → `_value` on `_EnumName`.
  - `scripts/exports.dart` — removed never-passed `path3`/`path4` params from `_joinPaths`.
  - `mix_annotations/annotations.dart` — backtick-wrapped `Prop<T>` in docstring.
  - `mix_generator/type_helpers.dart` (+ 2 callers) — converted positional `bool isWrapped` to `{required bool isWrapped}`.
- `style.dart` — dropped `$context` interpolation from a `FlutterError` message (diagnostic text only).

## Test plan

- [x] `melos run analyze` → SUCCESS (dart analyze + DCM)
- [x] `packages/mix` `flutter test` → 2693 passed
- [x] `packages/mix_generator` `dart test` → 174 passed
- [x] `packages/mix_tailwinds` `flutter test` → 322 passed
- [x] `dart fix --apply` and `dcm fix --unsafe` are idempotent (no further changes)