### PR TITLE
docs(mix): update changelog for 2.0.3 release

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.0.3
+
+This release adds finer-grained control over scope inheritance and theming, and restores compatibility with newer Flutter SDKs.
+
+### New features
+
+- **`MixScope.inherit`:** Opt into merging with the nearest ancestor `MixScope` instead of replacing it, so nested scopes can extend tokens and breakpoints without re-declaring them (#914).
+- **`ColorRef` directive overrides:** Non-deprecated `Color` methods on `ColorRef` (e.g. `withValues`) are now overridden to return a ref carrying a directive, keeping color tokens unresolved until rendering (#908).
+
+### Fixes
+
+- **Flutter SDK compatibility:** Removed `TextDecorationRef` so Mix builds against newer Flutter SDKs where `TextDecoration` is no longer extendable (#913).
+
 ## 2.0.2
 
 This release completes the 2.0 Styler migration by removing the remaining legacy utility surface, and adds new ergonomic shorthands and variant tooling.


### PR DESCRIPTION
#### Related issue

N/A

### Description

Adds a `2.0.3` section to `packages/mix/CHANGELOG.md` covering the four mix-package changes merged since the 2.0.2 release.

### Changes

- New features: `MixScope.inherit` (#914), `ColorRef` directive overrides for non-deprecated `Color` methods (#908).
- Fixes: dropped `TextDecorationRef` for newer Flutter SDK compatibility (#913).

**Review Checklist**

- [ ] **Testing**: Have you tested your changes, including unit tests and integration tests for affected code?
- [ ] **Breaking Changes**: Does this change introduce breaking changes affecting existing code or users?
- [ ] **Documentation Updates**: Are all relevant documentation files (e.g. README, API docs) updated to reflect the changes in this PR?
- [ ] **Website Updates**: Is the website containing the updates you make on documentation?

### Additional Information (optional)

Docs-only change; analyze/DCM chore (#912) was omitted as not user-facing.