### PR TITLE
feat(mix_generator): support @MixableField(setterType:) on @MixableModifier fields

### DIFF
--- a/packages/mix_annotations/lib/src/mixable_modifier.dart
+++ b/packages/mix_annotations/lib/src/mixable_modifier.dart
@@ -26,9 +26,9 @@
 ///
 /// Fields can opt into a Mix-typed setter with `@MixableField(setterType: ...)`
 /// when the field's runtime type has no automatic Mix counterpart. Modifier
-/// setter types must extend `Mix<T>` for the field's runtime value type; for
-/// example, use `BoxShadowListMix` for a `List<BoxShadow>` field. The generated
-/// `ModifierMix` constructor then accepts the Mix type and wraps it with
+/// setter types must extend `Mix<T>` for the field's non-nullable runtime value
+/// type; for example, use `BoxShadowListMix` for a `List<BoxShadow>` field. The
+/// generated `ModifierMix` constructor then accepts the Mix type and wraps it with
 /// `Prop.maybeMix`:
 /// ```dart
 /// @MixableModifier()

--- a/packages/mix_annotations/lib/src/mixable_modifier.dart
+++ b/packages/mix_annotations/lib/src/mixable_modifier.dart
@@ -25,9 +25,11 @@
 /// through a transition) that the generator's per-field lerp can't express.
 ///
 /// Fields can opt into a Mix-typed setter with `@MixableField(setterType: ...)`
-/// when the field's runtime type has no automatic Mix counterpart (for example
-/// `List<BoxShadow>`). The generated `ModifierMix` constructor then accepts the
-/// Mix type and wraps it with `Prop.maybeMix`:
+/// when the field's runtime type has no automatic Mix counterpart. Modifier
+/// setter types must extend `Mix<T>` for the field's runtime value type; for
+/// example, use `BoxShadowListMix` for a `List<BoxShadow>` field. The generated
+/// `ModifierMix` constructor then accepts the Mix type and wraps it with
+/// `Prop.maybeMix`:
 /// ```dart
 /// @MixableModifier()
 /// final class BoxShadowsModifier with _$BoxShadowsModifier {

--- a/packages/mix_annotations/lib/src/mixable_modifier.dart
+++ b/packages/mix_annotations/lib/src/mixable_modifier.dart
@@ -23,6 +23,20 @@
 /// it manually on the modifier class. Useful when interpolation needs custom
 /// semantics (e.g. snapping at a specific threshold, keeping a child visible
 /// through a transition) that the generator's per-field lerp can't express.
+///
+/// Fields can opt into a Mix-typed setter with `@MixableField(setterType: ...)`
+/// when the field's runtime type has no automatic Mix counterpart (for example
+/// `List<BoxShadow>`). The generated `ModifierMix` constructor then accepts the
+/// Mix type and wraps it with `Prop.maybeMix`:
+/// ```dart
+/// @MixableModifier()
+/// final class BoxShadowsModifier with _$BoxShadowsModifier {
+///   @MixableField(setterType: BoxShadowListMix)
+///   @override
+///   final List<BoxShadow> boxShadows;
+///   // ...
+/// }
+/// ```
 class MixableModifier {
   /// Whether to generate the `lerp` method. Defaults to `true`.
   ///

--- a/packages/mix_generator/lib/src/core/models/styler_field_model.dart
+++ b/packages/mix_generator/lib/src/core/models/styler_field_model.dart
@@ -71,16 +71,9 @@ class StylerFieldModel {
         mixableFieldAnnotation?.getField('ignoreSetter')?.toBoolValue() ??
         false;
 
-    final setterTypeValue = mixableFieldAnnotation?.getField('setterType');
-    final setterType = setterTypeValue?.toTypeValue();
-    final setterTypeOverride = setterType == null
-        ? null
-        : type_helpers.visibleTypeCodeForField(
-            element,
-            visibleFrom: element.library,
-            type: setterType,
-            usage: 'setter type',
-          );
+    final setterTypeOverride = type_helpers
+        .setterTypeOverrideForField(element)
+        ?.typeCode;
 
     final effectivePublicParamType =
         setterTypeOverride ??

--- a/packages/mix_generator/lib/src/core/models/type_helpers.dart
+++ b/packages/mix_generator/lib/src/core/models/type_helpers.dart
@@ -20,6 +20,14 @@ class FieldExtraction {
   });
 }
 
