### PR TITLE
fix(mix): drop TextDecorationRef so mix builds on newer Flutter SDKs

### DIFF
--- a/lints.yaml
+++ b/lints.yaml
@@ -1,9 +1,7 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  exclude: 
-  enable-experiment:
-    - dot-shorthands
+  exclude:
 linter:
   rules:
     # TODO: Turn this to true when all public apis are documented 

--- a/lints_with_dcm.yaml
+++ b/lints_with_dcm.yaml
@@ -1,9 +1,5 @@
 include: lints.yaml
 
-analyzer:
-  enable-experiment:
-    - dot-shorthands
-
 dart_code_metrics:
   extends:
     - package:dart_code_metrics_presets/recommended.yaml

--- a/packages/mix/analysis_options.yaml
+++ b/packages/mix/analysis_options.yaml
@@ -3,5 +3,3 @@ include: ../../lints_with_dcm.yaml
 analyzer:
   errors:
     prefer_const_constructors: ignore
-  enable-experiment:
-    - dot-shorthands

--- a/packages/mix/lib/src/core/prop_refs.dart
+++ b/packages/mix/lib/src/core/prop_refs.dart
@@ -45,13 +45,6 @@ final class FontWeightRef extends Prop<FontWeight>
   FontWeightRef(super.prop) : super.fromProp();
 }
 
-/// Token reference for [TextDecoration] values
-final class TextDecorationRef extends Prop<TextDecoration>
-    with ValueRef<TextDecoration>
-    implements TextDecoration {
-  TextDecorationRef(super.prop) : super.fromProp();
-}
-
 /// Token reference for [Offset] values
 final class OffsetRef extends Prop<Offset>
     with ValueRef<Offset>
@@ -314,7 +307,6 @@ void assertIsRealType(Type value) {
 
     // Text types
     == TextStyleRef => TextStyle,
-    == TextDecorationRef => TextDecoration,
     == StrutStyleRef => StrutStyle,
     == TextHeightBehaviorRef => TextHeightBehavior,
     == TextScalerRef => TextScaler,

--- a/packages/mix/test/src/core/assert_is_real_type_test.dart
+++ b/packages/mix/test/src/core/assert_is_real_type_test.dart
@@ -367,19 +367,6 @@ void main() {
         );
       });
 
-      test('should assert when TextDecorationRef is passed', () {
-        expect(
-          () => assertIsRealType(TextDecorationRef),
-          throwsA(
-            isA<AssertionError>().having(
-              (e) => e.message,
-              'message',
-              'Cannot use TextDecorationRef for generic, use TextDecoration instead.',
-            ),
-          ),
-        );
-      });
-
       test('should assert when StrutStyleRef is passed', () {
         expect(
           () => assertIsRealType(StrutStyleRef),


### PR DESCRIPTION
#### Related issue

No tracked issue — work started from a build failure when consuming `mix` on a newer Flutter SDK. Follow-up tracking issue for the broader cleanup: #915.

### Description

This PR bundles two small, related changes (one commit each).

**1. Fix the build failure on newer Flutter SDKs (`c68d3093`)**

Flutter's `dart:ui` recently marked `TextDecoration` as a `final class` (part of an engine-wide class-modifiers pass — `Paint` and `GlyphInfo` got the same treatment). A `final` class cannot be implemented outside its own library, so `TextDecorationRef`, which declared `implements TextDecoration`, fails to compile on those SDKs:

```
lib/src/core/prop_refs.dart:51:16: Error: The class 'TextDecoration'
can't be implemented outside of its library because it's a final class.
```

`TextDecorationRef` was also dead code: `getReferenceValue` never instantiates it, and without `implements TextDecoration` it cannot serve as a token reference. So it (and its `assertIsRealType` case + test) is removed outright.

**2. Drop the redundant `dot-shorthands` experiment flag (`a5c1819`)**

`dot-shorthands` is stable under the repo's Dart `>=3.11.0` constraint. Dart 3.12's analyzer (Flutter 3.44.0) now warns on the stale `enable-experiment` entry, which fails CI under `fatal-warnings: true`. Removed from `lints.yaml`, `lints_with_dcm.yaml`, and `packages/mix/analysis_options.yaml`.

### Scope note

Auditing `TextDecorationRef` revealed that **many other `*Ref` classes** in `prop_refs.dart` and `token_refs.dart` are also dead code (never instantiated by `getReferenceValue`, no matching `MixToken<T>`). Cleaning them all up is intentionally **out of scope for this PR** — it's worth a design discussion rather than a drive-by deletion, since some types could plausibly be wired up to real `MixToken` subclasses instead.

Tracked separately in #915.

### Changes

- **`packages/mix/lib/src/core/prop_refs.dart`**: removed `TextDecorationRef`.
- **`packages/mix/test/src/core/assert_is_real_type_test.dart`**: removed the `TextDecorationRef` test case.
- **`lints.yaml`, `lints_with_dcm.yaml`, `packages/mix/analysis_options.yaml`**: dropped the `dot-shorthands` `enable-experiment` entry.

**Review Checklist**

- [x] **Testing**: `flutter analyze` clean; remaining `assertIsRealType` tests pass.
- [x] **Breaking Changes**: `TextDecorationRef` was exported from `mix.dart`, so removal is technically breaking. In practice it was never instantiated (no `MixToken<TextDecoration>`, no `getReferenceValue` branch) and could not be constructed meaningfully by consumers.
- [ ] **Documentation Updates**: N/A — no docs reference `TextDecorationRef`.
- [ ] **Website Updates**: N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)