### PR TITLE
fix(mix): stop base color directives from leaking onto variant overrides

### DIFF
--- a/packages/mix/lib/src/core/prop.dart
+++ b/packages/mix/lib/src/core/prop.dart
@@ -185,14 +185,26 @@ class Prop<V> {
   /// - Mix sources: merged using accumulation strategy
   /// - Regular values: last value wins during resolution
   ///
-  /// Directives are merged from both properties.
+  /// Directives are handled in two modes:
+  /// - When [other] provides its own value/token source, its directives
+  ///   represent the new complete state and replace this property's
+  ///   directives. This prevents directives that were attached to a prior
+  ///   value (e.g. `token.withOpacity(0)` on a base style) from leaking onto
+  ///   a value supplied by a higher-priority layer (e.g. a hover variant).
+  /// - When [other] only carries directives (a directive-only [Prop], such as
+  ///   the ones produced by chained helpers like `withOpacity` or `scale`),
+  ///   its directives are appended to this property's directives.
   Prop<V> mergeProp(covariant Prop<V>? other) {
     if (other == null) return this;
+
+    final mergedDirectives = other.sources.isEmpty
+        ? PropOps.mergeDirectives($directives, other.$directives)
+        : other.$directives;
 
     // Always accumulate all sources - no conditional logic
     return Prop._(
       sources: [...sources, ...other.sources],
-      directives: PropOps.mergeDirectives($directives, other.$directives),
+      directives: mergedDirectives,
     );
   }
 

--- a/packages/mix/test/src/core/prop_test.dart
+++ b/packages/mix/test/src/core/prop_test.dart
@@ -59,15 +59,59 @@ void main() {
       expect(merged, resolvesTo(42, context: context));
     });
 
-    test('merges directives', () {
-      // Intentionally pass an empty directives list to 'a' and verify it is preserved
-      final a = Prop.value(1).directives(<Directive<int>>[]);
-      final b = Prop.value(2);
+    test(
+      'accumulates directives when other carries no sources',
+      () {
+        final a = Prop.value('hello').directives(<Directive<String>>[]);
+        final b = const Prop<String>.directives([UppercaseStringDirective()]);
 
-      final merged = a.mergeProp(b);
+        final merged = a.mergeProp(b);
 
-      expect(merged.$directives, a.$directives); // preserved from a
-    });
+        expect(
+          merged.$directives,
+          equals(const [UppercaseStringDirective()]),
+        );
+      },
+    );
+
+    test(
+      'replaces directives when other supplies a value source',
+      () {
+        // Base layer's directive belongs to its value; when a higher-priority
+        // layer supplies a new value, the base's directives must not stick.
+        final base = Prop.value(
+          'hello',
+        ).directives(const [UppercaseStringDirective()]);
+        final override = Prop.value('world');
+
+        final merged = base.mergeProp(override);
+
+        // Both sources are preserved, but only override's directives apply.
+        expect(merged.$directives, isNull);
+        expect(merged, resolvesTo('world'));
+      },
+    );
+
+    test(
+      "replaces directives with other's directives when other has both source and directives",
+      () {
+        final base = Prop.value(
+          'hello',
+        ).directives(const [UppercaseStringDirective()]);
+        final override = Prop.value(
+          'world',
+        ).directives(const [CapitalizeStringDirective()]);
+
+        final merged = base.mergeProp(override);
+
+        expect(
+          merged.$directives,
+          equals(const [CapitalizeStringDirective()]),
+        );
+        // 'world' -> capitalize = 'World'; UppercaseStringDirective is not applied.
+        expect(merged, resolvesTo('World'));
+      },
+    );
 
     test('throws when resolving without value or token', () {
       final p = const Prop<int>.directives([]);

--- a/packages/mix/test/src/theme/tokens/color_token_integration_test.dart
+++ b/packages/mix/test/src/theme/tokens/color_token_integration_test.dart
@@ -107,5 +107,72 @@ void main() {
       final decoration = container.decoration! as BoxDecoration;
       expect(decoration.color, baseColor.withValues(alpha: 0.5));
     });
+
+    // Regression test for https://github.com/btwld/mix/issues/935
+    //
+    // Base color uses `token.withOpacity(0)`; a hover variant overrides with
+    // `token` (no directives). Before the fix the base layer's
+    // [OpacityColorDirective] leaked onto the hover layer's value, so the
+    // resolved hover color stayed transparent and animations never ran.
+    testWidgets(
+      'hover variant clears base directives so the new value applies',
+      (tester) async {
+        const token = ColorToken('primary');
+        const baseColor = Color(0xFF00FF00);
+
+        final style = BoxStyler()
+            // ignore: deprecated_member_use
+            .color(token().withOpacity(0))
+            .onHovered(BoxStyler().color(token()));
+
+        await tester.pumpWidget(
+          MixScope(
+            tokens: {token: baseColor},
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: WidgetStateProvider(
+                states: const {WidgetState.hovered},
+                child: Box(style: style),
+              ),
+            ),
+          ),
+        );
+
+        final container = tester.widget<Container>(find.byType(Container));
+        final decoration = container.decoration! as BoxDecoration;
+        // Hover overrides the base, so we expect the fully opaque token color.
+        expect(decoration.color, baseColor);
+      },
+    );
+
+    testWidgets(
+      'resting state still respects directives when no override is active',
+      (tester) async {
+        const token = ColorToken('primary');
+        const baseColor = Color(0xFF00FF00);
+
+        final style = BoxStyler()
+            // ignore: deprecated_member_use
+            .color(token().withOpacity(0))
+            .onHovered(BoxStyler().color(token()));
+
+        await tester.pumpWidget(
+          MixScope(
+            tokens: {token: baseColor},
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: WidgetStateProvider(
+                states: const {},
+                child: Box(style: style),
+              ),
+            ),
+          ),
+        );
+
+        final container = tester.widget<Container>(find.byType(Container));
+        final decoration = container.decoration! as BoxDecoration;
+        expect(decoration.color, baseColor.withValues(alpha: 0));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Fixes #935. When a base style provided a value plus directives (e.g. `.color(token.withOpacity(0))`) and a variant overrode with a fresh value (e.g. `.onHovered(.color(token))`), `Prop.mergeProp` accumulated both directives and sources. The base's `OpacityColorDirective(0)` kept reapplying on top of the hover value, so the resolved color never changed and animations could not run.

`mergeProp` now replaces directives when the merging-in `Prop` supplies its own value/token source, and keeps the existing accumulation behavior when the incoming `Prop` is directive-only (as produced by chained helpers such as `withOpacity`, `withAlpha`, `scale`, etc.).

The reporter's reproducer now works as expected:

```dart
Box(
  style: BoxStyler()
      .color($accent().withOpacity(0.0))
      .size(100, 100)
      .onHovered(.color($danger().withOpacity(1)))
      .animate(.spring(1.s)),
)
```

## Test plan

- [x] `flutter test test/src/core/prop_test.dart` — three new unit tests cover accumulation when `other` has no sources, replacement when `other` supplies a source, and replacement when `other` has both source + directives.
- [x] `flutter test test/src/theme/tokens/color_token_integration_test.dart` — regression test asserts the hover state resolves to the opaque token color, plus a sibling test confirming the resting state still applies the base directive.
- [x] `flutter test` on `packages/mix` — no new failures (the single pre-existing failure in `widget_state_controller_test.dart` is a Flutter SDK shader-asset version mismatch unrelated to this change).
- [x] `dart analyze` on the edited files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)