### PR TITLE
chore: add workflow to triage new issues to AI Initiatives board

### DIFF
--- a/.github/workflows/add_to_ai_initiatives_board.yml
+++ b/.github/workflows/add_to_ai_initiatives_board.yml
@@ -1,0 +1,14 @@
+name: Add issues to AI Initiatives board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/btwld/projects/6
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically adds newly opened issues to the [AI Initiatives board](https://github.com/orgs/btwld/projects/6).
- Uses `actions/add-to-project@v1.0.2` with the `ADD_TO_PROJECT_PAT` repository secret.

## Test plan
- [ ] Ensure `ADD_TO_PROJECT_PAT` is configured as a repository secret (org-level if shared).
- [ ] Merge and open a test issue to confirm it appears on the AI Initiatives project board.

Made with [Cursor](https://cursor.com)