### PR TITLE
chore: release mix_generator 2.1.0

### DIFF
--- a/packages/mix_generator/CHANGELOG.md
+++ b/packages/mix_generator/CHANGELOG.md
@@ -1,5 +1,12 @@
-## 2.0.4
+## 2.1.0
 
+ - **FEAT**: Add `@MixableModifier` generator. Annotate a `WidgetModifier` subclass
+   to generate its modifier mixin and `ModifierMix` class. Requires
+   `mix_annotations` `^2.1.0` (#924).
+ - **FEAT**: Generate spec stylers with parity coverage, emitting styler methods
+   that match the spec's resolvable surface (#923).
+ - **TEST**: Cover the single-field `debugFillProperties` cascade in generated
+   output (#942).
  - **FEAT**: Add `@MixWidget` generator. Annotate a top-level `final` styler variable
    or a styler-returning function; the generator emits a `StatelessWidget` whose
    `build()` delegates to that styler's `call()`. Constructor parameters mirror
@@ -25,15 +32,9 @@
  - **CHORE**: `@MixWidget` requires the annotated element's name to be
    `lowerCamelCase` ending in `Style`. Names that don't match are rejected; use
    `@MixWidget(name: '...')` to override.
-
-## 2.0.3
-
  - **FEAT**: Emit a `@Deprecated typedef _$<Name>SpecMethods = _$<Name>;` alongside every `@MixableSpec` mixin so legacy `class X extends Spec<X> with Diagnosticable, _$XSpecMethods` declarations keep compiling against the 2.0+ generator. Removal scheduled for `mix_generator` 3.0.
  - **CHANGED**: Under the legacy declaration shape, `toString()` now routes through `Diagnosticable.toDiagnosticsNode`, replacing Equatable's `X(field: …)` format with Flutter's diagnostic-node format. Update any tests that pinned the old string.
  - **CHORE**: Drop unused direct dependencies (`collection`, `build_config`, `logging`, `path`); the generator no longer references them.
-
-## 2.0.2
-
  - **FIX**: `GeneratedSpecMethods.skipEquals` now only suppresses `props` generation. The rest of the equality surface (`==`, `hashCode`, `getDiff`, `stringify`) is always emitted, preserving the supported "user authors `props`" flag semantic after the spec-shape refactor.
  - **FIX**: `Prop<T>` detection now uses a URL-based `TypeChecker` (`package:mix/src/core/prop.dart#Prop`) instead of matching on the simple name `Prop`. Prevents unrelated local classes named `Prop` from being mistaken for Mix's `Prop`.
  - **FIX**: `@Mixable` validation now requires the annotated class to extend `Mix<T>` (or a subclass) directly. Classes extending `Mixable<T>` without going through `Mix<T>` are rejected with a clear error — the generated mixin's `on Mix<T>` constraint would have failed at apply time anyway.

--- a/packages/mix_generator/pubspec.yaml
+++ b/packages/mix_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mix_generator
 description: A code generator for Mix, an expressive way to effortlessly build design systems in Flutter.
-version: 2.0.3
+version: 2.1.0
 homepage: https://github.com/btwld/mix
 repository: https://github.com/btwld/mix/tree/main/packages/mix_generator
 
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.11.0 <4.0.0"
   
 dependencies:
-  mix_annotations: ^2.0.0
+  mix_annotations: ^2.1.0
   dart_style: ^3.0.0
   source_gen: ">=3.0.0 <5.0.0"
   analyzer: '>=9.0.0 <11.0.0'


### PR DESCRIPTION
## Release prep — mix_generator 2.1.0

Version bump + changelog only, no code changes. Part of a coordinated release split across three PRs.

### mix_generator 2.1.0 (published: 2.0.1)
- Consolidates the three never-published changelog entries (2.0.2, 2.0.3, 2.0.4) into one 2.1.0 release.
- Adds the `@MixableModifier` generator (#924).
- Generates spec stylers with parity coverage (#923).
- Adds `debugFillProperties` test coverage (#942).
- Bumps the `mix_annotations` constraint `^2.0.0 → ^2.1.0` — the new generator references `@MixableModifier`, which only exists in mix_annotations 2.1.0.

### Ordering note
Depends on **mix_annotations 2.1.0** (#945). Publish mix_annotations 2.1.0 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)