### PR TITLE
feat(mix_lint): add mix_avoid_token_ref_outside_mix rule

### DIFF
--- a/packages/mix_lint/README.md
+++ b/packages/mix_lint/README.md
@@ -25,6 +25,7 @@ plugins:
     diagnostics:
       mix_avoid_defining_tokens_within_style: true
       mix_avoid_defining_tokens_within_scope: true
+      mix_avoid_token_ref_outside_mix: true
       mix_avoid_empty_variants: true
       mix_max_number_of_attributes_per_style: true
       mix_variants_last: true
@@ -99,6 +100,39 @@ MixScope(
   },
   child: child,
 );
+```
+
+### mix_avoid_token_ref_outside_mix
+
+Ensure that a `MixToken` reference is only passed to Mix styling APIs.
+
+Calling a token — `token()` (or `token.mix()` on the tokens that expose it) — does not return a concrete value. It returns a *reference* sentinel (e.g. `ColorRef`, `RadiusRef`) that only resolves later inside Mix's pipeline, against the surrounding `MixScope`. Pass that sentinel to a non-Mix API — a plain Flutter widget, a `dart:core` function — and it never resolves, producing a silent bug.
+
+The rule allows the reference when it is an argument to anything whose receiver/constructed type descends from `Mix` (all Stylers and `*Mix` value utilities, whether shipped in Mix or generated in your package via `@MixableType`/`@MixableSpec`); it flags the reference when the consuming API is provably not Mix. To read a concrete value outside Mix, use `token.resolve(context)` instead.
+
+This is a warning rather than a hint: a misrouted reference is a correctness bug, not a style preference.
+
+> Note: the check is syntactic. A reference first stored in a variable (`final c = token(); Container(color: c);`) is not detected.
+
+#### Don't
+
+```dart
+final primary = ColorToken('primary');
+
+// Reference escapes into a non-Mix API and never resolves.
+Container(color: primary());
+```
+
+#### Do
+
+```dart
+final primary = ColorToken('primary');
+
+// Pass the reference to a Mix styling API…
+Box(style: BoxStyler().color(primary()));
+
+// …or resolve it to a concrete value for non-Mix APIs.
+Container(color: primary.resolve(context));
 ```
 
 ### mix_avoid_empty_variants

--- a/packages/mix_lint/lib/main.dart
+++ b/packages/mix_lint/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:analysis_server_plugin/registry.dart';
 import 'src/rules/mix_avoid_defining_tokens_within_scope.dart';
 import 'src/rules/mix_avoid_defining_tokens_within_style.dart';
 import 'src/rules/mix_avoid_empty_variants.dart';
+import 'src/rules/mix_avoid_token_ref_outside_mix.dart';
 import 'src/rules/mix_max_number_of_attributes_per_style.dart';
 import 'src/rules/mix_mixable_styler_has_create.dart';
 import 'src/rules/mix_prefer_dot_shorthands.dart';
@@ -19,6 +20,7 @@ class MixLintPlugin extends Plugin {
   void register(PluginRegistry registry) {
     registry.registerLintRule(MixAvoidDefiningTokensWithinStyle());
     registry.registerLintRule(MixAvoidDefiningTokensWithinScope());
+    registry.registerLintRule(MixAvoidTokenRefOutsideMix());
     registry.registerLintRule(MixAvoidEmptyVariants());
     registry.registerLintRule(MixMaxNumberOfAttributesPerStyle());
     registry.registerLintRule(MixVariantsLast());

--- a/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
+++ b/packages/mix_lint/lib/src/rules/mix_avoid_token_ref_outside_mix.dart
@@ -1,0 +1,170 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/error/error.dart';
+
+import '../utils/type_helpers.dart';
+
+/// Whether the consumer of a token reference belongs to Mix.
+enum _Verdict {
+  /// The consumer is a Mix API — the reference is handled correctly.
+  mix,
+
+  /// The consumer is provably not a Mix API — the reference escapes.
+  notMix,
+
+  /// The consumer could not be resolved — stay quiet.
+  unknown,
+}
+
+class MixAvoidTokenRefOutsideMix extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'mix_avoid_token_ref_outside_mix',
+    'MixToken references must only be passed to Mix styling APIs.',
+    correctionMessage:
+        'A token reference (e.g. token() or token.mix()) is a sentinel that only '
+        "resolves inside Mix's pipeline. Pass it to a Mix styler/utility, or use "
+        'token.resolve(context) to read the concrete value.',
+    severity: DiagnosticSeverity.WARNING,
+  );
+
+  MixAvoidTokenRefOutsideMix()
+    : super(
+        name: 'mix_avoid_token_ref_outside_mix',
+        description:
+            'Ensures MixToken references (call() and mix()) are only passed as '
+            'arguments to Mix APIs. A reference passed to a non-Mix API (e.g. a '
+            'plain Flutter widget) is an unresolved sentinel that causes silent '
+            'bugs.',
+      );
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    final visitor = _Visitor(this);
+    registry.addFunctionExpressionInvocation(this, visitor);
+    registry.addMethodInvocation(this, visitor);
+  }
+
+  @override
+  LintCode get diagnosticCode => code;
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+
+  const _Visitor(this.rule);
+
+  @override
+  void visitFunctionExpressionInvocation(FunctionExpressionInvocation node) {
+    // Implicit call: `token()`, `ColorToken('x')()`.
+    if (!isMixTokenType(node.function.staticType)) return;
+    _check(node);
+  }
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    // Explicit ref producers: `token.call()` and `token.mix()`.
+    final name = node.methodName.name;
+    if (name != 'call' && name != 'mix') return;
+    if (!isMixTokenType(node.target?.staticType)) return;
+    _check(node);
+  }
+
+  /// Reports [callable] (a token reference expression) when it is passed as an
+  /// argument to a non-Mix API. Stays silent when the reference is not an
+  /// argument or when the consumer cannot be resolved.
+  void _check(Expression callable) {
+    final consumer = _enclosingConsumer(callable);
+    if (consumer == null) return;
+
+    switch (_classify(consumer)) {
+      case _Verdict.notMix:
+        rule.reportAtNode(callable);
+      case _Verdict.mix:
+      case _Verdict.unknown:
+        break;
+    }
+  }
+
+  /// Walks up from [callable] to the innermost invocation it is an argument to,
+  /// passing through enclosing collection literals. Returns null when a
+  /// statement/declaration boundary is reached first (i.e. the reference is not
+  /// in an argument position).
+  AstNode? _enclosingConsumer(Expression callable) {
+    AstNode? current = callable.parent;
+    while (current != null &&
+        current is! Statement &&
+        current is! Declaration) {
+      if (current is ArgumentList) {
+        return current.parent;
+      }
+      // Keep climbing through collection literals (and their map entries) and
+      // named-expression wrappers so list/set/map args are still attributed to
+      // the enclosing invocation.
+      current = current.parent;
+    }
+
+    return null;
+  }
+
+  _Verdict _classify(AstNode consumer) {
+    if (consumer is InstanceCreationExpression) {
+      return _verdictForType(consumer.staticType);
+    }
+
+    if (consumer is MethodInvocation) {
+      // Instance receiver (e.g. `BoxStyler().color(...)`).
+      final receiverType = consumer.target?.staticType;
+      if (receiverType is InterfaceType) {
+        if (isMixType(receiverType)) return _Verdict.mix;
+
+        // A resolved non-type receiver: judge by enclosing element below, but
+        // a plain instance receiver that is not Mix is a clear escape.
+        final enclosing = _enclosingVerdict(consumer.methodName.element);
+        return enclosing == _Verdict.mix ? _Verdict.mix : _Verdict.notMix;
+      }
+
+      // Static method (`EdgeInsetsGeometryMix.all(...)`) or top-level function.
+      return _enclosingVerdict(consumer.methodName.element);
+    }
+
+    // A function-typed value is being invoked (e.g. a closure variable). We
+    // cannot tell whether it came from Mix, so stay silent.
+    return _Verdict.unknown;
+  }
+
+  /// Classifies a callee [element] by its enclosing type, falling back to the
+  /// declaring library URI for top-level functions.
+  _Verdict _enclosingVerdict(Element? element) {
+    if (element == null) return _Verdict.unknown;
+
+    final enclosing = element.enclosingElement;
+    if (enclosing is InterfaceElement) {
+      return isMixType(enclosing.thisType) ? _Verdict.mix : _Verdict.notMix;
+    }
+
+    // Top-level / free function: allow only when declared in `package:mix`.
+    final uri = element.library?.uri;
+    if (uri == null) return _Verdict.unknown;
+
+    return _isMixPackageUri(uri) ? _Verdict.mix : _Verdict.notMix;
+  }
+
+  _Verdict _verdictForType(DartType? type) {
+    if (type is! InterfaceType) return _Verdict.unknown;
+
+    return isMixType(type) ? _Verdict.mix : _Verdict.notMix;
+  }
+
+  bool _isMixPackageUri(Uri uri) =>
+      uri.scheme == 'package' &&
+      uri.pathSegments.isNotEmpty &&
+      uri.pathSegments.first == 'mix';
+}

--- a/packages/mix_lint/lib/src/utils/type_helpers.dart
+++ b/packages/mix_lint/lib/src/utils/type_helpers.dart
@@ -6,6 +6,15 @@ bool isMixStylerType(DartType? type) => _isSubtypeByName(type, 'MixStyler');
 /// Returns true if [type] is a subtype of [MixToken] (any token type).
 bool isMixTokenType(DartType? type) => _isSubtypeByName(type, 'MixToken');
 
+/// Returns true if [type] is a subtype of the Mix value base (`Mix`/`Mixable`).
+///
+/// Every ref-consuming Mix API — both Stylers (`MixStyler` → `Style` → `Mix`)
+/// and value utilities (`EdgeInsetsGeometryMix`, `DecorationMix`, ... → `Mix`) —
+/// shares this base, whether shipped in `package:mix` or generated in a user's
+/// package via `@MixableType`/`@MixableSpec`.
+bool isMixType(DartType? type) =>
+    _isSubtypeByName(type, 'Mix') || _isSubtypeByName(type, 'Mixable');
+
 /// Returns true if [type] is exactly [MixScope].
 bool isMixScopeType(DartType? type) => _matchesByName(type, 'MixScope');
 

--- a/packages/mix_lint/test/src/mix_stub.dart
+++ b/packages/mix_lint/test/src/mix_stub.dart
@@ -2,17 +2,32 @@
 // Used by analysis_rule tests that need MixStyler, MixToken, MixScope resolution.
 
 const String mixStubLibContent = r'''
-abstract class MixStyler {}
-abstract class MixToken<T> {}
+abstract class Mixable<T> {}
+abstract class Mix<T> extends Mixable<T> {}
+abstract class MixStyler extends Mix<Object> {}
+abstract class MixToken<T> {
+  const MixToken();
+  T call();
+  T resolve(Object context);
+}
 class MyToken extends MixToken<int> {
   const MyToken();
+  @override
+  int call() => 0;
+  @override
+  int resolve(Object context) => 0;
+  int mix() => 0;
 }
 class MixScope {
   MixScope([Map<Object?, Object?>? tokens]);
 }
-class EdgeInsetsGeometryMix {
+class EdgeInsetsGeometryMix extends Mix<Object> {
   EdgeInsetsGeometryMix();
   static EdgeInsetsGeometryMix all(double value) => EdgeInsetsGeometryMix();
+  static EdgeInsetsGeometryMix value(Object? v) => EdgeInsetsGeometryMix();
+}
+class Container {
+  Container({Object? color, List<Object?>? children});
 }
 class FontWeight {
   FontWeight();

--- a/packages/mix_lint/test/src/rules/mix_avoid_token_ref_outside_mix_test.dart
+++ b/packages/mix_lint/test/src/rules/mix_avoid_token_ref_outside_mix_test.dart
@@ -1,0 +1,161 @@
+import 'package:analyzer_testing/analysis_rule/analysis_rule.dart';
+import 'package:mix_lint/src/rules/mix_avoid_token_ref_outside_mix.dart';
+import 'package:test_reflective_loader/test_reflective_loader.dart';
+
+import '../mix_stub.dart';
+
+@reflectiveTest
+class MixAvoidTokenRefOutsideMixTest extends AnalysisRuleTest {
+  @override
+  void setUp() {
+    rule = MixAvoidTokenRefOutsideMix();
+    newPackage('mix').addFile('lib/mix.dart', mixStubLibContent);
+    super.setUp();
+  }
+
+  // --- Reports ---------------------------------------------------------------
+
+  void test_call_into_non_mix_constructor_reports() async {
+    await assertDiagnostics(
+      r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  Container(color: t());
+}
+''',
+      [lint(87, 3)],
+    );
+  }
+
+  void test_explicit_call_into_non_mix_constructor_reports() async {
+    await assertDiagnostics(
+      r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  Container(color: t.call());
+}
+''',
+      [lint(87, 8)],
+    );
+  }
+
+  void test_mix_method_into_non_mix_constructor_reports() async {
+    await assertDiagnostics(
+      r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  Container(color: t.mix());
+}
+''',
+      [lint(87, 7)],
+    );
+  }
+
+  void test_call_into_top_level_function_reports() async {
+    await assertDiagnostics(
+      r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  print(t());
+}
+''',
+      [lint(76, 3)],
+    );
+  }
+
+  void test_call_inside_collection_into_non_mix_reports() async {
+    await assertDiagnostics(
+      r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  print([t()]);
+}
+''',
+      [lint(77, 3)],
+    );
+  }
+
+  // --- No diagnostics --------------------------------------------------------
+
+  void test_call_into_styler_method_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  BoxStyler().color(t());
+}
+''');
+  }
+
+  void test_explicit_call_into_styler_method_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  BoxStyler().color(t.call());
+}
+''');
+  }
+
+  void test_call_into_mix_static_utility_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  EdgeInsetsGeometryMix.value(t());
+}
+''');
+  }
+
+  void test_resolve_is_not_a_ref_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  Container(color: t.resolve(0));
+}
+''');
+  }
+
+  void test_call_assigned_to_variable_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  final x = t();
+}
+''');
+  }
+
+  void test_call_in_return_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+int build() {
+  final t = MyToken();
+  return t();
+}
+''');
+  }
+
+  void test_call_into_unresolved_receiver_no_diagnostic() async {
+    await assertNoDiagnostics(r'''
+import 'package:mix/mix.dart';
+void main() {
+  final t = MyToken();
+  dynamic d;
+  d.foo(t());
+}
+''');
+  }
+}
+
+void main() {
+  defineReflectiveSuite(() {
+    defineReflectiveTests(MixAvoidTokenRefOutsideMixTest);
+  });
+}


### PR DESCRIPTION
## What

Adds a new lint rule **`mix_avoid_token_ref_outside_mix`** to `mix_lint`.

Calling a `MixToken` — `token()` (or `token.mix()` on tokens that expose it) — does **not** return a concrete value. It returns a *reference* sentinel (`ColorRef`, `RadiusRef`, …) that only resolves later inside Mix's pipeline, against the surrounding `MixScope`. Passing that sentinel to a non-Mix API (a plain Flutter widget, a `dart:core` function) means it never resolves — a silent bug.

This rule flags exactly that escape.

## Behavior

- **Syntactic** trigger on the three ref producers: `token()`, `token.call()`, `token.mix()`. `token.resolve(context)` is exempt (it yields the real value).
- Fires **only in argument positions** — directly, or nested through collection literals. Assignment / return / bare statements are not flagged.
- **Allowed** when the innermost consuming invocation's receiver/target/constructed type descends from `Mix` (covers all Stylers and `*Mix` value utilities, whether shipped in `package:mix` or generated in a user package via `@MixableType`/`@MixableSpec`), with a `package:mix/` library-URI fallback for free functions.
- **Skipped** when the consumer type can't be resolved (`dynamic` / unresolved code).
- **Severity: `WARNING`** (first rule in the package above `INFO`) — a misrouted reference is a correctness bug. **No quick-fix**; the correction message points to `token.resolve(context)`.

### Don't
```dart
final primary = ColorToken('primary');
Container(color: primary()); // ref escapes, never resolves
```
### Do
```dart
final primary = ColorToken('primary');
Box(style: BoxStyler().color(primary()));        // pass to a Mix API
Container(color: primary.resolve(context));       // or resolve for non-Mix APIs
```

## Known gap

The check is syntactic: a reference first stored in a variable (`final c = token(); Container(color: c);`) is not detected. Documented in the README.

## Changes

- `lib/src/rules/mix_avoid_token_ref_outside_mix.dart` (new)
- `lib/src/utils/type_helpers.dart` — `isMixType()`
- `lib/main.dart` — registration
- `test/src/mix_stub.dart` — `Mixable`/`Mix` hierarchy, ref producers, non-Mix `Container`
- `test/src/rules/mix_avoid_token_ref_outside_mix_test.dart` (new) — 12 tests
- `README.md` — config entry + rule section

## Testing

- `dart test` — all 33 mix_lint tests pass (12 new).
- `dart analyze` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)