### PR TITLE
feat(mix): add MixScope.inherit for merging with the ancestor scope

### DIFF
--- a/packages/mix/doc/mix-scope-and-theming.md
+++ b/packages/mix/doc/mix-scope-and-theming.md
@@ -149,7 +149,7 @@ MixScope(
 
 ## Combining/Overriding Scopes
 
-You can merge scopes or create nested scopes to override subsets of tokens for parts of the tree.
+You can merge several explicit scopes into one with `MixScope.combine`:
 
 ```dart
 final base = MixScope(
@@ -168,19 +168,31 @@ final combined = MixScope.combine(
 );
 ```
 
-Or simply nest a child scope where needed:
+### Overriding part of the tree with `MixScope.inherit`
+
+To override a subset of tokens for a feature or screen, use `MixScope.inherit`.
+It reads the nearest ancestor `MixScope` and merges the provided values on top
+of it — the same pattern as `DefaultTextStyle.merge` / `IconTheme.merge`:
 
 ```dart
 MixScope(
-  colors: { ColorToken('brand.primary'): Colors.blue },
+  colors: {
+    ColorToken('brand.primary'): Colors.blue,
+    ColorToken('brand.surface'): Colors.white,
+  },
   child: FeatureShell(
-    child: MixScope(
+    // Inherits brand.surface, overrides only brand.primary.
+    child: MixScope.inherit(
       colors: { ColorToken('brand.primary'): Colors.green },
       child: FeatureWidget(),
     ),
   ),
 )
 ```
+
+> **Note:** Nesting a plain `MixScope` does **not** merge — it fully shadows the
+> ancestor, so any token not redefined in the inner scope becomes unresolvable.
+> Use `MixScope.inherit` whenever you only want to override a subset of tokens.
 
 ## Hands‑On Tutorial
 
@@ -244,7 +256,7 @@ void main() {
 - Prefer semantic token names, e.g., `brand.primary`, `layout.content.padding`
 - Keep tokens type-safe using the provided token classes (ColorToken, SpaceToken, DoubleToken, RadiusToken, TextStyleToken, BreakpointToken, ShadowToken, BoxShadowToken, BorderSideToken, FontWeightToken)
 - Centralize token declarations for discoverability
-- Use nested scopes for feature- or screen-level overrides
+- Use `MixScope.inherit` for feature- or screen-level overrides so inherited tokens are preserved
 - Leverage `withMaterial` when you want automatic alignment with Material Theme
 
 ## Troubleshooting

--- a/packages/mix/lib/src/theme/mix_theme.dart
+++ b/packages/mix/lib/src/theme/mix_theme.dart
@@ -164,6 +164,69 @@ class MixScope extends InheritedModel<String> {
     );
   }
 
+  /// Creates a [MixScope] that inherits from the nearest ancestor [MixScope]
+  /// and merges the provided values on top of it.
+  ///
+  /// Mirrors the [DefaultTextStyle.merge] pattern: values passed here take
+  /// precedence, and anything omitted falls back to the ancestor scope.
+  ///
+  /// Use this for feature- or screen-level overrides. Unlike nesting a plain
+  /// [MixScope] — which fully shadows the ancestor, leaving non-overridden
+  /// tokens unresolvable — this keeps the inherited tokens intact.
+  ///
+  /// ```dart
+  /// MixScope.inherit(
+  ///   colors: {ColorToken('brand.primary'): Colors.green},
+  ///   child: FeatureWidget(),
+  /// )
+  /// ```
+  ///
+  /// Returns a [Widget] rather than a [MixScope] because it wraps a [Builder]
+  /// to obtain a [BuildContext] below the ancestor scope. For that reason it
+  /// is a static method, not a factory constructor.
+  ///
+  /// If no ancestor [MixScope] exists, this behaves like a plain [MixScope].
+  static Widget inherit({
+    Map<MixToken, Object>? tokens,
+    Map<ColorToken, Color>? colors,
+    Map<TextStyleToken, TextStyle>? textStyles,
+    Map<SpaceToken, double>? spaces,
+    Map<DoubleToken, double>? doubles,
+    Map<RadiusToken, Radius>? radii,
+    Map<BreakpointToken, Breakpoint>? breakpoints,
+    Map<ShadowToken, List<Shadow>>? shadows,
+    Map<BoxShadowToken, List<BoxShadow>>? boxShadows,
+    Map<BorderSideToken, BorderSide>? borders,
+    Map<FontWeightToken, FontWeight>? fontWeights,
+    List<Type>? orderOfModifiers,
+    required Widget child,
+    Key? key,
+  }) {
+    return Builder(
+      builder: (BuildContext context) {
+        final MixScope? parent = MixScope.maybeOf(context);
+        final MixScope scope = MixScope(
+          key: key,
+          tokens: tokens,
+          colors: colors,
+          textStyles: textStyles,
+          spaces: spaces,
+          doubles: doubles,
+          radii: radii,
+          breakpoints: breakpoints,
+          shadows: shadows,
+          boxShadows: boxShadows,
+          borders: borders,
+          fontWeights: fontWeights,
+          orderOfModifiers: orderOfModifiers,
+          child: child,
+        );
+
+        return parent == null ? scope : parent.merge(scope);
+      },
+    );
+  }
+
   final List<Type>? orderOfModifiers;
 
   final Map<MixToken, Object>? _tokens;
@@ -188,6 +251,9 @@ class MixScope extends InheritedModel<String> {
   }
 
   /// Returns a new [MixScope] by merging this scope with [other].
+  ///
+  /// Token maps are combined with [other] taking precedence; [other]'s
+  /// [orderOfModifiers], [key], and [child] win when provided.
   MixScope merge(MixScope other) {
     final mergedTokens = _tokens != null || other._tokens != null
         ? <MixToken, Object>{...?_tokens, ...?other._tokens}

--- a/packages/mix/test/src/theme/mix_scope_test.dart
+++ b/packages/mix/test/src/theme/mix_scope_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+/// Tests for [MixScope.inherit], which inherits the nearest ancestor [MixScope]
+/// and merges the provided values on top of it (the `DefaultTextStyle.merge`
+/// pattern).
+void main() {
+  group('MixScope.inherit', () {
+    const primary = ColorToken('brand.primary');
+    const surface = ColorToken('brand.surface');
+
+    testWidgets('inherits ancestor tokens that are not overridden', (
+      tester,
+    ) async {
+      late Color resolvedPrimary;
+      late Color resolvedSurface;
+
+      await tester.pumpWidget(
+        MixScope(
+          colors: {primary: Colors.blue, surface: Colors.white},
+          child: MixScope.inherit(
+            colors: {primary: Colors.green},
+            child: Builder(
+              builder: (context) {
+                resolvedPrimary = MixScope.tokenOf(primary, context);
+                resolvedSurface = MixScope.tokenOf(surface, context);
+
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedPrimary, Colors.green); // overridden by merge
+      expect(resolvedSurface, Colors.white); // inherited from ancestor
+    });
+
+    testWidgets('behaves like a plain MixScope when no ancestor exists', (
+      tester,
+    ) async {
+      late Color resolvedPrimary;
+
+      await tester.pumpWidget(
+        MixScope.inherit(
+          colors: {primary: Colors.green},
+          child: Builder(
+            builder: (context) {
+              resolvedPrimary = MixScope.tokenOf(primary, context);
+
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(resolvedPrimary, Colors.green);
+    });
+
+    testWidgets('orderOfModifiers falls back to the ancestor when omitted', (
+      tester,
+    ) async {
+      const ancestorOrder = <Type>[OpacityModifier, PaddingModifier];
+      late List<Type>? resolvedOrder;
+
+      await tester.pumpWidget(
+        MixScope(
+          orderOfModifiers: ancestorOrder,
+          child: MixScope.inherit(
+            colors: {primary: Colors.green},
+            child: Builder(
+              builder: (context) {
+                resolvedOrder = MixScope.of(context).orderOfModifiers;
+
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedOrder, ancestorOrder);
+    });
+
+    testWidgets('orderOfModifiers overrides the ancestor when provided', (
+      tester,
+    ) async {
+      const mergeOrder = <Type>[PaddingModifier, OpacityModifier];
+      late List<Type>? resolvedOrder;
+
+      await tester.pumpWidget(
+        MixScope(
+          orderOfModifiers: const [OpacityModifier, PaddingModifier],
+          child: MixScope.inherit(
+            orderOfModifiers: mergeOrder,
+            child: Builder(
+              builder: (context) {
+                resolvedOrder = MixScope.of(context).orderOfModifiers;
+
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(resolvedOrder, mergeOrder);
+    });
+
+    testWidgets('renders a token-driven Box using merged + inherited tokens', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MixScope(
+          colors: {primary: Colors.blue, surface: Colors.white},
+          child: MixScope.inherit(
+            colors: {primary: Colors.green},
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Box(style: BoxStyler().color(primary())),
+            ),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration! as BoxDecoration;
+      expect(decoration.color, Colors.green);
+    });
+  });
+}


### PR DESCRIPTION
#### Related issue

No related open issue.

### Description

Adds a `MixScope.inherit` static method following the `DefaultTextStyle.merge` / `IconTheme.merge` pattern: it reads the nearest ancestor `MixScope` and merges the provided values on top, so inherited tokens and modifier ordering are preserved. Previously, nesting a plain `MixScope` fully shadowed the ancestor, leaving any non-overridden token unresolvable — `MixScope.inherit` is the correct way to override a subset of tokens for a feature or screen. It is a static method (not a factory constructor) because it must return a `Builder` to obtain a `BuildContext` positioned below the ancestor scope.

### Changes

- Add `MixScope.inherit` static method to `packages/mix/lib/src/theme/mix_theme.dart`.
- Add `packages/mix/test/src/theme/mix_scope_test.dart` covering inheritance, override precedence, no-ancestor fallback, `orderOfModifiers` fallback/override, and a token-driven `Box` render.
- Update `mix-scope-and-theming.md` to document `MixScope.inherit` and correct the misleading guidance that nesting a plain `MixScope` merges with its ancestor.

**Review Checklist**

- [x] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [x] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users? — No; it only adds a new method.
- [x] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

`orderOfModifiers` uses last-write-wins (whole-list replacement, no element merge), consistent with the existing `MixScope.merge`/`MixScope.combine` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)