### PR TITLE
chore(mix): default StyleWidget to IdentityStyle<Spec>

### DIFF
--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -64,26 +64,6 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     return provider?.style;
   }
 
-  /// Merges [other] into [current] while treating [IdentityStyle] as a no-op.
-  ///
-  /// This preserves the normal [merge] precedence where [other] wins, without
-  /// passing an [IdentityStyle] into generated styler merge methods.
-  @internal
-  static Style<S> mergeStyles<S extends Spec<S>>(
-    Style<S>? current,
-    Style<S> other,
-  ) {
-    if (current == null || current is IdentityStyle<S>) {
-      return other;
-    }
-
-    if (other is IdentityStyle<S>) {
-      return current;
-    }
-
-    return current.merge(other);
-  }
-
   @internal
   Set<WidgetState> get widgetStates {
     return ($variants ?? [])
@@ -172,7 +152,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
               context,
               namedVariants: namedVariants,
             );
-      mergedStyle = Style.mergeStyles(mergedStyle, fullyResolvedStyle);
+      mergedStyle = _mergeStyles(mergedStyle, fullyResolvedStyle);
     }
 
     return mergedStyle;
@@ -204,6 +184,18 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
 
     return styleData.resolve(context);
   }
+}
+
+Style<S> _mergeStyles<S extends Spec<S>>(Style<S> current, Style<S> other) {
+  if (current is IdentityStyle<S>) {
+    return other;
+  }
+
+  if (other is IdentityStyle<S>) {
+    return current;
+  }
+
+  return current.merge(other);
 }
 
 /// A no-op [Style] that resolves to a provided [Spec].
@@ -288,7 +280,7 @@ final class VariantStyle<S extends Spec<S>> extends Mixable<StyleSpec<S>>
       );
     }
 
-    return VariantStyle(variant, Style.mergeStyles(_style, other._style));
+    return VariantStyle(variant, _mergeStyles(_style, other._style));
   }
 
   @override

--- a/packages/mix/lib/src/core/style.dart
+++ b/packages/mix/lib/src/core/style.dart
@@ -64,6 +64,26 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
     return provider?.style;
   }
 
+  /// Merges [other] into [current] while treating [IdentityStyle] as a no-op.
+  ///
+  /// This preserves the normal [merge] precedence where [other] wins, without
+  /// passing an [IdentityStyle] into generated styler merge methods.
+  @internal
+  static Style<S> mergeStyles<S extends Spec<S>>(
+    Style<S>? current,
+    Style<S> other,
+  ) {
+    if (current == null || current is IdentityStyle<S>) {
+      return other;
+    }
+
+    if (other is IdentityStyle<S>) {
+      return current;
+    }
+
+    return current.merge(other);
+  }
+
   @internal
   Set<WidgetState> get widgetStates {
     return ($variants ?? [])
@@ -152,7 +172,7 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
               context,
               namedVariants: namedVariants,
             );
-      mergedStyle = mergedStyle.merge(fullyResolvedStyle);
+      mergedStyle = Style.mergeStyles(mergedStyle, fullyResolvedStyle);
     }
 
     return mergedStyle;
@@ -184,6 +204,39 @@ abstract class Style<S extends Spec<S>> extends Mix<StyleSpec<S>>
 
     return styleData.resolve(context);
   }
+}
+
+/// A no-op [Style] that resolves to a provided [Spec].
+///
+/// This is useful for widget defaults where a concrete generated styler should
+/// not be required just to identify the default resolved spec.
+final class IdentityStyle<S extends Spec<S>> extends Style<S>
+    with Diagnosticable {
+  /// The spec used when this identity style is resolved.
+  final S spec;
+
+  /// Creates an identity style that resolves to [spec].
+  const IdentityStyle(this.spec)
+    : super(variants: null, modifier: null, animation: null);
+
+  @override
+  Style<S> merge(covariant Style<S>? other) {
+    return other ?? this;
+  }
+
+  @override
+  StyleSpec<S> resolve(BuildContext context) {
+    return StyleSpec(spec: spec);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<S>('spec', spec));
+  }
+
+  @override
+  List<Object?> get props => [spec];
 }
 
 abstract class ModifierMix<S extends WidgetModifier<S>> extends Mix<S>
