### PR TITLE
chore: release mix_annotations 2.1.0 and mix_lint 2.0.0

### DIFF
--- a/packages/mix_annotations/CHANGELOG.md
+++ b/packages/mix_annotations/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 2.0.1
+## 2.1.0
 
+ - **FEAT**: Add `@MixableModifier` annotation. Annotate a `WidgetModifier` subclass to generate its modifier mixin and `ModifierMix` class via `mix_generator` (#924).
+ - **FEAT**: Add `@MixWidget` annotation. Annotate a top-level styler variable or styler-returning function so `mix_generator` emits a matching `StatelessWidget` (#920).
+ - **FEAT**: Add `extraStylerMixins` to control additional mixins applied to generated stylers, and related `generator_flags` updates (#923).
  - **DEPRECATED**: `GeneratedStylerMethods.call` and `GeneratedStylerMethods.skipCall`. Call generation has not been supported since the 2.0 styler API; the flags are now annotated `@Deprecated` and will be removed in a future major release. The bit (`0x20`) remains in `GeneratedStylerMethods.all` for source and value compatibility — the generator already ignores it.
  - **DOCS**: Spec authoring examples in the README now include `package:flutter/foundation.dart` and `package:flutter/widgets.dart` imports plus the `@immutable` annotation, matching the symbols the generated `_$<Name>` mixin references.
  - **DOCS**: Note that `GeneratedSpecMethods.skipEquals` suppresses only the generated `props` getter; the surrounding equality surface is always emitted so a user-authored `props` powers a working `==`/`hashCode`/`getDiff`/`stringify`.

--- a/packages/mix_annotations/pubspec.yaml
+++ b/packages/mix_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_annotations
 description: Annotations for mix and mix_generator
-version: 2.0.1
+version: 2.1.0
 repository: https://github.com/btwld/mix/tree/main/packages/mix_annotations
 
 environment:

--- a/packages/mix_lint/CHANGELOG.md
+++ b/packages/mix_lint/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.0.0
+
+ - **BREAKING**: Rebuilt `mix_lint` on top of the `analysis_server_plugin` API,
+   replacing the previous `custom_lint` implementation. The plugin now runs
+   directly in the analysis server; remove any `custom_lint` analyzer plugin
+   wiring and enable `mix_lint` per the updated README (#871).
+ - **FEAT**: Add the `mix_avoid_token_ref_outside_mix` rule, flagging token
+   references resolved outside of a `Mix` context (#939).
+ - **FEAT**: Ship the Mix 2.0 rule set: `mix_avoid_empty_variants`,
+   `mix_variants_last`, `mix_max_number_of_attributes_per_style`,
+   `mix_avoid_defining_tokens_within_style`,
+   `mix_avoid_defining_tokens_within_scope`, `mix_mixable_styler_has_create`,
+   and `mix_prefer_dot_shorthands` (with an automated fix).
+
 ## 1.7.0
 
  - No changes in this release.


### PR DESCRIPTION
## Release prep — mix_annotations & mix_lint

Version bumps + changelogs only, no code changes. Part of a coordinated release split across three PRs (this one, `mix_generator`, and `mix`).

### mix_annotations 2.1.0 (published: 2.0.0)
- New `@MixableModifier` annotation (#924) and `@MixWidget` annotation (#920).
- `extraStylerMixins` support (#923).
- Folds in the previously staged 2.0.1 deprecations (`GeneratedStylerMethods.call`/`skipCall`) and docs that were never published.

### mix_lint 2.0.0 (published: 1.7.0)
- Documents the `analysis_server_plugin` rewrite (#871) — replaces the prior `custom_lint` implementation.
- Adds the `mix_avoid_token_ref_outside_mix` rule (#939) and lists the full 2.0 rule set.
- pubspec was already at 2.0.0; this PR supplies the missing changelog entry.

### Ordering note
`mix_generator` 2.1.0 (separate PR) bumps its `mix_annotations` constraint to `^2.1.0`, so **mix_annotations 2.1.0 should be published before mix_generator 2.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)