### PR TITLE
fix(mix): apply variants when resolving nested styles

### DIFF
--- a/packages/mix/lib/src/core/prop.dart
+++ b/packages/mix/lib/src/core/prop.dart
@@ -9,6 +9,7 @@ import 'directive.dart';
 import 'helpers.dart';
 import 'mix_element.dart';
 import 'prop_source.dart';
+import 'style.dart';
 
 /// A property that can hold values, tokens, or Mix types.
 ///
@@ -269,7 +270,18 @@ class Prop<V> {
         for (int i = 1; i < mixValues.length; i++) {
           mergedMix = PropOps.mergeMixes(context, mergedMix, mixValues[i]);
         }
-        resolvedValue = mergedMix.resolve(context);
+        // A [Style] nested inside another [Style]'s [Prop] (e.g. a component
+        // sub-style) carries its own context variants — widget states
+        // (hovered/pressed/disabled), brightness, breakpoints, etc. Those are
+        // applied by [Style.build], not by [Style.resolve], so resolving a
+        // nested style directly would silently drop them. Build styles instead
+        // so their variants resolve against the current context.
+        //
+        // Named variants are not propagated here (build uses the default empty
+        // set), matching how the top-level StyleBuilder builds styles.
+        resolvedValue = mergedMix is Style
+            ? (mergedMix as Style).build(context) as V
+            : mergedMix.resolve(context);
       }
     } else {
       // Simple values - use last one (replacement strategy)

--- a/packages/mix/test/src/core/nested_style_variant_test.dart
+++ b/packages/mix/test/src/core/nested_style_variant_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mix/mix.dart';
+
+/// Regression test for nested-style variant resolution.
+///
+/// A [Style] stored inside another [Style]'s [Prop] (a "sub-style", e.g.
+/// `FlexBoxStyler`'s nested box) carries its own context variants. Those are
+/// applied by [Style.build], not [Style.resolve]. Previously `Prop.resolveProp`
+/// resolved nested styles via `resolve()`, silently dropping their variants.
+/// See https://github.com/btwld/remix/issues/59.
+void main() {
+  group('Nested style prop variant resolution', () {
+    BoxDecoration? boxDecorationOf(FlexBoxSpec spec) =>
+        spec.box?.spec.decoration as BoxDecoration?;
+
+    testWidgets('applies a nested style prop\'s widget-state variant', (
+      tester,
+    ) async {
+      final controller = WidgetStatesController();
+      addTearDown(controller.dispose);
+
+      // The hover variant lives on the NESTED box style, while the top-level
+      // FlexBoxStyler has no widget-state variants of its own.
+      final style = FlexBoxStyler.create(
+        box: Prop.maybeMix(
+          BoxStyler()
+              .color(Colors.blue)
+              .onHovered(BoxStyler().color(Colors.red)),
+        ),
+      );
+
+      Color? boxColor;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StyleBuilder<FlexBoxSpec>(
+              style: style,
+              controller: controller,
+              builder: (context, spec) {
+                boxColor = boxDecorationOf(spec)?.color;
+
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      // Base state resolves to the nested style's base color.
+      expect(boxColor, Colors.blue);
+
+      // Toggling the widget state must activate the nested style's variant.
+      controller.update(WidgetState.hovered, true);
+      await tester.pumpAndSettle();
+      expect(boxColor, Colors.red);
+
+      controller.update(WidgetState.hovered, false);
+      await tester.pumpAndSettle();
+      expect(boxColor, Colors.blue);
+    });
+
+    testWidgets('nested style without variants resolves unchanged', (
+      tester,
+    ) async {
+      final controller = WidgetStatesController();
+      addTearDown(controller.dispose);
+
+      final style = FlexBoxStyler.create(
+        box: Prop.maybeMix(BoxStyler().color(Colors.green)),
+      );
+
+      Color? boxColor;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StyleBuilder<FlexBoxSpec>(
+              style: style,
+              controller: controller,
+              builder: (context, spec) {
+                boxColor = boxDecorationOf(spec)?.color;
+
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(boxColor, Colors.green);
+
+      controller.update(WidgetState.hovered, true);
+      await tester.pumpAndSettle();
+      expect(boxColor, Colors.green);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

A `Style` stored inside another `Style`'s `Prop` — i.e. a component **sub-style** — silently drops its own variants.

`Prop.resolveProp()` merges the `MixSource` values and then resolves them with `mergedMix.resolve(context)`. For a `Style`, `resolve()` only resolves props; it does **not** apply variants. Context variants (widget states `hovered`/`pressed`/`disabled`/`focused`, `brightness`, breakpoints, platform, …) are applied solely by `Style.build()` (`mergeActiveVariants(...)` → `resolve(...)`). The top-level style goes through `StyleBuilder` → `style.build(context)`, but every **nested** style prop went through `resolve()` — so its variants were quietly ignored.

This is what makes `btwld/remix#59` fail:

```dart
RemixSelectStyle().trigger(
  RemixSelectTriggerStyle()
    .onHovered(RemixSelectTriggerStyle().labelColor(Colors.red)) // never applied
)
```

The trigger style is stored as a nested `Prop<StyleSpec<RemixSelectTriggerSpec>>`, so `.onHovered` / `.onDisabled` had no effect. (Dropdown *items* worked only because each is built through its own `StyleBuilder` + controller.)

## Fix

Build nested styles instead of resolving them, so their context variants resolve against the current context:

```dart
resolvedValue = mergedMix is Style
    ? (mergedMix as Style).build(context) as V
    : mergedMix.resolve(context);
```

- **No-op for nested styles without variants** — `mergeActiveVariants` returns the style unchanged, then resolves identically to before. The blast radius is exactly "nested styles that carry variants."
- Only `Style` has `build()`; every other `Mix` (e.g. `ModifierMix`, `DecorationMix`, `ShapeBorderMix`) stays on the original `resolve()` path via the type guard.
- Type-safe: when `mergedMix` is a `Style<S>`, the prop's `V` is `StyleSpec<S>`, which is exactly what `build()` returns.

## Verification

- ✅ Full `mix` test suite: **2716/2716** pass with the change.
- ✅ New regression test `test/src/core/nested_style_variant_test.dart` is red/green-proven (fails without the fix, passes with it).
- ✅ Downstream `remix` full suite: **1742/1742** pass — issue #59 is fixed with **no remix-side code change**.

## Known boundary (follow-up, not addressed here)

`StyleBuilder` decides whether to auto-install a `WidgetStateProvider` from the **top-level** style's `widgetStates` only (it doesn't recurse into nested props). So a nested-only widget-state variant activates only when a state scope already exists (e.g. a component that passes a `controller`, as remix's `Select` does). Making `Style.widgetStates` recurse into nested style props is a larger, separate change worth a dedicated issue.

Fixes btwld/remix#59

🤖 Generated with [Claude Code](https://claude.com/claude-code)