### PR TITLE
fix(mix): fall back to previous animation config on null transition

### DIFF
--- a/packages/mix/lib/src/animation/style_animation_builder.dart
+++ b/packages/mix/lib/src/animation/style_animation_builder.dart
@@ -96,7 +96,7 @@ class _StyleAnimationBuilderState<S extends Spec<S>>
     } else {
       animationDriver.dispose();
       animationDriver = _createAnimationDriver(
-        config: config,
+        config: config ?? oldConfig,
         initialSpec: oldWidget.spec,
       );
     }

--- a/packages/mix/test/src/animation/style_animation_builder_test.dart
+++ b/packages/mix/test/src/animation/style_animation_builder_test.dart
@@ -294,9 +294,75 @@ void main() {
 
       // Should update immediately (no animation)
       await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('test-container')), findsOneWidget);
     });
+
+    testWidgets(
+      'animates with previous config when transitioning to null animation',
+      (tester) async {
+        const curveConfig = CurveAnimationConfig(
+          duration: Duration(milliseconds: 200),
+          curve: Curves.linear,
+        );
+
+        const specWithAnimation = StyleSpec<TestSpec>(
+          spec: TestSpec(color: Colors.red),
+          animation: curveConfig,
+        );
+        const specWithoutAnimation = StyleSpec<TestSpec>(
+          spec: TestSpec(color: Colors.blue),
+          animation: null,
+        );
+
+        Color? capturedColor;
+
+        Widget buildSubject(StyleSpec<TestSpec> spec) {
+          return MaterialApp(
+            home: StyleAnimationBuilder<TestSpec>(
+              spec: spec,
+              builder: (context, resolved) {
+                capturedColor = resolved.spec.color;
+
+                return Container(color: resolved.spec.color);
+              },
+            ),
+          );
+        }
+
+        // Start with the animated spec and let it settle on red.
+        await tester.pumpWidget(buildSubject(specWithAnimation));
+        await tester.pumpAndSettle();
+
+        expect(capturedColor, Colors.red);
+
+        // Switch to a spec with a null animation config. The builder should
+        // fall back to the previous config and keep animating instead of
+        // jumping straight to the new target value.
+        await tester.pumpWidget(buildSubject(specWithoutAnimation));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(
+          capturedColor,
+          isNot(Colors.red),
+          reason: 'animation should have progressed past the start value',
+        );
+        expect(
+          capturedColor,
+          isNot(Colors.blue),
+          reason:
+              'animation should not have jumped to the target value instantly',
+        );
+
+        // After the previous config's duration completes, the spec lands
+        // on the new target.
+        await tester.pumpAndSettle();
+
+        expect(capturedColor, Colors.blue);
+      },
+    );
 
     testWidgets('handles null animation value gracefully', (tester) async {
       // Create spec with animation that produces null value


### PR DESCRIPTION
## Summary
- `StyleAnimationBuilder.didUpdateWidget` now passes `config ?? oldConfig` when (re)creating the driver, so a spec transition from an animated config to `animation: null` keeps animating with the previous config instead of jumping straight to the new value via a `NoAnimationDriver`.
- Added a widget test that captures the resolved color on every rebuild and asserts the value is neither the start nor the end mid-flight when switching from a `CurveAnimationConfig(red)` to `animation: null` (blue), then lands on blue once settled.

## Test plan
- [x] `fvm flutter test test/src/animation/style_animation_builder_test.dart` — all 10 tests pass.
- [x] Reverted the fix locally and reran the new test — it fails, confirming it actually exercises the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)