### PR TITLE
chore(mix_tailwinds): enable shared lints and fix analyze warnings

### DIFF
--- a/packages/mix_tailwinds/analysis_options.yaml
+++ b/packages/mix_tailwinds/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../lints_with_dcm.yaml

--- a/packages/mix_tailwinds/lib/mix_tailwinds.dart
+++ b/packages/mix_tailwinds/lib/mix_tailwinds.dart
@@ -1,4 +1,4 @@
-library mix_tailwinds;
+library;
 
 export 'src/tw_config.dart';
 export 'src/tw_parser.dart';

--- a/packages/mix_tailwinds/lib/src/tw_config.dart
+++ b/packages/mix_tailwinds/lib/src/tw_config.dart
@@ -143,8 +143,8 @@ class TwConfig {
     required Map<String, double> scales,
     required Map<String, double> rotations,
     required Map<String, double> blurs,
-    TwTextDefaults textDefaults = const TwTextDefaults.tailwindSans(),
-    TwGradientStrategy gradientStrategy = TwGradientStrategy.cssAngleRect,
+    this.textDefaults = const TwTextDefaults.tailwindSans(),
+    this.gradientStrategy = TwGradientStrategy.cssAngleRect,
   }) : space = Map.unmodifiable(space),
        radii = Map.unmodifiable(radii),
        borderWidths = Map.unmodifiable(borderWidths),
@@ -155,9 +155,7 @@ class TwConfig {
        delays = Map.unmodifiable(delays),
        scales = Map.unmodifiable(scales),
        rotations = Map.unmodifiable(rotations),
-       blurs = Map.unmodifiable(blurs),
-       textDefaults = textDefaults,
-       gradientStrategy = gradientStrategy;
+       blurs = Map.unmodifiable(blurs);
 
   final Map<String, double> space;
   final Map<String, double> radii;

--- a/packages/mix_tailwinds/lib/src/tw_parser.dart
+++ b/packages/mix_tailwinds/lib/src/tw_parser.dart
@@ -185,11 +185,7 @@ class _GradientAccum {
 
   LinearGradientMix? toGradientMix(TwGradientStrategy strategy) {
     if (!hasGradient) return null;
-    final colors = <Color>[
-      fromColor!,
-      ?viaColor,
-      toColor ?? fromColor!,
-    ];
+    final colors = <Color>[fromColor!, ?viaColor, toColor ?? fromColor!];
     // Tailwind anchors via-* at 50% by default; without explicit stops
     // Flutter interpolates linearly which doesn't match Tailwind's behavior
     final stops = viaColor != null ? const [0.0, 0.5, 1.0] : const [0.0, 1.0];

--- a/packages/mix_tailwinds/lib/src/tw_parser.dart
+++ b/packages/mix_tailwinds/lib/src/tw_parser.dart
@@ -187,7 +187,7 @@ class _GradientAccum {
     if (!hasGradient) return null;
     final colors = <Color>[
       fromColor!,
-      if (viaColor != null) viaColor!,
+      ?viaColor,
       toColor ?? fromColor!,
     ];
     // Tailwind anchors via-* at 50% by default; without explicit stops

--- a/packages/mix_tailwinds/lib/src/tw_utils.dart
+++ b/packages/mix_tailwinds/lib/src/tw_utils.dart
@@ -1,4 +1,5 @@
 /// Shared helpers for Tailwind token parsing.
+library;
 
 /// Finds the first colon that's not inside square brackets.
 ///


### PR DESCRIPTION
## Summary

- `packages/mix_tailwinds` was the only workspace package without an `analysis_options.yaml`, so `dart analyze` was running on Dart's built-in defaults and silently reported no issues. Added the file (single-line `include: ../../lints_with_dcm.yaml`, matching `mix_annotations`).
- Fixed the 5 info-level warnings that surface once the shared lints are applied:
  - `unnecessary_library_name` in `lib/mix_tailwinds.dart`
  - `dangling_library_doc_comments` in `lib/src/tw_utils.dart`
  - `use_null_aware_elements` in `lib/src/tw_parser.dart`
  - `prefer_initializing_formals` x2 in `lib/src/tw_config.dart` (`textDefaults`, `gradientStrategy` moved to `this.x` form)
- `example/` was already clean.

Out of scope (follow-up): adding `dart_code_metrics_presets` to `mix_tailwinds` dev deps so `melos run analyze:dcm` covers it (currently filtered by `dependsOn`).

## Test plan

- [x] `dart analyze packages/mix_tailwinds packages/mix_tailwinds/example` → `No issues found!`
- [x] `flutter test` in `packages/mix_tailwinds` → 322 tests pass
- [x] `flutter test` in `packages/mix_tailwinds/example` → 7 tests pass (golden + smoke)