+/// A `@MixableField(setterType: ...)` override and its visible type code.
+class SetterTypeOverride {
+  final DartType type;
+  final String typeCode;
+
+  const SetterTypeOverride({required this.type, required this.typeCode});
+}
+
 /// Extracts common field metadata.
 FieldExtraction extractField(FieldElement element, {bool stripDollar = false}) {
   final type = element.type;
@@ -71,6 +79,23 @@ DartType getInnerType(DartType type, {required bool isWrapped}) {
 
 String getInnerTypeName(DartType type, {required bool isWrapped}) {
   return getBaseTypeName(getInnerType(type, isWrapped: isWrapped));
+}
+
+/// Reads `@MixableField(setterType: ...)` on [element], when present.
+SetterTypeOverride? setterTypeOverrideForField(FieldElement element) {
+  final annotation = mixableFieldAnnotationChecker.firstAnnotationOf(element);
+  final setterType = annotation?.getField('setterType')?.toTypeValue();
+  if (setterType == null) return null;
+
+  return SetterTypeOverride(
+    type: setterType,
+    typeCode: visibleTypeCodeForField(
+      element,
+      visibleFrom: element.library,
+      type: setterType,
+      usage: 'setter type',
+    ),
+  );
 }
 
 /// Returns Dart code for a field-related [type] from [visibleFrom].

--- a/packages/mix_generator/lib/src/modifier_generator.dart
+++ b/packages/mix_generator/lib/src/modifier_generator.dart
@@ -11,8 +11,10 @@ import 'package:source_gen/source_gen.dart';
 
 import 'core/builders/modifier_mix_builder.dart';
 import 'core/builders/modifier_mixin_builder.dart';
+import 'core/checkers.dart';
 import 'core/errors.dart';
 import 'core/models/field_model.dart';
+import 'core/models/type_helpers.dart' as type_helpers;
 
 /// Main generator for `ModifierMix` class code.
 ///
@@ -104,16 +106,40 @@ class ModifierGenerator extends GeneratorForAnnotation<MixableModifier> {
         );
       }
 
+      final mixTypeOverride = _setterTypeOverride(field);
+
       return (
         index: info.index,
         field: ModifierFieldModel.fromField(
           field: FieldModel.fromElement(field, stylerName: modifierName),
           isNamedParam: info.isNamed,
+          propWrapperKind: mixTypeOverride == null ? null : .maybeMix,
+          mixTypeName: mixTypeOverride,
         ),
       );
     }).toList()..sort((a, b) => a.index.compareTo(b.index));
 
     return indexedFields.map((entry) => entry.field).toList();
+  }
+
+  /// Reads `@MixableField(setterType: ...)` on [field] and returns the
+  /// resolved type code, or `null` when no override is present.
+  ///
+  /// A modifier field whose runtime type has no automatic Mix counterpart
+  /// (e.g. `List<BoxShadow>`) can opt into a Mix-typed setter so the generated
+  /// `ModifierMix` constructor accepts the Mix and wraps it with
+  /// `Prop.maybeMix`.
+  String? _setterTypeOverride(FieldElement field) {
+    final annotation = mixableFieldAnnotationChecker.firstAnnotationOf(field);
+    final setterType = annotation?.getField('setterType')?.toTypeValue();
+    if (setterType == null) return null;
+
+    return type_helpers.visibleTypeCodeForField(
+      field,
+      visibleFrom: field.library,
+      type: setterType,
+      usage: 'setter type',
+    );
   }
 
   @override