@@ -235,7 +288,7 @@ final class VariantStyle<S extends Spec<S>> extends Mixable<StyleSpec<S>>
       );
     }
 
-    return VariantStyle(variant, _style.merge(other._style));
+    return VariantStyle(variant, Style.mergeStyles(_style, other._style));
   }
 
   @override

--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -89,7 +89,7 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
   Style<S> _buildStyle(BuildContext context) {
     final inheritedStyle = Style.maybeOf<S>(context);
 
-    return inheritedStyle?.merge(widget.style) ?? widget.style;
+    return Style.mergeStyles(inheritedStyle, widget.style);
   }
 
   @override

--- a/packages/mix/lib/src/core/style_builder.dart
+++ b/packages/mix/lib/src/core/style_builder.dart
@@ -88,8 +88,17 @@ class _StyleBuilderState<S extends Spec<S>> extends State<StyleBuilder<S>>
 
   Style<S> _buildStyle(BuildContext context) {
     final inheritedStyle = Style.maybeOf<S>(context);
+    final style = widget.style;
 
-    return Style.mergeStyles(inheritedStyle, widget.style);
+    if (inheritedStyle == null || inheritedStyle is IdentityStyle<S>) {
+      return style;
+    }
+
+    if (style is IdentityStyle<S>) {
+      return inheritedStyle;
+    }
+
+    return inheritedStyle.merge(style);
   }
 
   @override

--- a/packages/mix/lib/src/specs/box/box_widget.dart
+++ b/packages/mix/lib/src/specs/box/box_widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/widgets.dart';
 
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import 'box_spec.dart';
-import 'box_style.dart';
 
 /// [Box] is equivalent to Flutter's [Container], it provides
 /// styling capabilities through the Mix framework. It can be used to
@@ -10,7 +10,7 @@ import 'box_style.dart';
 /// and constraints.
 ///
 ///
-/// You can use [BoxStyler] to create styles with a fluent API. Example:
+/// You can use `BoxStyler` to create styles with a fluent API. Example:
 ///
 /// ```dart
 /// final style = BoxStyler()
