### PR TITLE
fix(mix): tween Matrix4 against identity when one endpoint is null

### DIFF
--- a/packages/mix/lib/src/core/helpers.dart
+++ b/packages/mix/lib/src/core/helpers.dart
@@ -174,9 +174,12 @@ List<WidgetModifier>? _lerpModifierList(
 }
 
 Matrix4? _lerpMatrix4(Matrix4? a, Matrix4? b, double t) {
-  if (a == null || b == null) return _lerpSnap(a, b, t);
+  if (a == null && b == null) return null;
 
-  return Matrix4Tween(begin: a, end: b).lerp(t);
+  return Matrix4Tween(
+    begin: a ?? Matrix4.identity(),
+    end: b ?? Matrix4.identity(),
+  ).lerp(t);
 }
 
 T? _lerpValue<T>(T? a, T? b, double t) {
@@ -249,7 +252,7 @@ T? _lerpValue<T>(T? a, T? b, double t) {
     // Theme data
     (IconThemeData? a, IconThemeData? b) => IconThemeData.lerp(a, b, t) as T?,
 
-    // Matrix4 - animate real matrix pairs, snap nullable endpoints
+    // Matrix4 - animate using identity as the implicit endpoint when null
     (Matrix4? a, Matrix4? b) => _lerpMatrix4(a, b, t) as T?,
 
     // List of Modifiers - use ModifierListTween for proper lerping

--- a/packages/mix/test/src/specs/box/box_spec_test.dart
+++ b/packages/mix/test/src/specs/box/box_spec_test.dart
@@ -257,20 +257,29 @@ void main() {
         // Matrix4 lerp is handled by MixOps.lerp
       });
 
-      test('snaps transform when one endpoint is null', () {
+      test('treats null transform as identity when only one endpoint is set', () {
+        // Issue #927: previously this case snapped at t=0.5, so e.g. a hover
+        // variant adding .scale(1.1) on a base style with no transform would
+        // jump rather than tween. Treat the missing endpoint as identity so
+        // the matrix interpolates from / to the real one.
         final transform = Matrix4.translationValues(10.0, 20.0, 0.0);
         final withTransform = BoxSpec(transform: transform);
         const withoutTransform = BoxSpec();
 
-        final fadeOutBefore = withTransform.lerp(withoutTransform, 0.4);
-        final fadeOutAfter = withTransform.lerp(withoutTransform, 0.6);
-        final fadeInBefore = withoutTransform.lerp(withTransform, 0.4);
-        final fadeInAfter = withoutTransform.lerp(withTransform, 0.6);
+        Matrix4 expectedAt(Matrix4 a, Matrix4 b, double t) =>
+            Matrix4Tween(begin: a, end: b).lerp(t);
 
-        expect(fadeOutBefore.transform, same(transform));
-        expect(fadeOutAfter.transform, isNull);
-        expect(fadeInBefore.transform, isNull);
-        expect(fadeInAfter.transform, same(transform));
+        final fadeOut = withTransform.lerp(withoutTransform, 0.4);
+        final fadeIn = withoutTransform.lerp(withTransform, 0.4);
+
+        expect(
+          fadeOut.transform,
+          expectedAt(transform, Matrix4.identity(), 0.4),
+        );
+        expect(
+          fadeIn.transform,
+          expectedAt(Matrix4.identity(), transform, 0.4),
+        );
       });
     });
 

--- a/packages/mix/test/src/specs/box/box_spec_test.dart
+++ b/packages/mix/test/src/specs/box/box_spec_test.dart
@@ -257,30 +257,33 @@ void main() {
         // Matrix4 lerp is handled by MixOps.lerp
       });
 
-      test('treats null transform as identity when only one endpoint is set', () {
-        // Issue #927: previously this case snapped at t=0.5, so e.g. a hover
-        // variant adding .scale(1.1) on a base style with no transform would
-        // jump rather than tween. Treat the missing endpoint as identity so
-        // the matrix interpolates from / to the real one.
-        final transform = Matrix4.translationValues(10.0, 20.0, 0.0);
-        final withTransform = BoxSpec(transform: transform);
-        const withoutTransform = BoxSpec();
+      test(
+        'treats null transform as identity when only one endpoint is set',
+        () {
+          // Issue #927: previously this case snapped at t=0.5, so e.g. a hover
+          // variant adding .scale(1.1) on a base style with no transform would
+          // jump rather than tween. Treat the missing endpoint as identity so
+          // the matrix interpolates from / to the real one.
+          final transform = Matrix4.translationValues(10.0, 20.0, 0.0);
+          final withTransform = BoxSpec(transform: transform);
+          const withoutTransform = BoxSpec();
 
-        Matrix4 expectedAt(Matrix4 a, Matrix4 b, double t) =>
-            Matrix4Tween(begin: a, end: b).lerp(t);
+          Matrix4 expectedAt(Matrix4 a, Matrix4 b, double t) =>
+              Matrix4Tween(begin: a, end: b).lerp(t);
 
-        final fadeOut = withTransform.lerp(withoutTransform, 0.4);
-        final fadeIn = withoutTransform.lerp(withTransform, 0.4);
+          final fadeOut = withTransform.lerp(withoutTransform, 0.4);
+          final fadeIn = withoutTransform.lerp(withTransform, 0.4);
 
-        expect(
-          fadeOut.transform,
-          expectedAt(transform, Matrix4.identity(), 0.4),
-        );
-        expect(
-          fadeIn.transform,
-          expectedAt(Matrix4.identity(), transform, 0.4),
-        );
-      });
+          expect(
+            fadeOut.transform,
+            expectedAt(transform, Matrix4.identity(), 0.4),
+          );
+          expect(
+            fadeIn.transform,
+            expectedAt(Matrix4.identity(), transform, 0.4),
+          );
+        },
+      );
     });
 
     group('equality', () {


### PR DESCRIPTION
## Summary
  - Fixes #927 — `.onHovered(.scale(1.1)).animate(.easeInOut(...))` jumped instead of tweening because `BoxSpec.lerp` snapped
  the `transform` field whenever one endpoint was null (base style has no transform → variant's Matrix4 became the only
  non-null side → `_lerpSnap` returned a step at t=0.5).
  - Treats the missing endpoint as `Matrix4.identity()` so the matrix interpolates against the real one — same semantics
  Flutter's own `Matrix4Tween` uses.

  ## Test plan
  - New / updated regression in `packages/mix/test/src/specs/box/box_spec_test.dart` — asserts `BoxSpec.lerp` interpolates
  against `Matrix4.identity()` on both fade-in and fade-out (replaces the old "snaps transform" assertion that locked in the
  bug).
  - Verified against the reporter's pattern: `Box` with `.onHovered(BoxStyler.scale(1.1)).animate(.easeInOut(400.ms))` — at
  t=200ms the scale is now mid-tween, not 1.1.
  - Full `flutter test` for `packages/mix` (2719 tests) green.
  - `dart analyze` clean for touched files.