### PR TITLE
fix(mix): accept *ListMix on shadow styler methods so token refs work

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Fixes
+
+- **Box / text shadow tokens through styler methods:** `BoxStyler.boxShadows`, `BoxStyler.shadows`, `FlexBoxStyler.shadows`, `StackBoxStyler.shadows`, and `TextStyler.shadows` now accept the `BoxShadowListMix` / `ShadowListMix` wrapper so design-token references (`BoxShadowToken('x').mix()`, `ShadowToken('y').mix()`) can be passed directly (#925).
+
+### Breaking changes
+
+- **Shadow styler methods now take a Mix wrapper instead of a raw list.** Update call sites that pass a literal list to wrap it: `BoxStyler().boxShadows([s1, s2])` → `BoxStyler().boxShadows(BoxShadowListMix([s1, s2]))`. The same applies to `.shadows(...)` on `BoxStyler` / `FlexBoxStyler` / `StackBoxStyler` and to `TextStyler.shadows(...)`.
+
 ## 2.0.3
 
 This release adds finer-grained control over scope inheritance and theming, and restores compatibility with newer Flutter SDKs.

--- a/packages/mix/lib/src/specs/box/box_spec.g.dart
+++ b/packages/mix/lib/src/specs/box/box_spec.g.dart
@@ -233,7 +233,7 @@ class BoxStyler extends MixStyler<BoxStyler, BoxSpec>
   factory BoxStyler.elevation(ElevationShadow value) =>
       BoxStyler().elevation(value);
   factory BoxStyler.shadow(BoxShadowMix value) => BoxStyler().shadow(value);
-  factory BoxStyler.shadows(List<BoxShadowMix> value) =>
+  factory BoxStyler.shadows(BoxShadowListMix value) =>
       BoxStyler().shadows(value);
   factory BoxStyler.width(double value) => BoxStyler().width(value);
   factory BoxStyler.height(double value) => BoxStyler().height(value);

--- a/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/flexbox/flexbox_spec.g.dart
@@ -170,7 +170,7 @@ class FlexBoxStyler extends MixStyler<FlexBoxStyler, FlexBoxSpec>
       FlexBoxStyler().elevation(value);
   factory FlexBoxStyler.shadow(BoxShadowMix value) =>
       FlexBoxStyler().shadow(value);
-  factory FlexBoxStyler.shadows(List<BoxShadowMix> value) =>
+  factory FlexBoxStyler.shadows(BoxShadowListMix value) =>
       FlexBoxStyler().shadows(value);
   factory FlexBoxStyler.width(double value) => FlexBoxStyler().width(value);
   factory FlexBoxStyler.height(double value) => FlexBoxStyler().height(value);

--- a/packages/mix/lib/src/specs/stackbox/stackbox_spec.g.dart
+++ b/packages/mix/lib/src/specs/stackbox/stackbox_spec.g.dart
@@ -162,7 +162,7 @@ class StackBoxStyler extends MixStyler<StackBoxStyler, StackBoxSpec>
       StackBoxStyler().elevation(value);
   factory StackBoxStyler.shadow(BoxShadowMix value) =>
       StackBoxStyler().shadow(value);
-  factory StackBoxStyler.shadows(List<BoxShadowMix> value) =>
+  factory StackBoxStyler.shadows(BoxShadowListMix value) =>
       StackBoxStyler().shadows(value);
   factory StackBoxStyler.width(double value) => StackBoxStyler().width(value);
   factory StackBoxStyler.height(double value) => StackBoxStyler().height(value);

--- a/packages/mix/lib/src/specs/text/text_spec.g.dart
+++ b/packages/mix/lib/src/specs/text/text_spec.g.dart
@@ -309,7 +309,7 @@ class TextStyler extends MixStyler<TextStyler, TextSpec>
   factory TextStyler.fontFamilyFallback(List<String> value) =>
       TextStyler().fontFamilyFallback(value);
   factory TextStyler.shadow(ShadowMix value) => TextStyler().shadow(value);
-  factory TextStyler.shadows(List<ShadowMix> value) =>
+  factory TextStyler.shadows(ShadowListMix value) =>
       TextStyler().shadows(value);
   factory TextStyler.fontFeatures(List<FontFeature> value) =>
       TextStyler().fontFeatures(value);

--- a/packages/mix/lib/src/style/mixins/decoration_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/decoration_style_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../core/mix_element.dart';
+import '../../core/prop.dart';
 import '../../properties/painting/border_mix.dart';
 import '../../properties/painting/border_radius_mix.dart';
 import '../../properties/painting/decoration_image_mix.dart';
@@ -39,9 +40,13 @@ mixin DecorationStyleMixin<T extends Mix<Object?>> {
     return decoration(BoxDecorationMix.boxShadow([value]));
   }
 
-  /// Sets multiple shadows
-  T shadows(List<BoxShadowMix> value) {
-    return decoration(BoxDecorationMix.boxShadow(value));
+  /// Sets multiple shadows.
+  ///
+  /// Accepts a [BoxShadowListMix] so that both literal lists
+  /// (`BoxShadowListMix([shadow1, shadow2])`) and design-token references
+  /// (`boxShadowToken.mix()`) can be passed.
+  T shadows(BoxShadowListMix value) {
+    return decoration(BoxDecorationMix.create(boxShadow: Prop.mix(value)));
   }
 
   /// Sets elevation shadow

--- a/packages/mix/lib/src/style/mixins/shadow_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/shadow_style_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/mix_element.dart';
+import '../../core/prop.dart';
 import '../../properties/painting/decoration_mix.dart';
 import '../../properties/painting/shadow_mix.dart';
 
@@ -26,9 +27,13 @@ mixin ShadowStyleMixin<T extends Mix<Object?>> {
     return decoration(BoxDecorationMix.boxShadow([shadow]));
   }
 
-  /// Creates multiple box shadows from a list of BoxShadowMix
-  T boxShadows(List<BoxShadowMix> value) {
-    return decoration(BoxDecorationMix.boxShadow(value));
+  /// Sets multiple box shadows.
+  ///
+  /// Accepts a [BoxShadowListMix] so that both literal lists
+  /// (`BoxShadowListMix([shadow1, shadow2])`) and design-token references
+  /// (`boxShadowToken.mix()`) can be passed.
+  T boxShadows(BoxShadowListMix value) {
+    return decoration(BoxDecorationMix.create(boxShadow: Prop.mix(value)));
   }
 
   /// Creates box shadows from Material Design elevation level

--- a/packages/mix/lib/src/style/mixins/text_style_mixin.dart
+++ b/packages/mix/lib/src/style/mixins/text_style_mixin.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../core/mix_element.dart';
+import '../../core/prop.dart';
 import '../../properties/painting/shadow_mix.dart';
 import '../../properties/typography/text_style_mix.dart';
 
@@ -84,9 +85,13 @@ mixin TextStyleMixin<T extends Mix<Object?>> {
     return style(TextStyleMix.fontFamilyFallback(value));
   }
 
-  /// Sets text shadows
-  T shadows(List<ShadowMix> value) {
-    return style(TextStyleMix.shadows(value));
+  /// Sets text shadows.
+  ///
+  /// Accepts a [ShadowListMix] so that both literal lists
+  /// (`ShadowListMix([shadow1, shadow2])`) and design-token references
+  /// (`shadowToken.mix()`) can be passed.
+  T shadows(ShadowListMix value) {
+    return style(TextStyleMix.create(shadows: Prop.mix(value)));
   }
 
   /// Sets a single text shadow.

--- a/packages/mix/test/src/specs/box/box_style_factory_test.dart
+++ b/packages/mix/test/src/specs/box/box_style_factory_test.dart
@@ -120,10 +120,10 @@ void main() {
       });
 
       test('shadows', () {
-        final s = [
+        final s = BoxShadowListMix([
           BoxShadowMix(color: Colors.black, blurRadius: 10),
           BoxShadowMix(color: Colors.grey, blurRadius: 5),
-        ];
+        ]);
         expect(BoxStyler.shadows(s), equals(BoxStyler().shadows(s)));
       });
 

--- a/packages/mix/test/src/specs/box/box_style_test.dart
+++ b/packages/mix/test/src/specs/box/box_style_test.dart
@@ -251,10 +251,10 @@ void main() {
       });
 
       test('shadows method sets multiple shadows', () {
-        final shadows = [
+        final shadows = BoxShadowListMix([
           BoxShadowMix(color: Colors.black, blurRadius: 5.0),
           BoxShadowMix(color: Colors.grey, blurRadius: 10.0),
-        ];
+        ]);
         final boxMix = BoxStyler().shadows(shadows);
 
         expect(boxMix.$decoration, isNotNull);

--- a/packages/mix/test/src/specs/flexbox/flexbox_style_factory_test.dart
+++ b/packages/mix/test/src/specs/flexbox/flexbox_style_factory_test.dart
@@ -168,10 +168,10 @@ void main() {
       });
 
       test('shadows', () {
-        final s = [
+        final s = BoxShadowListMix([
           BoxShadowMix(color: Colors.black, blurRadius: 10),
           BoxShadowMix(color: Colors.grey, blurRadius: 5),
-        ];
+        ]);
         expect(FlexBoxStyler.shadows(s), equals(FlexBoxStyler().shadows(s)));
       });
 

--- a/packages/mix/test/src/specs/stackbox/stackbox_style_factory_test.dart
+++ b/packages/mix/test/src/specs/stackbox/stackbox_style_factory_test.dart
@@ -144,10 +144,10 @@ void main() {
       });
 
       test('shadows', () {
-        final s = [
+        final s = BoxShadowListMix([
           BoxShadowMix(color: Colors.black, blurRadius: 10),
           BoxShadowMix(color: Colors.grey, blurRadius: 5),
-        ];
+        ]);
         expect(StackBoxStyler.shadows(s), equals(StackBoxStyler().shadows(s)));
       });
 

--- a/packages/mix/test/src/specs/text/text_style_factory_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_factory_test.dart
@@ -200,7 +200,7 @@ void main() {
       });
 
       test('shadows', () {
-        final s = [ShadowMix(color: Colors.black, blurRadius: 4)];
+        final s = ShadowListMix([ShadowMix(color: Colors.black, blurRadius: 4)]);
         expect(TextStyler.shadows(s), equals(TextStyler().shadows(s)));
       });
 

--- a/packages/mix/test/src/specs/text/text_style_factory_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_factory_test.dart
@@ -200,7 +200,9 @@ void main() {
       });
 
       test('shadows', () {
-        final s = ShadowListMix([ShadowMix(color: Colors.black, blurRadius: 4)]);
+        final s = ShadowListMix([
+          ShadowMix(color: Colors.black, blurRadius: 4),
+        ]);
         expect(TextStyler.shadows(s), equals(TextStyler().shadows(s)));
       });
 