--- a/packages/mix_generator/lib/src/modifier_generator.dart
+++ b/packages/mix_generator/lib/src/modifier_generator.dart
@@ -5,6 +5,7 @@
 library;
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 import 'package:source_gen/source_gen.dart';
@@ -13,6 +14,7 @@ import 'core/builders/modifier_mix_builder.dart';
 import 'core/builders/modifier_mixin_builder.dart';
 import 'core/checkers.dart';
 import 'core/errors.dart';
+import 'core/helpers/type_hierarchy.dart';
 import 'core/models/field_model.dart';
 import 'core/models/type_helpers.dart' as type_helpers;
 
@@ -113,7 +115,6 @@ class ModifierGenerator extends GeneratorForAnnotation<MixableModifier> {
         field: ModifierFieldModel.fromField(
           field: FieldModel.fromElement(field, stylerName: modifierName),
           isNamedParam: info.isNamed,
-          propWrapperKind: mixTypeOverride == null ? null : .maybeMix,
           mixTypeName: mixTypeOverride,
         ),
       );
@@ -122,23 +123,58 @@ class ModifierGenerator extends GeneratorForAnnotation<MixableModifier> {
     return indexedFields.map((entry) => entry.field).toList();
   }
 
-  /// Reads `@MixableField(setterType: ...)` on [field] and returns the
-  /// resolved type code, or `null` when no override is present.
-  ///
-  /// A modifier field whose runtime type has no automatic Mix counterpart
-  /// (e.g. `List<BoxShadow>`) can opt into a Mix-typed setter so the generated
-  /// `ModifierMix` constructor accepts the Mix and wraps it with
-  /// `Prop.maybeMix`.
+  /// Reads and validates a modifier `@MixableField(setterType: ...)`.
   String? _setterTypeOverride(FieldElement field) {
-    final annotation = mixableFieldAnnotationChecker.firstAnnotationOf(field);
-    final setterType = annotation?.getField('setterType')?.toTypeValue();
+    final setterType = type_helpers.setterTypeOverrideForField(field);
     if (setterType == null) return null;
 
-    return type_helpers.visibleTypeCodeForField(
+    final typeSystem = field.library.typeSystem;
+    final fieldType = typeSystem.promoteToNonNull(field.type);
+    final fieldTypeCode = type_helpers.visibleTypeCodeForField(
       field,
       visibleFrom: field.library,
-      type: setterType,
-      usage: 'setter type',
+      type: fieldType,
+      usage: 'field type',
+    );
+    final setterInterfaceType = setterType.type;
+    final mixType = setterInterfaceType is InterfaceType
+        ? findSupertypeMatching(setterInterfaceType, mixChecker)
+        : null;
+
+    if (mixType == null || mixType.typeArguments.isEmpty) {
+      _failInvalidSetterType(field, setterType.typeCode, fieldTypeCode);
+    }
+
+    final mixValueType = typeSystem.promoteToNonNull(
+      mixType.typeArguments.first,
+    );
+    final typesMatch =
+        typeSystem.isAssignableTo(
+          fieldType,
+          mixValueType,
+          strictCasts: false,
+        ) &&
+        typeSystem.isAssignableTo(mixValueType, fieldType, strictCasts: false);
+    if (!typesMatch) {
+      _failInvalidSetterType(field, setterType.typeCode, fieldTypeCode);
+    }
+
+    return setterType.typeCode;
+  }
+
+  Never _failInvalidSetterType(
+    FieldElement field,
+    String setterTypeCode,
+    String expectedTypeCode,
+  ) {
+    final fieldName = field.name ?? '<unknown>';
+    fail(
+      field,
+      '@MixableModifier field `$fieldName` has setterType `$setterTypeCode`, '
+      'but modifier setterType must extend Mix<$expectedTypeCode>.',
+      todo:
+          'Use a Mix<$expectedTypeCode> type for setterType or remove the '
+          'setterType override.',
     );
   }
 

--- a/packages/mix_generator/lib/src/modifier_generator.dart
+++ b/packages/mix_generator/lib/src/modifier_generator.dart
@@ -145,9 +145,11 @@ class ModifierGenerator extends GeneratorForAnnotation<MixableModifier> {
       _failInvalidSetterType(field, setterType.typeCode, fieldTypeCode);
     }
 
-    final mixValueType = typeSystem.promoteToNonNull(
-      mixType.typeArguments.first,
-    );
+    final mixValueType = mixType.typeArguments.first;
+    if (_isInvalidMixValueType(mixValueType)) {
+      _failInvalidSetterType(field, setterType.typeCode, fieldTypeCode);
+    }
+
     final typesMatch =
         typeSystem.isAssignableTo(
           fieldType,
@@ -160,6 +162,10 @@ class ModifierGenerator extends GeneratorForAnnotation<MixableModifier> {
     }
 
     return setterType.typeCode;
+  }
+
+  bool _isInvalidMixValueType(DartType type) {
+    return type is DynamicType || type.nullabilitySuffix == .question;
   }
 
   Never _failInvalidSetterType(

--- a/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
@@ -107,7 +107,7 @@ class Prop<T> {
   const Prop();
 
   static Prop<T>? maybe<T>(T? value) => value == null ? null : Prop<T>();
-  static Prop<T>? maybeMix<T>(Object? value) =>
+  static Prop<T>? maybeMix<T>(Mix<T>? value) =>
       value == null ? null : Prop<T>();
 }
 
@@ -120,6 +120,37 @@ class MixOps {
 
 $body
 ''';
+}
+
+Future<void> _expectInvalidSetterType(String setterTypeSource) async {
+  final result = await testBuilder(
+    partBuilder(const ModifierGenerator()),
+    {
+      ..._modifierSupportSources,
+      'mix_generator|lib/modifier_case.dart': _modifierSource('''
+$setterTypeSource
+
+@MixableModifier()
+final class ShadowModifier with _\$ShadowModifier {
+  @MixableField(setterType: ShadowListMix)
+  @override
+  final List<int> shadows;
+
+  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
+
+  @override
+  Widget build(Widget child) => child;
+}
+'''),
+    },
+    generateFor: {'mix_generator|lib/modifier_case.dart'},
+  );
+
+  expect(result.succeeded, isFalse);
+  expect(
+    result.errors.join('\n'),
+    contains('modifier setterType must extend Mix<List<int>>'),
+  );
 }
 
 const _opacityMixinGolden = r'''
@@ -352,76 +383,60 @@ final class ShadowModifier with _$ShadowModifier {
     );
 
     test('rejects modifier setterType that does not extend Mix', () async {
-      final result = await testBuilder(
-        partBuilder(const ModifierGenerator()),
-        {
-          ..._modifierSupportSources,
-          'mix_generator|lib/modifier_case.dart': _modifierSource(r'''
-class NotAMix {
-  const NotAMix();
+      await _expectInvalidSetterType(r'''
+class ShadowListMix {
+  const ShadowListMix();
 }
-
-@MixableModifier()
-final class ShadowModifier with _$ShadowModifier {
-  @MixableField(setterType: NotAMix)
-  @override
-  final List<int> shadows;
-
-  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
-
-  @override
-  Widget build(Widget child) => child;
-}
-'''),
-        },
-        generateFor: {'mix_generator|lib/modifier_case.dart'},
-      );
-
-      expect(result.succeeded, isFalse);
-      expect(
-        result.errors.join('\n'),
-        contains('modifier setterType must extend Mix<List<int>>'),
-      );
+''');
     });
 
     test(
       'rejects modifier setterType whose Mix value type does not match field',
       () async {
-        final result = await testBuilder(
-          partBuilder(const ModifierGenerator()),
-          {
-            ..._modifierSupportSources,
-            'mix_generator|lib/modifier_case.dart': _modifierSource(r'''
+        await _expectInvalidSetterType(r'''
 class WrongMix extends Mix<int> {
   const WrongMix();
 
   @override
   List<Object?> get props => const [];
 }
-
-@MixableModifier()
-final class ShadowModifier with _$ShadowModifier {
-  @MixableField(setterType: WrongMix)
-  @override
-  final List<int> shadows;
-
-  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
-
-  @override
-  Widget build(Widget child) => child;
-}
-'''),
-          },
-          generateFor: {'mix_generator|lib/modifier_case.dart'},
-        );
-
-        expect(result.succeeded, isFalse);
-        expect(
-          result.errors.join('\n'),
-          contains('modifier setterType must extend Mix<List<int>>'),
-        );
+typedef ShadowListMix = WrongMix;
+''');
       },
     );
+
+    test('rejects modifier setterType with nullable Mix value type', () async {
+      await _expectInvalidSetterType(r'''
+class ShadowListMix extends Mix<List<int>?> {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+''');
+    });
+
+    test('rejects modifier setterType with dynamic Mix value type', () async {
+      await _expectInvalidSetterType(r'''
+class ShadowListMix extends Mix<dynamic> {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+''');
+    });
+
+    test('rejects raw modifier Mix setterType', () async {
+      await _expectInvalidSetterType(r'''
+class ShadowListMix extends Mix {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+''');
+    });
 
     test(
       'fails when an emitted field is not in the unnamed constructor',

--- a/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
@@ -41,6 +41,10 @@ class FlagProperty extends DiagnosticsProperty<bool> {
     : super(name, value);
 }
 
+class IterableProperty<T> extends DiagnosticsProperty<Iterable<T>> {
+  const IterableProperty(super.name, super.value);
+}
+
 mixin Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {}
 }
@@ -290,6 +294,48 @@ final class ConstructorOrderModifier with _$ConstructorOrderModifier {
         ]),
       );
     });
+
+    test(
+      'uses MixableField setterType for Mix-typed constructor params',
+      () async {
+        const body = r'''
+class ShadowListMix extends Mix<List<int>> {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+@MixableModifier()
+final class ShadowModifier with _$ShadowModifier {
+  @MixableField(setterType: ShadowListMix)
+  @override
+  final List<int> shadows;
+
+  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
+
+  @override
+  Widget build(Widget child) => child;
+}
+''';
+
+        await expectGeneratorOutputResolves(
+          builder: partBuilder(const ModifierGenerator()),
+          sources: {
+            ...mixAnnotationsSources,
+            'mix_generator|lib/modifier_case.dart': _modifierSource(body),
+          },
+          inputAsset: 'mix_generator|lib/modifier_case.dart',
+          outputAsset: 'mix_generator|lib/modifier_case.g.dart',
+          outputMatcher: allOf([
+            contains('final Prop<List<int>>? shadows;'),
+            contains('ShadowModifierMix({ShadowListMix? shadows})'),
+            contains('shadows: Prop.maybeMix(shadows)'),
+            isNot(contains('Prop.maybe(shadows)')),
+          ]),
+        );
+      },
+    );
 
     test(
       'fails when an emitted field is not in the unnamed constructor',

--- a/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
@@ -427,6 +427,20 @@ class ShadowListMix extends Mix<dynamic> {
 ''');
     });
 
+    test(
+      'rejects modifier setterType with nested dynamic Mix value type',
+      () async {
+        await _expectInvalidSetterType(r'''
+class ShadowListMix extends Mix<List<dynamic>> {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+''');
+      },
+    );
+
     test('rejects raw modifier Mix setterType', () async {
       await _expectInvalidSetterType(r'''
 class ShadowListMix extends Mix {
@@ -435,6 +449,30 @@ class ShadowListMix extends Mix {
   @override
   List<Object?> get props => const [];
 }
+''');
+    });
+
+    test('rejects raw nested modifier Mix value type', () async {
+      await _expectInvalidSetterType(r'''
+class ShadowListMix extends Mix<List> {
+  const ShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+''');
+    });
+
+    test('rejects raw generic modifier Mix setterType alias', () async {
+      await _expectInvalidSetterType(r'''
+class GenericShadowListMix<T> extends Mix<List<T>> {
+  const GenericShadowListMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+typedef ShadowListMix = GenericShadowListMix;
 ''');
     });
 

--- a/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
+++ b/packages/mix_generator/test/integration/modifier_generator_smoke_test.dart
@@ -4,11 +4,27 @@ import 'package:test/test.dart';
 
 import '../core/test_helpers.dart';
 
+const _mixElementSource = r'''
+library mix_element;
+
+abstract class Mix<T> {
+  const Mix();
+
+  List<Object?> get props;
+}
+''';
+
+const _modifierSupportSources = {
+  ...mixAnnotationsSources,
+  'mix|lib/src/core/mix_element.dart': _mixElementSource,
+};
+
 String _modifierSource(String body) {
   return '''
 library modifier_case;
 
 import 'package:mix_annotations/mix_annotations.dart';
+import 'package:mix/src/core/mix_element.dart';
 
 part 'modifier_case.g.dart';
 
@@ -78,10 +94,6 @@ abstract class WidgetModifier<Self extends WidgetModifier<Self>>
   const WidgetModifier();
 
   Widget build(Widget child);
-}
-
-abstract class Mix<T> with Equatable {
-  const Mix();
 }
 
 abstract class ModifierMix<S extends WidgetModifier<S>> extends Mix<S> {
@@ -167,7 +179,7 @@ final class OpacityModifier with _$OpacityModifier {
       await expectGeneratorOutputResolves(
         builder: partBuilder(const ModifierGenerator()),
         sources: {
-          ...mixAnnotationsSources,
+          ..._modifierSupportSources,
           'mix_generator|lib/modifier_case.dart': _modifierSource(body),
         },
         inputAsset: 'mix_generator|lib/modifier_case.dart',
@@ -205,7 +217,7 @@ final class VisibilityModifier with _$VisibilityModifier {
       await expectGeneratorOutputResolves(
         builder: partBuilder(const ModifierGenerator()),
         sources: {
-          ...mixAnnotationsSources,
+          ..._modifierSupportSources,
           'mix_generator|lib/modifier_case.dart': _modifierSource(body),
         },
         inputAsset: 'mix_generator|lib/modifier_case.dart',
@@ -240,7 +252,7 @@ final class PositionalModifier with _$PositionalModifier {
         await expectGeneratorOutputResolves(
           builder: partBuilder(const ModifierGenerator()),
           sources: {
-            ...mixAnnotationsSources,
+            ..._modifierSupportSources,
             'mix_generator|lib/modifier_case.dart': _modifierSource(body),
           },
           inputAsset: 'mix_generator|lib/modifier_case.dart',
@@ -276,7 +288,7 @@ final class ConstructorOrderModifier with _$ConstructorOrderModifier {
       await expectGeneratorOutputResolves(
         builder: partBuilder(const ModifierGenerator()),
         sources: {
-          ...mixAnnotationsSources,
+          ..._modifierSupportSources,
           'mix_generator|lib/modifier_case.dart': _modifierSource(body),
         },
         inputAsset: 'mix_generator|lib/modifier_case.dart',
@@ -322,7 +334,7 @@ final class ShadowModifier with _$ShadowModifier {
         await expectGeneratorOutputResolves(
           builder: partBuilder(const ModifierGenerator()),
           sources: {
-            ...mixAnnotationsSources,
+            ..._modifierSupportSources,
             'mix_generator|lib/modifier_case.dart': _modifierSource(body),
           },
           inputAsset: 'mix_generator|lib/modifier_case.dart',
@@ -331,8 +343,82 @@ final class ShadowModifier with _$ShadowModifier {
             contains('final Prop<List<int>>? shadows;'),
             contains('ShadowModifierMix({ShadowListMix? shadows})'),
             contains('shadows: Prop.maybeMix(shadows)'),
+            contains('shadows: MixOps.resolve(context, shadows)'),
+            contains('shadows: MixOps.merge(shadows, other.shadows)'),
             isNot(contains('Prop.maybe(shadows)')),
           ]),
+        );
+      },
+    );
+
+    test('rejects modifier setterType that does not extend Mix', () async {
+      final result = await testBuilder(
+        partBuilder(const ModifierGenerator()),
+        {
+          ..._modifierSupportSources,
+          'mix_generator|lib/modifier_case.dart': _modifierSource(r'''
+class NotAMix {
+  const NotAMix();
+}
+
+@MixableModifier()
+final class ShadowModifier with _$ShadowModifier {
+  @MixableField(setterType: NotAMix)
+  @override
+  final List<int> shadows;
+
+  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
+
+  @override
+  Widget build(Widget child) => child;
+}
+'''),
+        },
+        generateFor: {'mix_generator|lib/modifier_case.dart'},
+      );
+
+      expect(result.succeeded, isFalse);
+      expect(
+        result.errors.join('\n'),
+        contains('modifier setterType must extend Mix<List<int>>'),
+      );
+    });
+
+    test(
+      'rejects modifier setterType whose Mix value type does not match field',
+      () async {
+        final result = await testBuilder(
+          partBuilder(const ModifierGenerator()),
+          {
+            ..._modifierSupportSources,
+            'mix_generator|lib/modifier_case.dart': _modifierSource(r'''
+class WrongMix extends Mix<int> {
+  const WrongMix();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+@MixableModifier()
+final class ShadowModifier with _$ShadowModifier {
+  @MixableField(setterType: WrongMix)
+  @override
+  final List<int> shadows;
+
+  const ShadowModifier({List<int>? shadows}) : shadows = shadows ?? const [];
+
+  @override
+  Widget build(Widget child) => child;
+}
+'''),
+          },
+          generateFor: {'mix_generator|lib/modifier_case.dart'},
+        );
+
+        expect(result.succeeded, isFalse);
+        expect(
+          result.errors.join('\n'),
+          contains('modifier setterType must extend Mix<List<int>>'),
         );
       },
     );
@@ -343,7 +429,7 @@ final class ShadowModifier with _$ShadowModifier {
         final result = await testBuilder(
           partBuilder(const ModifierGenerator()),
           {
-            ...mixAnnotationsSources,
+            ..._modifierSupportSources,
             'mix_generator|lib/modifier_case.dart': _modifierSource(r'''
 @MixableModifier()
 final class InvalidModifier with _$InvalidModifier {
@@ -374,7 +460,7 @@ final class InvalidModifier with _$InvalidModifier {
       final result = await testBuilder(
         partBuilder(const ModifierGenerator()),
         {
-          ...mixAnnotationsSources,
+          ..._modifierSupportSources,
           'mix_generator|lib/modifier_case.dart': r'''
 library modifier_case;
 


### PR DESCRIPTION
## Summary
- Closes #948.
- `@MixableModifier` now reads `@MixableField(setterType: ...)` on its fields, so a modifier field whose runtime type has no automatic Mix counterpart (e.g. `List<BoxShadow>`) can opt into a Mix-typed setter.
- The generated `ModifierMix` constructor accepts the Mix type and wraps it with `Prop.maybeMix` instead of falling back to `Prop.maybe(List<...>)`.

### Before
A `List<BoxShadow>` modifier field had no way to accept its `BoxShadowListMix`; the generated `ModifierMix` only took the raw Flutter type.

### After
```dart
@MixableModifier()
final class BoxShadowsModifier with _$BoxShadowsModifier {
  @MixableField(setterType: BoxShadowListMix)
  @override
  final List<BoxShadow> boxShadows;
  // ...
}
```
generates:
```dart
BoxShadowsModifierMix({BoxShadowListMix? boxShadows, ...})
    : this.create(boxShadows: Prop.maybeMix(boxShadows), ...);
```

## Implementation
- `modifier_generator.dart`: resolve `setterType` per field (mirroring the styler path) and pass it as `mixTypeName` with `propWrapperKind: .maybeMix` to `ModifierFieldModel.fromField`. The infrastructure for `mixTypeName`/`Prop.maybeMix` already existed; it was simply never wired to the annotation.
- Updated the `MixableModifier` doc comment with a usage example.

## Test plan
- [x] Added integration test: `ModifierGenerator uses MixableField setterType for Mix-typed constructor params`.
- [x] `dart test` (mix_generator): 258 tests pass.
- [x] `dart analyze` on changed files: no issues.

Made with [Cursor](https://cursor.com)