### PR TITLE
chore: release mix 2.1.0, mix_annotations 2.1.0, mix_generator 2.1.0, mix_lint 2.0.0

### DIFF
--- a/packages/mix/CHANGELOG.md
+++ b/packages/mix/CHANGELOG.md
@@ -1,11 +1,30 @@
-## Unreleased
+## 2.1.0
 
-This release hardens the token-reference system: it fixes correctness gaps
-around `DoubleRef` sentinels, breakpoint resolution, and numeric directives,
-and tightens public API around the internal token registry.
+This release adds context-derived token resolution and richer animation
+configuration, fixes variant resolution in nested styles and animation
+interpolation edge cases, and hardens the token-reference system while
+tightening the public API around the internal token registry.
+
+### New features
+
+- **`ContextToken`:** Zero-config token whose value is derived directly from
+  the build context, so context-dependent values resolve without first
+  registering a token in a scope (#938).
+- **Spring animation helpers:** `AnimationConfig` statics are now factories,
+  with added spring-curve wrappers for configuring physics-based transitions
+  (#937).
 
 ### Fixes
 
+- **Variants in nested styles:** A `Style` nested inside another style's `Prop`
+  (a component sub-style) now applies its own context variants — widget states,
+  brightness, breakpoints. Previously `Prop.resolveProp` resolved the merged
+  nested style via `resolve()`, which skips variants. No-op for nested styles
+  without variants (#926).
+- **`Matrix4` interpolation:** Tween a transform against the identity matrix
+  when one endpoint is null, instead of producing a degenerate result (#931).
+- **Animation config fallback:** Fall back to the previous animation config
+  when a transition resolves to null, rather than dropping the animation (#930).
 - **`DoubleRef` sentinel collisions:** Two distinct `MixToken<double>`
   instances whose hashes landed in the same bucket previously aliased to the
   same sentinel. The registry now hands out sentinels from a monotonic
@@ -42,6 +61,11 @@ and tightens public API around the internal token registry.
 - **`isAnyTokenRef`** drops the brittle `runtimeType.toString().endsWith(...)`
   check; a `Prop` carrying a `TokenSource` is now the sole class-based
   invariant.
+
+### Other changes
+
+- **`StyleWidget` defaults to `IdentityStyle<Spec>`**, giving widgets a
+  well-defined no-op style when none is supplied (#921).
 
 ## 2.0.3
 

--- a/packages/mix/pubspec.yaml
+++ b/packages/mix/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix
 description: An expressive way to effortlessly build design systems in Flutter.
-version: 2.0.3
+version: 2.1.0
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix
 

--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 2.0.1
+## 2.1.0
 
+ - **FEAT**: Add `@MixableModifier` annotation. Annotate a `WidgetModifier` subclass to generate its modifier mixin and `ModifierMix` class via `mix_generator` (#924).
+ - **FEAT**: Add `@MixWidget` annotation. Annotate a top-level styler variable or styler-returning function so `mix_generator` emits a matching `StatelessWidget` (#920).
+ - **FEAT**: Add `extraStylerMixins` to control additional mixins applied to generated stylers, and related `generator_flags` updates (#923).
  - **DEPRECATED**: `GeneratedStylerMethods.call` and `GeneratedStylerMethods.skipCall`. Call generation has not been supported since the 2.0 styler API; the flags are now annotated `@Deprecated` and will be removed in a future major release. The bit (`0x20`) remains in `GeneratedStylerMethods.all` for source and value compatibility — the generator already ignores it.
  - **DOCS**: Spec authoring examples in the README now include `package:flutter/foundation.dart` and `package:flutter/widgets.dart` imports plus the `@immutable` annotation, matching the symbols the generated `_$<Name>` mixin references.
  - **DOCS**: Note that `GeneratedSpecMethods.skipEquals` suppresses only the generated `props` getter; the surrounding equality surface is always emitted so a user-authored `props` powers a working `==`/`hashCode`/`getDiff`/`stringify`.

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:

--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,5 +1,12 @@
-## 2.0.4
+## 2.1.0
 
+ - **FEAT**: Add `@MixableModifier` generator. Annotate a `WidgetModifier` subclass
+   to generate its modifier mixin and `ModifierMix` class. Requires
+   `mix_annotations` `^2.1.0` (#924).
+ - **FEAT**: Generate spec stylers with parity coverage, emitting styler methods
+   that match the spec's resolvable surface (#923).
+ - **TEST**: Cover the single-field `debugFillProperties` cascade in generated
+   output (#942).
  - **FEAT**: Add `@MixWidget` generator. Annotate a top-level `final` styler variable
    or a styler-returning function; the generator emits a `StatelessWidget` whose
    `build()` delegates to that styler's `call()`. Constructor parameters mirror
@@ -25,15 +32,9 @@
  - **CHORE**: `@MixWidget` requires the annotated element's name to be
    `lowerCamelCase` ending in `Style`. Names that don't match are rejected; use
    `@MixWidget(name: '...')` to override.
-
-## 2.0.3
-
  - **FEAT**: Emit a `@Deprecated typedef _$<Name>SpecMethods = _$<Name>;` alongside every `@MixableSpec` mixin so legacy `class X extends Spec<X> with Diagnosticable, _$XSpecMethods` declarations keep compiling against the 2.0+ generator. Removal scheduled for `mix_generator` 3.0.
  - **CHANGED**: Under the legacy declaration shape, `toString()` now routes through `Diagnosticable.toDiagnosticsNode`, replacing Equatable's `X(field: …)` format with Flutter's diagnostic-node format. Update any tests that pinned the old string.
  - **CHORE**: Drop unused direct dependencies (`collection`, `build_config`, `logging`, `path`); the generator no longer references them.
-
-## 2.0.2
-
  - **FIX**: `GeneratedSpecMethods.skipEquals` now only suppresses `props` generation. The rest of the equality surface (`==`, `hashCode`, `getDiff`, `stringify`) is always emitted, preserving the supported "user authors `props`" flag semantic after the spec-shape refactor.
  - **FIX**: `Prop<T>` detection now uses a URL-based `TypeChecker` (`package:mix/src/core/prop.dart#Prop`) instead of matching on the simple name `Prop`. Prevents unrelated local classes named `Prop` from being mistaken for Mix's `Prop`.
  - **FIX**: `@Mixable` validation now requires the annotated class to extend `Mix<T>` (or a subclass) directly. Classes extending `Mixable<T>` without going through `Mix<T>` are rejected with a clear error — the generated mixin's `on Mix<T>` constraint would have failed at apply time anyway.

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.0.3
+version: 2.1.0
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
   
 dependencies:
-  mix_annotations: ^2.0.0
+  mix_annotations: ^2.1.0
   dart_style: ^3.0.0
   source_gen: ">=3.0.0 <5.0.0"
   analyzer: '>=9.0.0 <11.0.0'

--- a/packages/mix_lint/CHANGELOG.md
+++ b/packages/mix_lint/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.0.0
+
+ - **BREAKING**: Rebuilt `mix_lint` on top of the `analysis_server_plugin` API,
+   replacing the previous `custom_lint` implementation. The plugin now runs
+   directly in the analysis server; remove any `custom_lint` analyzer plugin
+   wiring and enable `mix_lint` per the updated README (#871).
+ - **FEAT**: Add the `mix_avoid_token_ref_outside_mix` rule, flagging token
+   references resolved outside of a `Mix` context (#939).
+ - **FEAT**: Ship the Mix 2.0 rule set: `mix_avoid_empty_variants`,
+   `mix_variants_last`, `mix_max_number_of_attributes_per_style`,
+   `mix_avoid_defining_tokens_within_style`,
+   `mix_avoid_defining_tokens_within_scope`, `mix_mixable_styler_has_create`,
+   and `mix_prefer_dot_shorthands` (with an automated fix).
+
 ## 1.7.0
 
  - No changes in this release.


### PR DESCRIPTION
## Release prep

Coordinated version bumps + changelogs across the Mix packages. No code changes — pubspec versions and changelogs only.

| Package | Published | This PR |
|---|---|---|
| `mix` | 2.0.3 | **2.1.0** |
| `mix_annotations` | 2.0.0 | **2.1.0** |
| `mix_generator` | 2.0.1 | **2.1.0** |
| `mix_lint` | 1.7.0 | **2.0.0** |

`mix_tailwinds` is intentionally left untouched.

### mix 2.1.0
- **Features:** `ContextToken` for context-derived token resolution (#938); spring animation helpers, `AnimationConfig` statics → factories (#937).
- **Fixes:** apply variants when resolving nested styles (#926); tween `Matrix4` against identity when an endpoint is null (#931); fall back to previous animation config on null transition (#930).
- **Token-ref hardening + API changes:** `DoubleRef` sentinel uniqueness, `BreakpointToken.resolve` type-error surfacing, numeric directives on multi-source props, `Prop.value` null safety. **Breaking-ish:** `clearTokenRegistry`/`getTokenFromValue` no longer exported, public `DoubleRef(double)` ctor removed, `ValueRef.noSuchMethod`/`getReferenceValue` now throw `UnsupportedError`.

### mix_annotations 2.1.0
- New `@MixableModifier` (#924) and `@MixWidget` (#920) annotations; `extraStylerMixins` (#923); plus the previously staged 2.0.1 deprecations/docs.

### mix_generator 2.1.0
- Consolidates the never-published 2.0.2–2.0.4 changelog entries into one release.
- Adds the `@MixableModifier` generator (#924), spec stylers with parity coverage (#923), and `debugFillProperties` test coverage (#942).
- Bumps `mix_annotations` constraint to `^2.1.0` (the new generator references `@MixableModifier`).

### mix_lint 2.0.0
- Documents the `analysis_server_plugin` rewrite (#871) and the new `mix_avoid_token_ref_outside_mix` rule (#939), plus the full 2.0 rule set. (pubspec was already at 2.0.0; this adds the missing changelog entry.)

### Verification
- `dart pub get` resolves the workspace cleanly.
- `melos run verify_version_pubspec_changelog` passes — every changelog top matches its pubspec version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)