--- a/packages/mix/test/src/specs/text/text_style_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_test.dart
@@ -525,9 +525,11 @@ void main() {
       });
 
       test('shadows utility works correctly', () {
-        final attribute = TextStyler().shadows([
-          ShadowMix(color: Colors.black, offset: Offset(2, 2)),
-        ]);
+        final attribute = TextStyler().shadows(
+          ShadowListMix([
+            ShadowMix(color: Colors.black, offset: Offset(2, 2)),
+          ]),
+        );
 
         expect(attribute.$style, isNotNull);
       });

--- a/packages/mix/test/src/specs/text/text_style_test.dart
+++ b/packages/mix/test/src/specs/text/text_style_test.dart
@@ -526,9 +526,7 @@ void main() {
 
       test('shadows utility works correctly', () {
         final attribute = TextStyler().shadows(
-          ShadowListMix([
-            ShadowMix(color: Colors.black, offset: Offset(2, 2)),
-          ]),
+          ShadowListMix([ShadowMix(color: Colors.black, offset: Offset(2, 2))]),
         );
 
         expect(attribute.$style, isNotNull);

--- a/packages/mix/test/src/theme/tokens/shadow_list_token_integration_test.dart
+++ b/packages/mix/test/src/theme/tokens/shadow_list_token_integration_test.dart
@@ -127,5 +127,92 @@ void main() {
       expect(boxShadowRef, isA<List<BoxShadow>>());
       expect(boxShadowRef.runtimeType, equals(BoxShadowListRef));
     });
+
+    test('BoxShadowToken.mix() returns BoxShadowListMixRef', () {
+      const boxShadowToken = BoxShadowToken('test.box.shadows.mix');
+      final mixRef = boxShadowToken.mix();
+
+      expect(mixRef, isA<BoxShadowListMixRef>());
+      expect(mixRef, isA<BoxShadowListMix>());
+      expect(isAnyTokenRef(mixRef), isTrue);
+    });
+
+    test('BoxStyler.boxShadows accepts BoxShadowToken.mix()', () {
+      const boxShadowToken = BoxShadowToken('test.box.shadows.boxShadows');
+
+      // Compiles and produces a styler with the token-backed shadow prop.
+      final styler = BoxStyler().boxShadows(boxShadowToken.mix());
+
+      expect(styler.$decoration, isNotNull);
+    });
+
+    test('BoxStyler.shadows accepts BoxShadowToken.mix()', () {
+      const boxShadowToken = BoxShadowToken('test.box.shadows.shadows');
+
+      final styler = BoxStyler().shadows(boxShadowToken.mix());
+
+      expect(styler.$decoration, isNotNull);
+    });
+
+    test('BoxStyler.shadows accepts a BoxShadowListMix literal', () {
+      final styler = BoxStyler().shadows(
+        BoxShadowListMix([
+          BoxShadowMix(color: Colors.black, blurRadius: 5),
+          BoxShadowMix(color: Colors.grey, blurRadius: 10),
+        ]),
+      );
+
+      expect(styler.$decoration, isNotNull);
+    });
+
+    testWidgets(
+      'BoxStyler.boxShadows resolves BoxShadowToken.mix() through MixScope',
+      (tester) async {
+        const boxShadowToken = BoxShadowToken('box.shadows.token-mix.resolved');
+        final testBoxShadows = [
+          const BoxShadow(color: Colors.black, blurRadius: 4),
+          const BoxShadow(color: Colors.grey, blurRadius: 2),
+        ];
+
+        await tester.pumpWidget(
+          MixScope(
+            tokens: {boxShadowToken: testBoxShadows},
+            child: Builder(
+              builder: (context) {
+                final styler = BoxStyler().boxShadows(boxShadowToken.mix());
+                final styleSpec = styler.resolve(context);
+                final decoration = styleSpec.spec.decoration;
+
+                expect(decoration, isA<BoxDecoration>());
+                expect(
+                  (decoration as BoxDecoration).boxShadow,
+                  equals(testBoxShadows),
+                );
+
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      },
+    );
+
+    test('TextStyler.shadows accepts ShadowToken.mix()', () {
+      const shadowToken = ShadowToken('text.shadows.mix');
+
+      final styler = TextStyler().shadows(shadowToken.mix());
+
+      expect(styler.$style, isNotNull);
+    });
+
+    test('TextStyler.shadows accepts a ShadowListMix literal', () {
+      final styler = TextStyler().shadows(
+        ShadowListMix([
+          ShadowMix(color: Colors.black, offset: const Offset(1, 1)),
+        ]),
+      );
+
+      expect(styler.$style, isNotNull);
+    });
   });
 }

--- a/packages/mix_tailwinds/lib/src/tw_parser.dart
+++ b/packages/mix_tailwinds/lib/src/tw_parser.dart
@@ -1063,7 +1063,8 @@ FlexBoxStyler _applyFlexShadow(FlexBoxStyler styler, TwValue value) {
     styler,
     value,
     applyElevation: (style, elevation) => style.elevation(elevation),
-    applyBoxShadows: (style, shadows) => style.boxShadows(shadows),
+    applyBoxShadows: (style, shadows) =>
+        style.boxShadows(BoxShadowListMix(shadows)),
   );
 }
 
@@ -1211,7 +1212,8 @@ BoxStyler _applyBoxShadow(BoxStyler styler, TwValue value) {
     styler,
     value,
     applyElevation: (style, elevation) => style.elevation(elevation),
-    applyBoxShadows: (style, shadows) => style.boxShadows(shadows),
+    applyBoxShadows: (style, shadows) =>
+        style.boxShadows(BoxShadowListMix(shadows)),
   );
 }
 
@@ -1363,7 +1365,7 @@ BoxStyler _applyBoxTextShadow(BoxStyler styler, TwValue value) {
 TextStyler _applyTextShadow(TextStyler styler, TwValue value) {
   final shadows = _resolveTextShadowMixes(value);
   if (shadows == null) return styler;
-  return styler.shadows(shadows);
+  return styler.shadows(ShadowListMix(shadows));
 }
 
 TextStyler _applyPropertyToText(


### PR DESCRIPTION
## Summary

- `BoxStyler().boxShadows(token.mix())` failed to compile because the shadow styler methods took `List<BoxShadowMix>` while `BoxShadowToken.mix()` returns a `BoxShadowListMixRef` (implements `BoxShadowListMix`, not the raw list type). The same gap blocked `.shadows()` on Box/Flex/StackBox stylers and `TextStyler.shadows()` with `ShadowToken`.
- Change the shadow styler-mixin signatures to take the matching `*ListMix` wrapper and route through `Prop.mix(value)` so token refs flow end-to-end. Regenerated the affected `.g.dart` factory files; updated `mix_tailwinds/tw_parser.dart` for parity.
- Breaking: literal-list callers wrap with `BoxShadowListMix([...])` / `ShadowListMix([...])`. Logged under `Unreleased` in `packages/mix/CHANGELOG.md`.

Fixes #925.

## What changed

| File | Change |
|---|---|
| `packages/mix/lib/src/style/mixins/shadow_style_mixin.dart` | `boxShadows(List<BoxShadowMix>)` → `boxShadows(BoxShadowListMix)` |
| `packages/mix/lib/src/style/mixins/decoration_style_mixin.dart` | `shadows(List<BoxShadowMix>)` → `shadows(BoxShadowListMix)` |
| `packages/mix/lib/src/style/mixins/text_style_mixin.dart` | `shadows(List<ShadowMix>)` → `shadows(ShadowListMix)` |
| `packages/mix/lib/src/specs/{box,flexbox,stackbox,text}/*.g.dart` | Regenerated `BoxStyler.shadows` / `FlexBoxStyler.shadows` / `StackBoxStyler.shadows` / `TextStyler.shadows` factory signatures to match. |
| `packages/mix_tailwinds/lib/src/tw_parser.dart` | Wrap parsed shadow lists with `BoxShadowListMix(...)` / `ShadowListMix(...)` before forwarding to the styler. |
| `packages/mix/test/...` | Updated literal-list callsites in box/flexbox/stackbox/text styler tests. |
| `packages/mix/test/src/theme/tokens/shadow_list_token_integration_test.dart` | New tests covering `token.mix()` and `*ListMix` literal flows. |
| `packages/mix/CHANGELOG.md` | New "Unreleased" entry documenting the breaking change. |

> Note: `IconStyler.shadows(List<ShadowMix>)` is intentionally unchanged — that setter is derived from the `IconSpec.shadows` field, not from `TextStyleMixin`. It can be migrated in a follow-up if we want `IconStyler` to accept `ShadowToken.mix()` too.

## Migration

```dart
// Before
BoxStyler().boxShadows([
  BoxShadowMix(color: Colors.black, blurRadius: 8),
  BoxShadowMix(color: Colors.grey, blurRadius: 4),
]);

// After (literal)
BoxStyler().boxShadows(BoxShadowListMix([
  BoxShadowMix(color: Colors.black, blurRadius: 8),
  BoxShadowMix(color: Colors.grey, blurRadius: 4),
]));

// After (token — the case that motivated this fix)
const cardShadow = BoxShadowToken('shadows.card');
BoxStyler().boxShadows(cardShadow.mix());
```

The same wrapping applies to `BoxStyler.shadows(...)`, `FlexBoxStyler.shadows(...)`, `StackBoxStyler.shadows(...)`, and `TextStyler.shadows(...)`.

## Test plan

- [x] `dart analyze .` clean across all workspace packages (`mix`, `mix_annotations`, `mix_generator`, `mix_lint`, `mix_tailwinds`, `mix_tailwinds_example`).
- [x] `flutter test` in `packages/mix`: **2726/2726 passing**.
- [x] `flutter test` in `packages/mix_tailwinds`: **322/322 passing**.
- [x] New integration tests in `shadow_list_token_integration_test.dart`:
  - `BoxShadowToken.mix()` returns a `BoxShadowListMixRef` that satisfies the `BoxShadowListMix` interface.
  - `BoxStyler().boxShadows(token.mix())` compiles and produces a styler with the token-backed shadow prop.
  - `BoxStyler().shadows(token.mix())` (the `DecorationStyleMixin` path) compiles and produces a styler.
  - `BoxStyler().shadows(BoxShadowListMix([...]))` literal form works.
  - End-to-end `MixScope` resolve: `boxShadowToken.mix()` resolves to the configured `List<BoxShadow>` at render time.
  - `TextStyler().shadows(shadowToken.mix())` and the `ShadowListMix([...])` literal form for text shadows.

> DCM was skipped locally (not installed in this environment). Should be re-checked by CI.