@@ -25,7 +25,7 @@ import 'box_style.dart';
 ///
 class Box extends StyleWidget<BoxSpec> {
   const Box({
-    super.style = const BoxStyler.create(),
+    super.style = const IdentityStyle(BoxSpec()),
     super.styleSpec,
     super.key,
     this.child,

--- a/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_widget.dart
@@ -2,11 +2,11 @@
 
 import 'package:flutter/widgets.dart';
 
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import '../box/box_widget.dart';
 import '../flex/flex_spec.dart';
 import 'flexbox_spec.dart';
-import 'flexbox_style.dart';
 
 /// [FlexBox] combines Flutter's [Container] and [Flex] widgets with Mix styling.
 ///
@@ -16,7 +16,7 @@ import 'flexbox_style.dart';
 ///
 /// For specific layouts, use [RowBox] for horizontal layouts or [ColumnBox] for vertical layouts.
 ///
-/// You can use [FlexBoxStyler] to create styles with a fluent API. Example:
+/// You can use `FlexBoxStyler` to create styles with a fluent API. Example:
 ///
 /// ```dart
 /// final style = FlexBoxStyler()
@@ -40,7 +40,7 @@ import 'flexbox_style.dart';
 ///
 class FlexBox extends StyleWidget<FlexBoxSpec> {
   const FlexBox({
-    super.style = const FlexBoxStyler.create(),
+    super.style = const IdentityStyle(FlexBoxSpec()),
     super.styleSpec,
     super.key,
     this.children = const <Widget>[],

--- a/packages/mix/lib/src/specs/icon/icon_widget.dart
+++ b/packages/mix/lib/src/specs/icon/icon_widget.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import 'icon_spec.dart';
-import 'icon_style.dart';
 
 /// `StyledIcon` is equivalent to Flutter's `Icon` widget, but provides styling capabilities through the Mix framework.
 /// It allows you to create visually styled icons with color, size, shadows, and responsive variants.
@@ -23,7 +23,7 @@ class StyledIcon extends StyleWidget<IconSpec> {
   const StyledIcon({
     this.icon,
     this.semanticLabel,
-    super.style = const IconStyler.create(),
+    super.style = const IdentityStyle(IconSpec()),
     super.styleSpec,
     super.key,
   });

--- a/packages/mix/lib/src/specs/image/image_widget.dart
+++ b/packages/mix/lib/src/specs/image/image_widget.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/widgets.dart';
 
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import 'image_spec.dart';
-import 'image_style.dart';
 
 /// [StyledImage] is equivalent to Flutter's [Image] widget, but provides styling
 /// capabilities through the Mix framework. It allows you to create visually styled
 /// images with dimensions, colors, blend modes, filters, and responsive variants.
 ///
-/// You can use [ImageStyler] to create styles with a fluent API. Example:
+/// You can use `ImageStyler` to create styles with a fluent API. Example:
 ///
 /// ```dart
 /// final style = ImageStyler()
@@ -26,7 +26,7 @@ import 'image_style.dart';
 class StyledImage extends StyleWidget<ImageSpec> {
   const StyledImage({
     super.key,
-    super.style = const ImageStyler.create(),
+    super.style = const IdentityStyle(ImageSpec()),
     super.styleSpec,
     this.frameBuilder,
     this.loadingBuilder,

--- a/packages/mix/lib/src/specs/pressable/pressable_widget.dart
+++ b/packages/mix/lib/src/specs/pressable/pressable_widget.dart
@@ -43,6 +43,8 @@ class PressableBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final style = this.style;
+
     return Pressable(
       enabled: enabled,
       onPress: onPress,
@@ -51,7 +53,9 @@ class PressableBox extends StatelessWidget {
       onFocusChange: onFocusChange,
       autofocus: autofocus,
       focusNode: focusNode,
-      child: Box(style: style ?? const BoxStyler.create(), child: child),
+      child: style == null
+          ? Box(child: child)
+          : Box(style: style, child: child),
     );
   }
 }

--- a/packages/mix/lib/src/specs/stackbox/stackbox_widget.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_widget.dart
@@ -2,17 +2,17 @@
 
 import 'package:flutter/widgets.dart';
 
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import '../box/box_widget.dart';
 import '../stack/stack_spec.dart';
 import 'stackbox_spec.dart';
-import 'stackbox_style.dart';
 
 /// [StackBox] is equivalent to Flutter's [Stack] and [Container] widgets combined, but provides powerful styling capabilities through the Mix framework.
 ///
 /// [StackBox] enables you to create stacked layouts with visual styles such as decoration, padding, margin, constraints, and box/stack behaviors—all customizable and responsive.
 ///
-/// You can use the [StackBoxStyler] API to fluently compose your layout and decoration styles. Example:
+/// You can use the `StackBoxStyler` API to fluently compose your layout and decoration styles. Example:
 ///
 /// ```dart
 /// final style = StackBoxStyler()
@@ -39,7 +39,7 @@ import 'stackbox_style.dart';
 /// ```
 class StackBox extends StyleWidget<StackBoxSpec> {
   const StackBox({
-    super.style = const StackBoxStyler.create(),
+    super.style = const IdentityStyle(StackBoxSpec()),
     super.styleSpec,
     super.key,
     this.children = const <Widget>[],

--- a/packages/mix/lib/src/specs/text/text_widget.dart
+++ b/packages/mix/lib/src/specs/text/text_widget.dart
@@ -1,16 +1,16 @@
 import 'package:flutter/material.dart';
 
 import '../../core/directive.dart';
+import '../../core/style.dart';
 import '../../core/style_widget.dart';
 import 'text_spec.dart';
-import 'text_style.dart';
 
 /// [StyledText] is equivalent to Flutter's [Text] widget, but provides
 /// styling capabilities through the Mix framework. It allows you to create
 /// visually styled text with typography, colors, decorations, text
 /// transformations, and responsive variants.
 ///
-/// You can use [TextStyler] to create styles with a fluent API. Example:
+/// You can use `TextStyler` to create styles with a fluent API. Example:
 ///
 /// ```dart
 /// final style = TextStyler()
@@ -27,7 +27,7 @@ class StyledText extends StyleWidget<TextSpec> {
   /// Creates a [StyledText] with required [text] and optional [style] or [spec].
   const StyledText(
     this.text, {
-    super.style = const TextStyler.create(),
+    super.style = const IdentityStyle(TextSpec()),
     super.styleSpec,
     super.key,
   });

--- a/packages/mix/test/src/core/identity_style_test.dart
+++ b/packages/mix/test/src/core/identity_style_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+import '../../helpers/testing_utils.dart';
+
+void main() {
+  group('IdentityStyle', () {
+    test('resolves to the provided spec without metadata', () {
+      const spec = BoxSpec();
+      const style = IdentityStyle<BoxSpec>(spec);
+
+      final resolved = style.resolve(MockBuildContext());
+
+      expect(resolved, const StyleSpec<BoxSpec>(spec: spec));
+      expect(resolved.animation, isNull);
+      expect(resolved.widgetModifiers, isNull);
+    });
+
+    test('merge returns itself when other style is null', () {
+      const style = IdentityStyle<BoxSpec>(BoxSpec());
+
+      expect(style.merge(null), same(style));
+    });
+
+    test('merge returns other style when provided', () {
+      const style = IdentityStyle<BoxSpec>(BoxSpec());
+      final other = BoxStyler().color(Colors.red);
+
+      expect(style.merge(other), same(other));
+    });
+
+    testWidgets('preserves inherited style when used as a child style', (
+      tester,
+    ) async {
+      final parentStyle = BoxStyler().color(Colors.red);
+      const childStyle = IdentityStyle<BoxSpec>(BoxSpec());
+
+      late BoxSpec childSpec;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StyleBuilder<BoxSpec>(
+            style: parentStyle,
+            inheritable: true,
+            builder: (context, spec) {
+              return StyleBuilder<BoxSpec>(
+                style: childStyle,
+                builder: (context, spec) {
+                  childSpec = spec;
+
+                  return const SizedBox();
+                },
+              );
+            },
+          ),
+        ),
+      );
+
+      expect((childSpec.decoration as BoxDecoration?)?.color, Colors.red);
+    });
+
+    test('is ignored when merged into an existing VariantStyle', () {
+      final style = BoxStyler().color(Colors.red);
+      final variant = VariantStyle<BoxSpec>(const NamedVariant('test'), style);
+      const identityVariant = VariantStyle<BoxSpec>(
+        NamedVariant('test'),
+        IdentityStyle<BoxSpec>(BoxSpec()),
+      );
+
+      final merged = variant.merge(identityVariant);
+
+      expect(merged.value, same(style));
+    });
+
+    test('is ignored when active as a variant style', () {
+      final style = BoxStyler(
+        decoration: DecorationMix.color(Colors.red),
+        variants: const [
+          VariantStyle<BoxSpec>(
+            NamedVariant('test'),
+            IdentityStyle<BoxSpec>(BoxSpec()),
+          ),
+        ],
+      );
+
+      final resolved = style.build(
+        MockBuildContext(),
+        namedVariants: {const NamedVariant('test')},
+      );
+
+      expect((resolved.spec.decoration as BoxDecoration?)?.color, Colors.red);
+    });
+
+    test('supports value equality by spec', () {
+      const first = IdentityStyle<BoxSpec>(BoxSpec());
+      const second = IdentityStyle<BoxSpec>(BoxSpec());
+
+      expect(first, second);
+    });
+  });
+}

--- a/packages/mix/test/src/core/style_widget_default_style_test.dart
+++ b/packages/mix/test/src/core/style_widget_default_style_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+void main() {
+  group('StyleWidget default style', () {
+    test('uses IdentityStyle with the concrete default spec', () {
+      expectIdentityStyle(const Box().style, const BoxSpec());
+      expectIdentityStyle(const StyledText('').style, const TextSpec());
+      expectIdentityStyle(const StyledIcon().style, const IconSpec());
+      expectIdentityStyle(const StyledImage().style, const ImageSpec());
+      expectIdentityStyle(const FlexBox().style, const FlexBoxSpec());
+      expectIdentityStyle(const RowBox().style, const FlexBoxSpec());
+      expectIdentityStyle(const ColumnBox().style, const FlexBoxSpec());
+      expectIdentityStyle(const StackBox().style, const StackBoxSpec());
+    });
+
+    test('preserves explicit concrete widget styles', () {
+      final boxStyle = BoxStyler().width(100);
+      final textStyle = TextStyler().fontSize(16);
+      final iconStyle = IconStyler().size(24);
+      final imageStyle = ImageStyler().width(200);
+      final flexBoxStyle = FlexBoxStyler().direction(Axis.vertical);
+      final stackBoxStyle = StackBoxStyler().fit(StackFit.expand);
+
+      expect(Box(style: boxStyle).style, same(boxStyle));
+      expect(StyledText('', style: textStyle).style, same(textStyle));
+      expect(StyledIcon(style: iconStyle).style, same(iconStyle));
+      expect(StyledImage(style: imageStyle).style, same(imageStyle));
+      expect(FlexBox(style: flexBoxStyle).style, same(flexBoxStyle));
+      expect(RowBox(style: flexBoxStyle).style, same(flexBoxStyle));
+      expect(ColumnBox(style: flexBoxStyle).style, same(flexBoxStyle));
+      expect(StackBox(style: stackBoxStyle).style, same(stackBoxStyle));
+    });
+
+    testWidgets('default Box inherits parent style', (tester) async {
+      const boxKey = Key('box');
+      final parentStyle = BoxStyler().width(120).height(80).color(Colors.green);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StyleBuilder<BoxSpec>(
+            style: parentStyle,
+            inheritable: true,
+            builder: (context, spec) => const Box(key: boxKey),
+          ),
+        ),
+      );
+
+      final styledContainer = tester.widget<Container>(
+        find.descendant(
+          of: find.byKey(boxKey),
+          matching: find.byType(Container),
+        ),
+      );
+
+      expect(styledContainer.constraints?.minWidth, 120);
+      expect(styledContainer.constraints?.maxWidth, 120);
+      expect(styledContainer.constraints?.minHeight, 80);
+      expect(styledContainer.constraints?.maxHeight, 80);
+      expect(
+        (styledContainer.decoration as BoxDecoration?)?.color,
+        Colors.green,
+      );
+    });
+  });
+}
+
+void expectIdentityStyle<S extends Spec<S>>(Style<S> style, S spec) {
+  expect(
+    style,
+    isA<IdentityStyle<S>>().having((style) => style.spec, 'spec', spec),
+  );
+}


### PR DESCRIPTION
## Summary
- Default `style` on every `StyleWidget<S>` (`Box`, `StyledIcon`, `FlexBox`, `StyledImage`, `Pressable`, `StackBox`, `StyledText`) is now `const IdentityStyle<S>(const S())` instead of the concrete `*Styler.create()`.
- Widget files no longer import their companion `*_style.dart`; they depend only on the `Spec` and the generic plumbing in `core/style.dart`.
- Supporting tweaks in `core/style.dart` and `core/style_builder.dart`; new tests in `test/src/core/identity_style_test.dart` and `style_widget_default_style_test.dart`.

## Motivation
Removing the widget → custom-Styler dependency is a prerequisite for code-generating widget files from the `Spec` alone. With this in place, the generator does not need to know which `*Styler` subclass exists for each spec.

## Test plan
- [x] `melos run gen:build`
- [x] `melos run ci` (test:flutter + test:dart — all green)
- [ ] `melos run analyze` — `mix` package is clean (`No issues found!`). `mix_tailwinds` reports pre-existing issues identical to `origin/main` (3777, unrelated to this branch).
- [x] Confirmed no `Styler.create()` remains as a widget-level default under `packages/mix/lib/src/specs/**/*_widget.dart`.